### PR TITLE
refactor: use gravitee public latest image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,9 +170,7 @@ jobs:
       - run:
           name: Start APIM using k3d
           command: |
-            export APIM_IMAGE_REGISTRY=graviteeio.azurecr.io
-            export APIM_IMAGE_TAG=master-latest
-            K3DARGS="--pull=${K3D_PULL}" make k3d-init
+            K3DARGS="--pull=${K3D_PULL}" APIM_HELM_VERSION=3.1.58 make k3d-init
       - run:
           name: Run tests
           command: GOTESTARGS="--output-dir=/tmp/junit/reports --junit-report=junit.xml" make test

--- a/scripts/k3d.mjs
+++ b/scripts/k3d.mjs
@@ -31,6 +31,7 @@ const APIM_IMAGE_REGISTRY = `${
   process.env.APIM_IMAGE_REGISTRY || "graviteeio"
 }`;
 const APIM_IMAGE_TAG = `${process.env.APIM_IMAGE_TAG || "latest"}`;
+const APIM_HELM_VERSION = `${process.env.APIM_HELM_VERSION || ""}`;
 
 // Docker dependencies images tags
 const NGINX_CONTROLLER_IMAGE_TAG = "1.3.0";
@@ -263,6 +264,13 @@ LOG.blue(`
 
 setNoQuoteEscape();
 
+function getApimHelmVersion() {
+  if(!!APIM_HELM_VERSION) {
+    return "--version=" + APIM_HELM_VERSION;
+  }
+  return " ";
+}
+
 const helmInstallApim = $`
 helm install \
     --namespace ${K3D_NAMESPACE_NAME} \
@@ -307,7 +315,7 @@ helm install \
     --set "mongo.dbhost=mongodb" \
     --set "mongodb-replicaset=false" \
     --set "mongo.rsEnabled=false" \
-    apim graviteeio/apim3 > /dev/null
+    ${getApimHelmVersion()} apim graviteeio/apim3 > /dev/null
 `;
 
 const helmInstallMongo = $`


### PR DESCRIPTION
## Description

Currently we have an issue on the gateway master-latest that why we move temporarily on public latest to run the tests. 
On public latest if we use the last helm chart with apim-apim-3 role the Gateway kubernetes websocket is not able to get the ConfigMaps on the cluster. That's why we downgrade the version use in the test to have the good Cluster Role which is automatically created using the version 3.1.58 of gravitee helm charts 