### PR TITLE
feat: patch resource definitions on startup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
 
   lint-resources:
     docker:
-      - image: cimg/go:<< pipeline.parameters.go-version >>
+      - image: cimg/go:<< pipeline.parameters.go-version >>-node
     resource_class: small
     steps:
       - checkout
@@ -109,14 +109,19 @@ jobs:
             make generate
             git diff --quiet HEAD
       - run:
-          name: Check that make manifests have been executed
+          name: Check that make manifests has been executed
           command: |
             make manifests
             git diff --quiet HEAD
       - run:
-          name: Check that make reference have been executed
+          name: Check that make reference has been executed
           command: |
             make reference
+            git diff --quiet HEAD
+      - run:
+          name: Check that make helm-reference has been executed
+          command: |
+            make helm-reference
             git diff --quiet HEAD
 
   test:

--- a/helm/gko/README.md
+++ b/helm/gko/README.md
@@ -23,6 +23,7 @@ Kubernetes: `>=1.14.0-0`
 |-----|------|---------|-------------|
 | ingress.templates.404.name | string | `""` | name of the config map storing the HTTP 404 ingress response template. A default template is used if this entry is empty. The config map should contain a content key and a contentType key. The default template is used if one of the key is missing. |
 | ingress.templates.404.namespace | string | `""` | namespace of the config map storing the HTTP 404 ingress response template. A default template is used if this entry is empty. The config map should contain a content key and a contentType key. The default template is used if one of the key is missing.        |
+| manager.applyCRDs | bool | `true` | If true, the manager will apply custom resource definitions on startup. |
 | manager.configMap.name | string | `"gko-config"` | The name of the config map used to set the manager config from this values. |
 | manager.logs.json | bool | `true` | Whether to output manager logs in JSON format. |
 | manager.scope.cluster | bool | `true` | If true, the manager listens to resources created in the whole cluster. Use false to listen only in the release namespace. |

--- a/helm/gko/templates/bundle-config.yaml
+++ b/helm/gko/templates/bundle-config.yaml
@@ -17,12 +17,15 @@ apiVersion: v1
 metadata:
   name: {{ .Values.manager.configMap.name }}
 data:
-{{- if not .Values.manager.scope.cluster }}
+  {{- if not .Values.manager.scope.cluster }}
   NAMESPACE: {{ .Release.Namespace }}
-{{- end }}
-{{- if not .Values.manager.logs.json }}
+  {{- end }}
+  {{- if .Values.manager.applyCRDs }}
+  APPLY_CRDS: "true"
+  {{- end }}
+  {{- if not .Values.manager.logs.json }}
   DEV_MODE: "true"
-{{- end }}
+  {{- end }}
   {{- $template404 := get .Values.ingress.templates "404" }}
   {{- if $template404.name }}
   TEMPLATE_404_CONFIG_MAP_NAME: {{ $template404.name }}

--- a/helm/gko/templates/bundle.yaml
+++ b/helm/gko/templates/bundle.yaml
@@ -160,6 +160,33 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - gravitee.io
+    resources:
+      - applications
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - gravitee.io
+    resources:
+      - applications/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - gravitee.io
+    resources:
+      - applications/status
+    verbs:
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/helm/gko/tests/bundle-config_test.yaml
+++ b/helm/gko/tests/bundle-config_test.yaml
@@ -27,9 +27,10 @@ tests:
       - equal:
           path: metadata.name
           value: gko-config
-      - isEmpty:
+      - equal:
           # It should not contain environment variable by default
-          path: data
+          path: data.APPLY_CRDS
+          value: "true"
 
   - it: Check config with json logs disabled
     set:
@@ -39,13 +40,6 @@ tests:
     asserts:
       - hasDocuments:
           count: 1
-      - isKind:
-          of: ConfigMap
-      - isAPIVersion:
-          of: v1
-      - equal:
-          path: metadata.name
-          value: gko-config
       - equal:
           # It should not contain environment variable by default
           path: data.DEV_MODE

