### PR TITLE
ci: add user and email in sync-branches

### DIFF
--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -32,6 +32,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TARGET_BRANCH: "alpha"
           SOURCE_BRANCH: "master"
+          GIT_AUTHOR_NAME: "Gravitee.io Bot"
+          GIT_COMMITTER_NAME: "Gravitee.io Bot"
+          GIT_AUTHOR_EMAIL: "contact@gravitee.io"
+          GIT_COMMITTER_EMAIL: "contact@gravitee.io"
         run: |
           echo "🚀 Rebasing ${TARGET_BRANCH} on ${SOURCE_BRANCH}"
 


### PR DESCRIPTION
## Description

Now we can trigger the sync manually we need to configure git email and user name before running the commands