### PR TITLE
Align master alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# [0.4.0](https://github.com/gravitee-io/gravitee-kubernetes-operator/compare/0.3.0...0.4.0) (2022-12-07)
+
+
+### Bug Fixes
+
+* error log typo ([a7377ec](https://github.com/gravitee-io/gravitee-kubernetes-operator/commit/a7377ec9ba2535307a3d435fa165fb7ed52ca629))
+
+
+### Features
+
+* add DEV_MODE logging option ([d1cae84](https://github.com/gravitee-io/gravitee-kubernetes-operator/commit/d1cae8487ad7627651e20026e40776087a3ff614))
+* use `message` and `timestamp` keys in log ([15b75d4](https://github.com/gravitee-io/gravitee-kubernetes-operator/commit/15b75d483520e06eb245b4af8671d9f768564955))
+
 # [0.3.0](https://github.com/gravitee-io/gravitee-kubernetes-operator/compare/0.2.0...0.3.0) (2022-11-23)
 
 


### PR DESCRIPTION
## Description

After the release 0.4.0 we forget rebase alpha on master. The following commits are present in both branches and are creating a conflict for the next release.

Here is the list of the commits 
- edf467673ca616f53218e092effa89d92c9c9044 --> chore(release): 0.4.0 [skip ci]
- 8ab7399f686d1f1b945d0e73ae2a9adf585b7659 --> chore(deps): update slack orb to v4.12.0
- 6e997b618aee80a33cd3e940ae33e6a98dc5d769 --> chore: add prometheus label to service monitor and change default namespace
- 09d393debe8f9380453e991e6553dffafe5c1312 --> chore(deps): update gravitee orb to v2.2.0
- a7377ec9ba2535307a3d435fa165fb7ed52ca629 -->fix: error log typo
- 15b75d483520e06eb245b4af8671d9f768564955 - feat: use `message` and `timestamp` keys in log
- d1cae8487ad7627651e20026e40776087a3ff614 --> feat: add DEV_MODE logging option
- b919952f1d1c04428d04c61351570d267efa7a65 --> docs: update read me commands
- 682d6f62f2c9bac7933487fb4e7dda12294acec3 --> refactor: add cause and url to cross id request error
-  61a4a0faa29dcaa8e1d981d5f8dc8857ba51d5b7 --> ci: fix changelog link when notifying release
- 73af2c37b49ee14b0c3de29816981077248354ed --> test: ensure context is created before creating api
- 2c11b07752745947e3dc63d8e70b89481012c91d --> chore: check api definitions on all namespaces
- 7e53a6b328e824888aca41cc93e2553e2a6ababc -->  test: install ginkgo when running make test
- a91779990294beb41584282a950e9ef509b5a3c4 --> ci: fix release action