--- a/helm/gko/values.yaml
+++ b/helm/gko/values.yaml
@@ -23,6 +23,8 @@ manager:
     # -- If true, the manager listens to resources created in the whole cluster.
     # Use false to listen only in the release namespace.
     cluster: true
+  # -- If true, the manager will apply custom resource definitions on startup.
+  applyCRDs: true
 
 ingress:
   templates:

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -23,10 +23,12 @@ const (
 	CMTemplate404NS   = "TEMPLATE_404_CONFIG_MAP_NAMESPACE"
 	Development       = "DEV_MODE"
 	NS                = "NAMESPACE"
+	ApplyCRDs         = "APPLY_CRDS"
 )
 
 var Config = struct {
 	NS                string
+	ApplyCRDs         bool
 	Development       bool
 	CMTemplate404Name string
 	CMTemplate404NS   string
@@ -34,6 +36,7 @@ var Config = struct {
 
 func init() {
 	Config.NS = os.Getenv(NS)
+	Config.ApplyCRDs = os.Getenv(ApplyCRDs) == "true"
 	Config.Development = os.Getenv(Development) == "true"
 	Config.CMTemplate404Name = os.Getenv(CMTemplate404Name)
 	Config.CMTemplate404NS = os.Getenv(CMTemplate404NS)

--- a/main.go
+++ b/main.go
@@ -18,15 +18,19 @@ package main
 
 import (
 	"context"
+	"embed"
 	"flag"
 	"fmt"
+	"io/fs"
 	"os"
 
+	"gopkg.in/yaml.v3"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/gravitee-io/gravitee-kubernetes-operator/controllers/apim/application"
 
 	v1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/env"
 
@@ -36,26 +40,32 @@ import (
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
-	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"k8s.io/client-go/dynamic"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	gio "github.com/gravitee-io/gravitee-kubernetes-operator/api/v1alpha1"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/controllers/apim/apidefinition"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/controllers/apim/apiresource"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/controllers/apim/ingress"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/controllers/apim/managementcontext"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	//+kubebuilder:scaffold:imports
 )
 
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
+
+	//go:embed helm
+	helm embed.FS
 )
 
 const managerPort = 9443
@@ -103,8 +113,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = addIndexer(mgr)
-	if err != nil {
+	if env.Config.ApplyCRDs {
+		if err = applyCRDs(); err != nil {
+			setupLog.Error(err, "unable to apply custom resource definitions")
+			os.Exit(1)
+		}
+	}
+
+	if err = addIndexer(mgr); err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
@@ -117,6 +133,7 @@ func main() {
 		setupLog.Error(healthCheckErr, "unable to set up health check")
 		os.Exit(1)
 	}
+
 	if readyCheckErr := mgr.AddReadyzCheck("readyz", healthz.Ping); readyCheckErr != nil {
 		setupLog.Error(readyCheckErr, "unable to set up ready check")
 		os.Exit(1)
@@ -255,4 +272,44 @@ func indexApplicationFields(manager ctrl.Manager) error {
 	}
 
 	return nil
+}
+
+func applyCRDs() error {
+	client := dynamic.NewForConfigOrDie(ctrl.GetConfigOrDie())
+	ctx := context.Background()
+
+	version := schema.GroupVersionResource{
+		Group:    "apiextensions.k8s.io",
+		Version:  "v1",
+		Resource: "customresourcedefinitions",
+	}
+
+	return fs.WalkDir(helm, "helm/gko/crds", func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		b, err := fs.ReadFile(helm, path)
+		if err != nil {
+			return err
+		}
+
+		obj := make(map[string]interface{})
+		if err = yaml.Unmarshal(b, &obj); err != nil {
+			return err
+		}
+
+		opts := metav1.ApplyOptions{Force: true, FieldManager: "gravitee.io/operator"}
+		crd := &unstructured.Unstructured{Object: obj}
+
+		if crd, err = client.Resource(version).Apply(ctx, crd.GetName(), crd, opts); err == nil {
+			setupLog.Info("applied resource definition", "name", crd.GetName())
+		}
+
+		return err
+	})
 }


### PR DESCRIPTION
This is to circumvent the fact that helm does not re-apply the crds directory on updates.