### PR TITLE
Fix plan subscription

### DIFF
--- a/controllers/apim/apidefinition/internal/helper.go
+++ b/controllers/apim/apidefinition/internal/helper.go
@@ -69,6 +69,7 @@ func retrieveMgmtPlanIds(apiDefinition *gio.ApiDefinition, mgmtApi *managementap
 		for _, mgmtPlan := range mgmtApi.Plans {
 			if plan.CrossId == mgmtPlan.CrossId {
 				plan.Id = mgmtPlan.Id
+				plan.Api = mgmtPlan.Api
 			}
 		}
 	}

--- a/internal/apim/managementapi/model/api.go
+++ b/internal/apim/managementapi/model/api.go
@@ -44,6 +44,7 @@ type Plan struct {
 	Name     string           `json:"name"`
 	Security PlanSecurityType `json:"security"`
 	Status   PlanStatus       `json:"status"`
+	Api      string           `json:"api"`
 }
 
 type PlanSecurityType string


### PR DESCRIPTION
The API id is missing when registering the API definitions created by GKO. This fix will add the missing ID to the API definition.