### PR TITLE
ci: add make target to authenticate against cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,3 +250,7 @@ k3d-apim-stop: # Stop exiting APIM node in k3d
 .PHONY: k3d-apim-clean
 k3d-apim-clean: # Clean k3d APIM nodes and remove registry in docker
 	k3d cluster delete graviteeio
+
+.PHONY:
+local-service-account:
+	bash ./scripts/service_account.sh

--- a/README.adoc
+++ b/README.adoc
@@ -27,8 +27,8 @@ make k3d-apim-init
 
 make install
 
+# should return apidefinitions.gravitee.io and managementcontexts.gravitee.io
 kubectl get crd 
-#should return apidefinitions.gravitee.io and managementcontexts.gravitee.io
 
 make run
 ----
@@ -38,9 +38,36 @@ To create a basic api definition run following command
 
 [source,shell]
 ----
-kubectl apply -f ./config/samples/apim/basic-example.yml
+# Create a management context for your APIM instance running on K3D
+kubectl apply -f ./config/samples/context/managementcontext_credentials_k3d.yaml
+
+# Create a basic API definition resource
+kubectl apply -f ./config/samples/apim/basic-example-with-ctx.yml
 
 kubectl get graviteeapis  -o wide
 # NAME                ID                                     ENTRYPOINT   ENDPOINT                       VERSION   ENABLED
 # basic-api-example   ff3549c9-ceb2-36da-87f7-f5e51ba89097   /k8s-basic   https://api.gravitee.io/echo   1.0       true
+----
+
+== Debugging with a locally running APIM
+To be abble to run the operator against a local instance of both APIM Gateway and APIM Management API you will need to
+  - Attach to a local cluster context
+  - Create a local service account to authenticate the gateway against the local cluster
+  - Run both APIM Gateway and APIM Management API in debug mode
+  - Create a management context pointing to your local APIM management API
+
+[source,shell]
+----
+make install
+
+# should return apidefinitions.gravitee.io and managementcontexts.gravitee.io
+kubectl get crd 
+
+make run # or run using a debugger if you need to debug the operator as well
+
+# Create a management context for APIM
+kubectl apply -f ./config/samples/context/managementcontext_credentials.yaml
+
+# Create a basic API definition resource
+kubectl apply -f ./config/samples/apim/basic-example-with-ctx.yml
 ----

--- a/config/samples/context/managementcontext_credentials_k3d.yaml
+++ b/config/samples/context/managementcontext_credentials_k3d.yaml
@@ -1,0 +1,10 @@
+apiVersion: gravitee.io/v1alpha1
+kind: ManagementContext
+metadata:
+  name: dev-mgmt-ctx
+spec:
+  baseUrl: http://localhost:9000/management
+  auth:
+    credentials:
+      username: admin
+      password: admin

--- a/scripts/service_account.sh
+++ b/scripts/service_account.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+SERVICE_ACCOUNT_NAME=kubeconfig-sa
+SERVICE_ACCOUNT_NAMESPACE=kube-system
+CLUSTER_ROLE_BINDING_NAME=add-on-cluster-admin
+
+KUBE_CONTEXT=$(kubectl config current-context)
+
+echo "
+
+    You are about to create a service account with 'cluster-admin' in kube context ${KUBE_CONTEXT}
+    
+"
+read -r -p "
+    Do you want to continue (type yes if you want to proceed) ? " CONTINUE
+
+if [ "$CONTINUE" != "yes" ]; then
+    echo "
+
+    Exiting ...
+
+    "
+    exit 0
+else
+    echo "
+    
+    Proceeding ...
+
+    "
+fi
+
+kubectl -n "${SERVICE_ACCOUNT_NAMESPACE}" create serviceaccount ${SERVICE_ACCOUNT_NAME} > /dev/null 2>&1 
+
+kubectl create clusterrolebinding "${CLUSTER_ROLE_BINDING_NAME}" --clusterrole=cluster-admin --serviceaccount=${SERVICE_ACCOUNT_NAMESPACE}:${SERVICE_ACCOUNT_NAME} > /dev/null 2>&1
+
+TOKEN_NAME=$(kubectl -n ${SERVICE_ACCOUNT_NAMESPACE} get serviceaccount/${SERVICE_ACCOUNT_NAME} -o jsonpath='{.secrets[0].name}')
+
+TOKEN=$(kubectl -n ${SERVICE_ACCOUNT_NAMESPACE} get secret ${TOKEN_NAME} -o jsonpath='{.data.token}'| base64 --decode)
+
+kubectl config set-credentials ${SERVICE_ACCOUNT_NAME} --token="${TOKEN}"
+kubectl config set-context --current --user=${SERVICE_ACCOUNT_NAME}
+
+echo "
+    You are now authenticated against ${KUBE_CONTEXT} as ${SERVICE_ACCOUNT_NAME}
+"


### PR DESCRIPTION
when trying to debug the APIM gateway locally we need to obtain an access
token to authenticate the gateway against the cluster