### PR TITLE
feat: configure the gateway via listeners

### DIFF
--- a/scripts/k3d.mjs
+++ b/scripts/k3d.mjs
@@ -319,6 +319,13 @@ const helmInstallApim = $`
 helm install \
     --namespace ${K3D_NAMESPACE_NAME} \
     --set "portal.enabled=false" \
+    --set "listeners.http.port=8082"
+    --set "listeners.https.port=8443"
+    --set "listeners.https.secured: false
+    --set "listeners.https.ssl.keystore.type"=jks"
+    --set "listeners.https.ssl.keystore.kubernetes=/default/secrets/gw-keystore/keystore"
+    --set "listeners.https.ssl.keystore.password=changeme"
+    --set "listeners.https.ssl.sni=true"
     --set "gateway.image.repository=${K3D_IMAGES_REGISTRY}/apim-gateway" \
     --set "gateway.services.sync.kubernetes.enabled=true" \
     --set "gateway.services.sync.kubernetes.namespaces=default" \


### PR DESCRIPTION
**Issue**
https://gravitee.atlassian.net/browse/APIM-1109

**Description**
As of now the users can only provide one setting for the http(s) and the gateway is only listening on a single port. the idea is to enable users to configure the gateway in a way that it will listen to multiple ports using different protocols.
