### PR TITLE
test: ensure context is created before creating api

### DIFF
--- a/test/apidefinition_controller_create_test.go
+++ b/test/apidefinition_controller_create_test.go
@@ -123,15 +123,13 @@ var _ = Describe("Create", func() {
 			By("Create a management context to synchronize with the REST API")
 			Expect(k8sClient.Create(ctx, managementContextFixture)).Should(Succeed())
 
-			By("Create an API definition resource referencing the management context")
-			Expect(k8sClient.Create(ctx, apiDefinitionFixture)).Should(Succeed())
-
-			By("Get created resource and expect to find it")
-
 			managementContext := new(gio.ManagementContext)
 			Eventually(func() error {
 				return k8sClient.Get(ctx, contextLookupKey, managementContext)
 			}, timeout, interval).Should(Succeed())
+
+			By("Create an API definition resource referencing the management context")
+			Expect(k8sClient.Create(ctx, apiDefinitionFixture)).Should(Succeed())
 
 			apiDefinition := new(gio.ApiDefinition)
 			Eventually(func() bool {
@@ -175,15 +173,13 @@ var _ = Describe("Create", func() {
 			By("Create a management context to synchronize with the REST API")
 			Expect(k8sClient.Create(ctx, managementContextFixture)).Should(Succeed())
 
-			By("Create an API definition resource referencing the management context")
-			Expect(k8sClient.Create(ctx, apiDefinitionFixture)).Should(Succeed())
-
-			By("Get created resource and expect to find it")
-
 			managementContext := new(gio.ManagementContext)
 			Eventually(func() error {
 				return k8sClient.Get(ctx, contextLookupKey, managementContext)
 			}, timeout, interval).Should(Succeed())
+
+			By("Create an API definition resource referencing the management context")
+			Expect(k8sClient.Create(ctx, apiDefinitionFixture)).Should(Succeed())
 
 			apiDefinition := new(gio.ApiDefinition)
 			Eventually(func() bool {
@@ -244,15 +240,13 @@ var _ = Describe("Create", func() {
 			By("Create a management context to synchronize with the REST API")
 			Expect(k8sClient.Create(ctx, managementContextFixture)).Should(Succeed())
 
-			By("Create an API definition resource referencing the management context")
-			Expect(k8sClient.Create(ctx, apiDefinitionFixture)).Should(Succeed())
-
-			By("Get created resource and expect to find it")
-
 			managementContext := new(gio.ManagementContext)
 			Eventually(func() error {
 				return k8sClient.Get(ctx, contextLookupKey, managementContext)
 			}, timeout, interval).Should(Succeed())
+
+			By("Create an API definition resource referencing the management context")
+			Expect(k8sClient.Create(ctx, apiDefinitionFixture)).Should(Succeed())
 
 			apiDefinition := new(gio.ApiDefinition)
 			Eventually(func() bool {

--- a/test/apidefinition_controller_delete_test.go
+++ b/test/apidefinition_controller_delete_test.go
@@ -48,6 +48,7 @@ var _ = Describe("API Definition Controller", func() {
 	Context("With Started basic ApiDefinition & ManagementContext", func() {
 		var apiDefinitionFixture *gio.ApiDefinition
 		var apiLookupKey types.NamespacedName
+		var contextLookupKey types.NamespacedName
 
 		BeforeEach(func() {
 			By("Create a management context to synchronize with the REST API")
@@ -63,9 +64,14 @@ var _ = Describe("API Definition Controller", func() {
 
 			apiDefinition := apiWithContext.Api
 			managementContext := apiWithContext.Context
+			contextLookupKey = types.NamespacedName{Name: managementContext.Name, Namespace: namespace}
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(k8sClient.Create(ctx, managementContext)).Should(Succeed())
+
+			Eventually(func() error {
+				return k8sClient.Get(ctx, contextLookupKey, managementContext)
+			}, timeout, interval).Should(Succeed())
 
 			By("Create an API definition resource stared by default")
 

--- a/test/apidefinition_controller_error_test.go
+++ b/test/apidefinition_controller_error_test.go
@@ -47,6 +47,7 @@ var _ = Describe("Checking NoneRecoverable && Recoverable error", Label("Disable
 		var savedApiDefinition *gio.ApiDefinition
 
 		var apiLookupKey types.NamespacedName
+		var contextLookupKey types.NamespacedName
 
 		BeforeEach(func() {
 			By("Create a management context to synchronize with the REST API")
@@ -62,6 +63,11 @@ var _ = Describe("Checking NoneRecoverable && Recoverable error", Label("Disable
 
 			managementContext := apiWithContext.Context
 			Expect(k8sClient.Create(ctx, managementContext)).Should(Succeed())
+			contextLookupKey = types.NamespacedName{Name: managementContext.Name, Namespace: namespace}
+
+			Eventually(func() error {
+				return k8sClient.Get(ctx, contextLookupKey, managementContext)
+			}, timeout, interval).Should(Succeed())
 
 			By("Create an API definition resource stared by default")
 

--- a/test/apidefinition_controller_plan_and_subscription_test.go
+++ b/test/apidefinition_controller_plan_and_subscription_test.go
@@ -55,6 +55,7 @@ var _ = Describe("Checking ApiKey plan and subscription", Ordered, func() {
 		var savedApiDefinition *gio.ApiDefinition
 
 		var apiLookupKey types.NamespacedName
+		var contextLookupKey types.NamespacedName
 
 		var gatewayEndpoint string
 		var mgmtClient *managementapi.Client
@@ -72,8 +73,12 @@ var _ = Describe("Checking ApiKey plan and subscription", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			managementContext := apiWithContext.Context
-
 			Expect(k8sClient.Create(ctx, managementContext)).Should(Succeed())
+
+			contextLookupKey = types.NamespacedName{Name: managementContext.Name, Namespace: namespace}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, contextLookupKey, managementContext)
+			}, timeout, interval).Should(Succeed())
 
 			By("Create an API definition resource stared by default")
 

--- a/test/apidefinition_controller_start_stop_test.go
+++ b/test/apidefinition_controller_start_stop_test.go
@@ -46,6 +46,7 @@ var _ = Describe("API Definition Controller", func() {
 	Context("With Started basic ApiDefinition & ManagementContext", func() {
 		var apiDefinitionFixture *gio.ApiDefinition
 		var apiLookupKey types.NamespacedName
+		var contextLookupKey types.NamespacedName
 
 		BeforeEach(func() {
 			By("Create a management context to synchronize with the REST API")
@@ -61,6 +62,11 @@ var _ = Describe("API Definition Controller", func() {
 
 			managementContext := apiWithContext.Context
 			Expect(k8sClient.Create(ctx, managementContext)).Should(Succeed())
+
+			contextLookupKey = types.NamespacedName{Name: managementContext.Name, Namespace: namespace}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, contextLookupKey, managementContext)
+			}, timeout, interval).Should(Succeed())
 
 			By("Create an API definition resource stared by default")
 

--- a/test/apidefinition_controller_udpate_test.go
+++ b/test/apidefinition_controller_udpate_test.go
@@ -116,6 +116,7 @@ var _ = Describe("API Definition Controller", func() {
 	Context("With basic ApiDefinition & ManagementContext", func() {
 		var apiDefinitionFixture *gio.ApiDefinition
 		var apiLookupKey types.NamespacedName
+		var contextLookupKey types.NamespacedName
 
 		BeforeEach(func() {
 			By("Create a management context to synchronize with the REST API")
@@ -131,6 +132,11 @@ var _ = Describe("API Definition Controller", func() {
 
 			managementContext := apiWithContext.Context
 			Expect(k8sClient.Create(ctx, managementContext)).Should(Succeed())
+
+			contextLookupKey = types.NamespacedName{Name: managementContext.Name, Namespace: namespace}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, contextLookupKey, managementContext)
+			}, timeout, interval).Should(Succeed())
 
 			By("Create an API definition resource stared by default")
 
@@ -198,6 +204,7 @@ var _ = Describe("API Definition Controller", func() {
 		var managementContextFixture *gio.ManagementContext
 		var apiDefinitionFixture *gio.ApiDefinition
 		var apiLookupKey types.NamespacedName
+		var contextLookupKey types.NamespacedName
 
 		BeforeEach(func() {
 			By("Create a management context to synchronize with the REST API")
@@ -213,6 +220,11 @@ var _ = Describe("API Definition Controller", func() {
 
 			managementContext := apiWithContext.Context
 			Expect(k8sClient.Create(ctx, managementContext)).Should(Succeed())
+
+			contextLookupKey = types.NamespacedName{Name: managementContext.Name, Namespace: namespace}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, contextLookupKey, managementContext)
+			}, timeout, interval).Should(Succeed())
 
 			By("Create an API definition resource stared by default")
 

--- a/test/apiresource_controller_update_test.go
+++ b/test/apiresource_controller_update_test.go
@@ -43,6 +43,7 @@ var _ = Describe("API Resource Controller", func() {
 	Context("Update an API Resource", func() {
 
 		var apiLookupKey types.NamespacedName
+		var contextLookupKey types.NamespacedName
 		var resourceLookupKey types.NamespacedName
 
 		BeforeEach(func() {
@@ -58,7 +59,13 @@ var _ = Describe("API Resource Controller", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(k8sClient.Create(ctx, fixture.Context)).Should(Succeed())
+			managementContext := fixture.Context
+			Expect(k8sClient.Create(ctx, managementContext)).Should(Succeed())
+
+			contextLookupKey = types.NamespacedName{Name: managementContext.Name, Namespace: namespace}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, contextLookupKey, managementContext)
+			}, timeout, interval).Should(Succeed())
 
 			Expect(k8sClient.Create(ctx, fixture.Resource)).Should(Succeed())
 


### PR DESCRIPTION
This is to avoid the smoke test becoming flaky because of errors reported in our logs during test execution.