### PR TITLE
refactor: rename has management context method

### DIFF
--- a/controllers/apim/apidefinition/internal/delegate.go
+++ b/controllers/apim/apidefinition/internal/delegate.go
@@ -60,6 +60,6 @@ func (d *Delegate) SetManagementContext(managementContext *gio.ManagementContext
 	d.apimClient = managementapi.NewClient(d.ctx, d.managementContext, httpClient)
 }
 
-func (d *Delegate) IsConnectedToManagementApi() bool {
-	return d.apimClient != nil
+func (d *Delegate) HasManagementContext() bool {
+	return d.managementContext != nil
 }

--- a/controllers/apim/apidefinition/internal/delete.go
+++ b/controllers/apim/apidefinition/internal/delete.go
@@ -32,7 +32,7 @@ func (d *Delegate) Delete(
 	}
 
 	var apiNotFoundError *managementapierror.ApiNotFoundError
-	if d.IsConnectedToManagementApi() && apiDefinition.Status.ID != "" {
+	if d.HasManagementContext() && apiDefinition.Status.ID != "" {
 		d.log.Info("Delete API definition into Management API")
 		err := d.apimClient.DeleteApi(apiDefinition.Status.ID)
 		if errors.As(err, &apiNotFoundError) {

--- a/controllers/apim/apidefinition/internal/update.go
+++ b/controllers/apim/apidefinition/internal/update.go
@@ -45,7 +45,7 @@ func (d *Delegate) CreateOrUpdate(
 		Mode:   mode,
 	}
 
-	if d.IsConnectedToManagementApi() {
+	if d.HasManagementContext() {
 		apiJson, marshalErr := json.Marshal(apiDefinition.Spec)
 		if marshalErr != nil {
 			d.log.Error(marshalErr, "Unable to marshall API definition as JSON")

--- a/controllers/apim/apidefinition/internal/update_api_state.go
+++ b/controllers/apim/apidefinition/internal/update_api_state.go
@@ -31,7 +31,7 @@ func (d *Delegate) updateApiState(
 	apiDefinition *gio.ApiDefinition,
 ) error {
 	// Check if Management context is provided
-	if !d.IsConnectedToManagementApi() {
+	if !d.HasManagementContext() {
 		return nil
 	}
 


### PR DESCRIPTION
As having a management context does not implie being connected to mapi this seems more appropriate (eg, the context could point to a bad url)