### PR TITLE
Deploy gateway as LB

### DIFF
--- a/config/samples/ingress/ingress-with-multiple-hosts.yml
+++ b/config/samples/ingress/ingress-with-multiple-hosts.yml
@@ -24,23 +24,23 @@ metadata:
     gravitee.io/ingress: graviteeio
 spec:
   rules:
-    - host: bar.example.com
+    - host: httpbin.example.com
       http:
         paths:
-          - path: /bar
+          - path: /httpbin
             pathType: Prefix
             backend:
               service:
-                name: bar-svc
+                name: httpbin
                 port:
-                  number: 8080
-    - host: foo.example.com
+                  number: 8000
+    - host: wiremock.example.com
       http:
         paths:
-          - path: /foo
+          - path: /wiremock
             pathType: Prefix
             backend:
               service:
-                name: foo-svc
+                name: wiremock-svc
                 port:
                   number: 8080

--- a/config/samples/ingress/ingress-without-api-template.yml
+++ b/config/samples/ingress/ingress-without-api-template.yml
@@ -24,13 +24,13 @@ metadata:
     gravitee.io/ingress: graviteeio
 spec:
   rules:
-    - host: local.example.com
+    - host: httpbin.example.com
       http:
         paths:
-          - path: /
+          - path: /get
             pathType: Prefix
             backend:
               service:
-                name: wiremock-svc
+                name: httpbin
                 port:
-                  number: 8080
+                  number: 8000

--- a/test/ingress_controller_create_test.go
+++ b/test/ingress_controller_create_test.go
@@ -57,12 +57,12 @@ var _ = Describe("Creating an ingress", func() {
 			expectedApiName := ingressFixture.Name
 			Expect(createdApiDefinition.Name).Should(Equal(expectedApiName))
 
-			Expect(createdApiDefinition.Spec.Proxy.VirtualHosts[0].Path).Should(Equal("/"))
+			Expect(createdApiDefinition.Spec.Proxy.VirtualHosts[0].Path).Should(Equal("/get"))
 			Expect(createdApiDefinition.Spec.Proxy.Groups[0].Endpoints).Should(Equal(
 				[]*model.HttpEndpoint{
 					{
-						Name:   "wiremock-svc",
-						Target: "http://wiremock-svc.default.svc.cluster.local:8080",
+						Name:   "httpbin",
+						Target: "http://httpbin.default.svc.cluster.local:8000",
 					},
 				},
 			))
@@ -102,19 +102,25 @@ var _ = Describe("Creating an ingress", func() {
 			Expect(createdApiDefinition.Spec.Proxy.VirtualHosts).Should(HaveLen(2))
 			Expect(createdApiDefinition.Spec.Proxy.VirtualHosts).Should(
 				Equal([]*model.VirtualHost{
-					{Host: "bar.example.com", Path: "/bar"},
-					{Host: "foo.example.com", Path: "/foo"},
+					{
+						Host: "httpbin.example.com",
+						Path: "/httpbin",
+					},
+					{
+						Host: "wiremock.example.com",
+						Path: "/wiremock",
+					},
 				}),
 			)
 			Expect(createdApiDefinition.Spec.Proxy.Groups[0].Endpoints).Should(Equal(
 				[]*model.HttpEndpoint{
 					{
-						Name:   "bar-svc",
-						Target: "http://bar-svc.default.svc.cluster.local:8080",
+						Name:   "httpbin",
+						Target: "http://httpbin.default.svc.cluster.local:8000",
 					},
 					{
-						Name:   "foo-svc",
-						Target: "http://foo-svc.default.svc.cluster.local:8080",
+						Name:   "wiremock-svc",
+						Target: "http://wiremock-svc.default.svc.cluster.local:8080",
 					},
 				},
 			))

--- a/test/internal/constants.go
+++ b/test/internal/constants.go
@@ -15,7 +15,7 @@
 package internal
 
 const (
-	GatewayUrl = "http://localhost:9000/gateway"
+	GatewayUrl = "http://localhost:9001"
 
 	SamplesPath = "../config/samples"
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-784

## Description

Run k3d using the APIM Gatweay as a LoadBalancer service.
Now when you apply the example ingress-with-multiple-hosts.yml the gateway should respond if you do the following call for example `curl -i http://localhost:9001/httpbin/get --header "Host: httpbin.example.com"`