### PR TITLE
chore: add prometheus label to service monitor and change default nam…

### DIFF
--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -19,8 +19,9 @@ kind: ServiceMonitor
 metadata:
   labels:
     control-plane: controller-manager
+    release: prometheus
   name: controller-manager-metrics-monitor
-  namespace: system
+  namespace: gko-system
 spec:
   endpoints:
     - path: /metrics


### PR DESCRIPTION
## Description

Change default namespace of GKO Service monitor.
Add prometheus release label to allow service discovery to detect it by default

See https://github.com/gravitee-io/gravitee-docs/pull/911 to test it