### PR TITLE
ci: add k3d setup for CI and devs

### DIFF
--- a/scripts/helm/apim-values.yml
+++ b/scripts/helm/apim-values.yml
@@ -42,6 +42,11 @@ gateway:
     requests:
       cpu: 1000m
       memory: 1024Mi
+  env:
+    - name: GIO_MIN_MEM
+      value: 768m
+    - name: GIO_MAX_MEM
+      value: 768m
 
 api:
   image:
@@ -70,8 +75,10 @@ api:
     initialDelaySeconds: 120
     timeoutSeconds: 30
   env:
-    - name: JAVA_OPTS
-      value: "-Xms512m -Xmx512m"
+    - name: GIO_MIN_MEM
+      value: 768m
+    - name: GIO_MAX_MEM
+      value: 768m
 ui:
   image:
     repository: graviteeio/apim-management-ui


### PR DESCRIPTION
The script runs APIM in a k3d cluster, which may be useful if we want to run integration tests in a CI.

Tested locally apple arm64 and apple x86

~Note: images preload does not work on m1 (should be fixed in next k3d minor version)~

The second commit changes the preloading strategy to use a local docker registry, which should work on all platforms (at least on unix)