### PR TITLE
refactor: context not removable when linked to api definition

### DIFF
--- a/api/v1alpha1/managementcontext_types.go
+++ b/api/v1alpha1/managementcontext_types.go
@@ -60,3 +60,7 @@ type ManagementContextList struct {
 func init() {
 	SchemeBuilder.Register(&ManagementContext{}, &ManagementContextList{})
 }
+
+func (context *ManagementContext) IsBeingDeleted() bool {
+	return !context.ObjectMeta.DeletionTimestamp.IsZero()
+}

--- a/controllers/apim/apidefinition/apidefinition_controller.go
+++ b/controllers/apim/apidefinition/apidefinition_controller.go
@@ -102,8 +102,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&gio.ApiDefinition{}).
-		Watches(&source.Kind{Type: &gio.ManagementContext{}}, r.ContextWatcher(indexer.ContextField.String())).
-		Watches(&source.Kind{Type: &gio.ApiResource{}}, r.ResourceWatcher(indexer.ResourceField.String())).
+		Watches(&source.Kind{Type: &gio.ManagementContext{}}, r.ContextWatcher(indexer.ContextField)).
+		Watches(&source.Kind{Type: &gio.ApiResource{}}, r.ResourceWatcher(indexer.ResourceField)).
 		WithEventFilter(ApiUpdateFilter{}).
 		Complete(r)
 }

--- a/controllers/apim/managementcontext/internal/delete.go
+++ b/controllers/apim/managementcontext/internal/delete.go
@@ -1,0 +1,59 @@
+// Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"fmt"
+
+	"github.com/gravitee-io/gravitee-kubernetes-operator/api/model"
+	gio "github.com/gravitee-io/gravitee-kubernetes-operator/api/v1alpha1"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/indexer"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/search"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/pkg/keys"
+	"golang.org/x/net/context"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	util "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func Delete(
+	ctx context.Context,
+	client client.Client,
+	instance *gio.ManagementContext,
+) error {
+	if !util.ContainsFinalizer(instance, keys.ManagementContextDeletionFinalizer) {
+		return nil
+	}
+
+	apis := &gio.ApiDefinitionList{}
+	err := search.New(ctx, client).FindByFieldReferencing(
+		indexer.ContextField,
+		model.NewNamespacedName(instance.Namespace, instance.Name),
+		apis,
+	)
+
+	if err != nil {
+		err = fmt.Errorf("an error occured while checking if the management context is linked to an api definition: %w", err)
+		return err
+	}
+
+	if len(apis.Items) > 0 {
+		err = fmt.Errorf("can not delete %s because it depends on %v", instance.Name, apis)
+		return err
+	}
+
+	util.RemoveFinalizer(instance, keys.ManagementContextDeletionFinalizer)
+
+	return client.Update(ctx, instance)
+}

