### PR TITLE
ci: add semantic commits option to renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
   "extends": [
     "config:base",
     "schedule:earlyMondays",
+    ":semanticCommits",
     ":semanticCommitTypeAll(chore)"
   ],
   "prConcurrentLimit": 3,


### PR DESCRIPTION
Renovate still does not use the commit convention 