### PR TITLE
Issues/#8139 delete gko api

### DIFF
--- a/controllers/apidefinition_controller_delete_test.go
+++ b/controllers/apidefinition_controller_delete_test.go
@@ -1,10 +1,9 @@
 /*
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,12 +18,15 @@ import (
 	"net/http"
 	"time"
 
+	"errors"
+
+	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/apim/managementapi"
+	clientError "github.com/gravitee-io/gravitee-kubernetes-operator/internal/apim/managementapi/clienterror"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 
 	gio "github.com/gravitee-io/gravitee-kubernetes-operator/api/v1alpha1"
-	managementapi "github.com/gravitee-io/gravitee-kubernetes-operator/internal/apim/managementapi"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/test"
 )
 
@@ -116,13 +118,48 @@ var _ = Describe("API Definition Controller", func() {
 			By("Call rest API and expect DELETED api")
 			apimClient := managementapi.NewClient(ctx, managementContextFixture, httpClient)
 			Eventually(func() bool {
-				api, apiErr := apimClient.GetByCrossId(createdApiDefinition.Status.CrossID)
-
-				return apiErr == nil &&
-					api.State == "STOPPED" &&
-					api.ApiLifecycleState == "UNPUBLISHED" &&
-					api.Visibility == "PRIVATE"
+				_, apiErr := apimClient.GetApiById(createdApiDefinition.Status.CrossID)
+				var apiNotFoundError *clientError.ApiNotFoundError
+				return apiErr != nil && errors.As(apiErr, &apiNotFoundError)
 			}, timeout, interval).Should(BeTrue())
+
+			By("Expect that the ConfigMap has been deleted")
+			Eventually(func() error {
+				return k8sClient.Get(ctx, apiLookupKey, apiDefinitionFixture)
+			}, timeout, interval).ShouldNot(Succeed())
+		})
+
+		It("Should detect when API has already been deleted", func() {
+			createdApiDefinition := new(gio.ApiDefinition)
+			managementClient := managementapi.NewClient(ctx, managementContextFixture, httpClient)
+
+			// Expect the API Definition is Ready
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, apiLookupKey, createdApiDefinition)
+				return err == nil && createdApiDefinition.Status.CrossID != ""
+			}, timeout, interval).Should(BeTrue())
+
+			By("Call initial API definition URL and expect no error")
+			// Check created api is callable
+			var gatewayEndpoint = test.GatewayUrl + createdApiDefinition.Spec.Proxy.VirtualHosts[0].Path
+
+			Eventually(func() bool {
+				res, callErr := httpClient.Get(gatewayEndpoint)
+				return callErr == nil && res.StatusCode == 200
+			}, timeout, interval).Should(BeTrue())
+
+			By("Delete the API calling directly the REST API")
+			deleteErr := managementClient.DeleteApi(createdApiDefinition.Status.ID)
+			Expect(deleteErr).ToNot(HaveOccurred())
+
+			By("Delete the API Definition")
+			err := k8sClient.Delete(ctx, apiDefinitionFixture)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Expect that the ConfigMap has been deleted")
+			Eventually(func() error {
+				return k8sClient.Get(ctx, apiLookupKey, apiDefinitionFixture)
+			}, timeout, interval).ShouldNot(Succeed())
 		})
 	})
 })

--- a/controllers/apidefinition_controller_plan_and_subscription_test.go
+++ b/controllers/apidefinition_controller_plan_and_subscription_test.go
@@ -1,10 +1,9 @@
 /*
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +15,11 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
+
+	clientError "github.com/gravitee-io/gravitee-kubernetes-operator/internal/apim/managementapi/clienterror"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -206,14 +208,9 @@ var _ = Describe("Checking ApiKey plan and subscription", Ordered, func() {
 			By("Get the API definition from ManagementApi and expect deleted state")
 
 			Eventually(func() bool {
-				api, apiErr := mgmtClient.GetApiById(savedApiDefinition.Status.ID)
-
-				return apiErr == nil &&
-					api.State == "STOPPED" &&
-					api.ApiLifecycleState == "UNPUBLISHED" &&
-					api.Visibility == "PRIVATE" &&
-					api.Plans[0].Status == "CLOSED" &&
-					api.Plans[1].Status == "CLOSED"
+				_, apiErr := mgmtClient.GetApiById(savedApiDefinition.Status.ID)
+				var apiNotFoundError *clientError.ApiNotFoundError
+				return apiErr != nil && errors.As(apiErr, &apiNotFoundError)
 			}, timeout, interval).Should(BeTrue())
 		})
 	})

--- a/internal/apim/managementapi/apis.go
+++ b/internal/apim/managementapi/apis.go
@@ -80,6 +80,10 @@ func (client *Client) GetApiById(
 
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, &clienterror.ApiNotFoundError{ApiId: apiId}
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf(
 			"an error as occurred trying to get API matching id %s, HTTP Status: %d ",
@@ -199,7 +203,11 @@ func (client *Client) DeleteApi(
 		defer resp.Body.Close()
 	}
 
-	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+	if resp.StatusCode == http.StatusNotFound {
+		return &clienterror.ApiNotFoundError{ApiId: apiId}
+	}
+
+	if resp.StatusCode != http.StatusNoContent {
 		return fmt.Errorf("management has returned a %d code", resp.StatusCode)
 	}
 

--- a/internal/apim/managementapi/clienterror/api_not_found_error.go
+++ b/internal/apim/managementapi/clienterror/api_not_found_error.go
@@ -1,0 +1,9 @@
+package clienterror
+
+type ApiNotFoundError struct {
+	ApiId string
+}
+
+func (e *ApiNotFoundError) Error() string {
+	return "No API found for ApiId " + e.ApiId
+}


### PR DESCRIPTION
**Issue**

gravitee-io/issues#8139

**Description**

- [x] Add query param to force all plans to be closed before removing the api.
- [x] Check if the api does not exists and if the finalizer needs to be removed. This test has to be done to avoid infinit loop if you have a timeout for example with the delete http request.
