### PR TITLE
test: listen all namespaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ lint-license: addlicense ## Run addlicense lint and fail on error
 
 GOTESTARGS ?= ""
 .PHONY: test
-test: manifests generate install ## Run tests.
+test: manifests generate install ginkgo ## Run tests.
 	kubectl config use-context k3d-graviteeio
 	KUBEBUILDER_ASSETS=USE_EXISTING_CLUSTER=true $(GINKGO) $(GOTESTARGS) --timeout 380s --cover --coverprofile=cover.out ./...
 

--- a/scripts/k3d.mjs
+++ b/scripts/k3d.mjs
@@ -301,6 +301,7 @@ helm install \
     --set "portal.enabled=false" \
     --set "gateway.image.repository=${K3D_IMAGES_REGISTRY}/apim-gateway" \
     --set "gateway.services.sync.kubernetes.enabled=true" \
+    --set "gateway.services.sync.kubernetes.namespaces=ALL" \
     --set "gateway.ingress.hosts[0]=localhost" \
     --set "gateway.ingress.path=/gateway/?(.*)" \
     --set "gateway.ingress.tls=false" \


### PR DESCRIPTION
## Description

Install ginkgo before running test. It will allow any new contributor to run the tests without having to install ginkgo manually in the bin directory

Add the flag to allow the gateway to listen to all namespaces