### PR TITLE
feat: add DEV_MODE logging option

### DIFF
--- a/controllers/apim/apidefinition/apidefinition_controller.go
+++ b/controllers/apim/apidefinition/apidefinition_controller.go
@@ -93,7 +93,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		managementContext, ctxErr := apisDelegate.ResolveContext(apiDefinition.Spec.Context)
 
 		if ctxErr != nil {
-			log.Error(ctxErr, "And error has occurred while trying to retrieve ManagementContext")
+			log.Error(ctxErr, "An error has occurred while trying to retrieve ManagementContext")
 			event.NormalEvent(
 				apiDefinition,
 				"ManagementContextUnlinked",

--- a/internal/utils/zap.go
+++ b/internal/utils/zap.go
@@ -1,0 +1,39 @@
+// Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"go.uber.org/zap/zapcore"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func NewEncoderConfigOption() []zap.EncoderConfigOption {
+	return []zap.EncoderConfigOption{
+		func(config *zapcore.EncoderConfig) {
+			config.MessageKey = "message"
+			config.TimeKey = "timestamp"
+			config.LevelKey = "level"
+			config.NameKey = "logger"
+			config.CallerKey = "caller"
+			config.FunctionKey = zapcore.OmitKey
+			config.StacktraceKey = "stacktrace"
+			config.LineEnding = zapcore.DefaultLineEnding
+			config.EncodeLevel = zapcore.LowercaseLevelEncoder
+			config.EncodeTime = zapcore.EpochTimeEncoder
+			config.EncodeDuration = zapcore.SecondsDurationEncoder
+			config.EncodeCaller = zapcore.ShortCallerEncoder
+		},
+	}
+}

--- a/main.go
+++ b/main.go
@@ -65,9 +65,11 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+
 	opts := zap.Options{
-		Development: true,
+		Development: os.Getenv("DEV_MODE") == "true",
 	}
+
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 

--- a/main.go
+++ b/main.go
@@ -21,6 +21,8 @@ import (
 	"flag"
 	"os"
 
+	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/utils"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -67,7 +69,8 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 
 	opts := zap.Options{
-		Development: os.Getenv("DEV_MODE") == "true",
+		Development:          os.Getenv("DEV_MODE") == "true",
+		EncoderConfigOptions: utils.NewEncoderConfigOption(),
 	}
 
 	opts.BindFlags(flag.CommandLine)


### PR DESCRIPTION
## Description

The dev mode will allow us to pass from something like

```
1.67032314137655e+09    INFO    All workers finished    {"controller": "apiresource", "controllerGroup": "gravitee.io", "controllerKind": "ApiResource"}
1.67032314137655e+09    INFO    All workers finished    {"controller": "managementcontext", "controllerGroup": "gravitee.io", "controllerKind": "ManagementContext"}
1.670323141376551e+09   INFO    Shutdown signal received, waiting for all workers to finish     {"controller": "ingress", "controllerGroup": "networking.k8s.io", "controllerKind": "Ingress"}
1.670323141376686e+09   INFO    All workers finished    {"controller": "ingress", "controllerGroup": "networking.k8s.io", "controllerKind": "Ingress"}
```

to

```json
{"level":"info","ts":1670323158.854773,"msg":"Stopping and waiting for leader election runnables"}
{"level":"info","ts":1670323158.854789,"msg":"Shutdown signal received, waiting for all workers to finish","controller":"managementcontext","controllerGroup":"gravitee.io","controllerKind":"ManagementContext"}
```