### PR TITLE
docs: mention alpha in helm note

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -119,7 +119,7 @@ When committing your contributions, please follow link:https://www.conventionalc
 
 === Release process
 
-/!\ All new changes should be committed to the `alpha` branch. A prerelease is automatically created on `alpha` like `0.2.0-alpha.1`.
+/!\ All new changes should be committed to the `alpha` branch.
 
 To create a new release, we need to merge `alpha` into `master`. 
 A github action do the job. 

--- a/README.adoc
+++ b/README.adoc
@@ -3,6 +3,7 @@
 image:https://img.shields.io/badge/License-Apache%202.0-blue.svg["License", link="https://github.com/gravitee-io/gravitee-kubernetes-operator/blob/master/LICENSE.txt"]
 image:https://dl.circleci.com/status-badge/img/gh/gravitee-io/gravitee-kubernetes-operator/tree/master.svg?style=svg&circle-token=fede14bc30847f9ef01ae44c12c44edbe817c3b0["CircleCI", link="https://app.circleci.com/pipelines/github/gravitee-io/gravitee-kubernetes-operator?branch=master"]
 image:https://img.shields.io/badge/semantic--release-📦🚀-e10079?logo=semantic-release["semantic-release: 📦🚀", link="https://github.com/semantic-release/semantic-release"]
+image:https://goreportcard.com/badge/github.com/gravitee-io/gravitee-kubernetes-operator["Go Report Card", link="https://goreportcard.com/report/github.com/gravitee-io/gravitee-kubernetes-operator"]
 
 image:./.assets/gravitee-logo-cyan.svg["Gravitee.io",400]
 

--- a/helm/gko/templates/NOTES.txt
+++ b/helm/gko/templates/NOTES.txt
@@ -8,3 +8,14 @@ To learn more about your release, try:
 Please visit our documentation to learn about custom resources managed by the operator:
 
 https://docs.gravitee.io/apim/3.x/apim_kubernetes_operator_overview.html
+
+⚠️ Warning
+
+The Gravitee Kubernetes Operator is still in alpha stage.
+
+  ○ The software may contain bugs. Enabling a feature may expose bugs.
+  ○ Support for an alpha API may be dropped at any time without notice.
+  ○ The API may change in incompatible ways in a later software release without notice.
+  ○ The software is recommended for use only in short-lived testing clusters, due to the lack of long-term support.
+
+Please use with caution and feel free to provide feedback for further improvement.


### PR DESCRIPTION
## Description

- Mention in helm note that the operator is still in beta
- Remove prerelease references 
- add go report badge