--- a/controllers/apim/managementcontext/internal/update.go
+++ b/controllers/apim/managementcontext/internal/update.go
@@ -1,0 +1,41 @@
+// Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"fmt"
+
+	gio "github.com/gravitee-io/gravitee-kubernetes-operator/api/v1alpha1"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/pkg/keys"
+	"golang.org/x/net/context"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	util "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func CreateOrUpdate(
+	ctx context.Context,
+	k8s client.Client,
+	instance *gio.ManagementContext,
+) error {
+	if !util.ContainsFinalizer(instance, keys.ManagementContextDeletionFinalizer) {
+		util.AddFinalizer(instance, keys.ManagementContextDeletionFinalizer)
+	}
+
+	if err := k8s.Update(ctx, instance); err != nil {
+		err = fmt.Errorf("an error occurs while adding finalizer to the management context: %w", err)
+		return err
+	}
+	return nil
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1,0 +1,51 @@
+// Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package search
+
+import (
+	"github.com/gravitee-io/gravitee-kubernetes-operator/api/model"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/indexer"
+	"golang.org/x/net/context"
+	"k8s.io/apimachinery/pkg/fields"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Type struct {
+	k8s client.Client
+	ctx context.Context
+}
+
+func New(ctx context.Context, k8s client.Client) *Type {
+	return &Type{
+		k8s: k8s,
+		ctx: ctx,
+	}
+}
+
+func (s *Type) FindByFieldReferencing(
+	field indexer.IndexField,
+	ref model.NamespacedName,
+	result client.ObjectList,
+) error {
+	filter := &client.ListOptions{
+		FieldSelector: fields.SelectorFromSet(fields.Set{field.String(): ref.String()}),
+	}
+
+	if err := s.k8s.List(s.ctx, result, filter); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -110,8 +110,9 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&managementcontext.Reconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("managementcontext-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ManagementContext")
 		os.Exit(1)

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -21,7 +21,6 @@ const (
 	IngressClassAnnotation      = "kubernetes.io/ingress.class"
 	IngressClassAnnotationValue = "graviteeio"
 	IngressTemplateAnnotation   = "gravitee.io/template"
-	IngressFinalizer            = "finalizers.gravitee.io/ingress"
 )
 
 // Gravitee.io CRDs.
@@ -38,6 +37,8 @@ const Extends = "gravitee.io/extends"
 
 // Kubernetes Finalizers.
 const (
-	ApiDefinitionDeletionFinalizer = "finalizers.gravitee.io/apidefinitiondeletion"
-	ApiDefinitionTemplateFinalizer = "finalizers.gravitee.io/apidefinitiontemplate"
+	ApiDefinitionDeletionFinalizer     = "finalizers.gravitee.io/apidefinitiondeletion"
+	ApiDefinitionTemplateFinalizer     = "finalizers.gravitee.io/apidefinitiontemplate"
+	ManagementContextDeletionFinalizer = "finalizers.gravitee.io/managementcontextdeletion"
+	IngressFinalizer                   = "finalizers.gravitee.io/ingress"
 )

--- a/test/internal/fixtures.go
+++ b/test/internal/fixtures.go
@@ -84,7 +84,7 @@ func (f *FixtureGenerator) NewFixtures(files FixtureFiles, transforms ...func(*F
 		fixtures.Resource = resource
 	}
 
-	if fixtures.Context != nil {
+	if fixtures.Context != nil && fixtures.Api != nil {
 		fixtures.Api.Spec.Context = fixtures.Context.GetNamespacedName()
 	}
 

--- a/test/managementcontext_controller_delete_test.go
+++ b/test/managementcontext_controller_delete_test.go
@@ -1,0 +1,123 @@
+// Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	gio "github.com/gravitee-io/gravitee-kubernetes-operator/api/v1alpha1"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Deleting a management context", func() {
+	Context("Not linked to an api definition", func() {
+		var contextFixture *gio.ManagementContext
+		var contextLookupKey types.NamespacedName
+
+		BeforeEach(func() {
+			By("Initializing the management context fixture")
+			fixtureGenerator := internal.NewFixtureGenerator()
+
+			fixtures, err := fixtureGenerator.NewFixtures(internal.FixtureFiles{
+				Context: internal.ContextWithCredentialsFile,
+			})
+
+			Expect(err).ToNot(HaveOccurred())
+
+			contextFixture = fixtures.Context
+			contextLookupKey = types.NamespacedName{Name: contextFixture.Name, Namespace: namespace}
+		})
+
+		It("Should delete the management context", func() {
+			By("Creating a new management context")
+
+			Expect(k8sClient.Create(ctx, contextFixture)).Should(Succeed())
+
+			By("Getting created resource and expect to find it")
+
+			createdContext := new(gio.ManagementContext)
+			Eventually(func() error {
+				return k8sClient.Get(ctx, contextLookupKey, createdContext)
+			}, timeout, interval).ShouldNot(HaveOccurred())
+
+			By("Deleting the management context")
+			Expect(k8sClient.Delete(ctx, createdContext)).ToNot(HaveOccurred())
+
+			By("Checking the management context has been deleted")
+			context := &gio.ManagementContext{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, contextLookupKey, context)
+			}, timeout, interval).ShouldNot(Succeed())
+		})
+	})
+
+	Context("Linked to an api definition", func() {
+		var contextFixture *gio.ManagementContext
+		var contextLookupKey types.NamespacedName
+		var apiFixture *gio.ApiDefinition
+		var apiLookupKey types.NamespacedName
+
+		BeforeEach(func() {
+			By("Initializing the management context fixture and api definition")
+			fixtureGenerator := internal.NewFixtureGenerator()
+
+			fixtures, err := fixtureGenerator.NewFixtures(internal.FixtureFiles{
+				Api:     internal.ApiWithContextFile,
+				Context: internal.ContextWithCredentialsFile,
+			})
+
+			Expect(err).ToNot(HaveOccurred())
+
+			contextFixture = fixtures.Context
+			contextLookupKey = types.NamespacedName{Name: contextFixture.Name, Namespace: namespace}
+
+			apiFixture = fixtures.Api
+			apiLookupKey = types.NamespacedName{Name: apiFixture.Name, Namespace: namespace}
+		})
+
+		It("Should not delete the management context", func() {
+			By("Creating a new management context")
+			Expect(k8sClient.Create(ctx, contextFixture)).Should(Succeed())
+
+			By("Getting created resource and expect to find it")
+			createdContext := new(gio.ManagementContext)
+			Eventually(func() error {
+				if err := k8sClient.Get(ctx, contextLookupKey, createdContext); err != nil {
+					return err
+				}
+				return internal.AssertEquals("finalizer.length", 1, len(createdContext.ObjectMeta.Finalizers))
+			}, timeout, interval).ShouldNot(HaveOccurred())
+
+			By("Creating a api definition")
+			Expect(k8sClient.Create(ctx, apiFixture)).Should(Succeed())
+
+			By("Getting created resource and expect to find it")
+			createdApi := new(gio.ApiDefinition)
+			Eventually(func() error {
+				return k8sClient.Get(ctx, apiLookupKey, createdApi)
+			}, timeout, interval).ShouldNot(HaveOccurred())
+
+			By("Trying to delete the management context")
+			Expect(k8sClient.Delete(ctx, createdContext)).ToNot(HaveOccurred())
+
+			By("Checking the management context has not been deleted")
+			context := &gio.ManagementContext{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, contextLookupKey, context)
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+})

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -103,8 +103,9 @@ var _ = SynchronizedBeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&managementcontext.Reconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
+		Client:   k8sManager.GetClient(),
+		Scheme:   k8sManager.GetScheme(),
+		Recorder: k8sManager.GetEventRecorderFor("managementcontext_controller"),
 	}).SetupWithManager(k8sManager)
 
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
## Description

When a context path is linked to an api definition it should not be removable. It a user remove it, it becomes really difficult for them to remove tha apidefinition as they wont have access to the context to call APIM