### PR TITLE
ci: remove test chart from release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -518,13 +518,9 @@ workflows:
             equal:
               [<< pipeline.git.revision >>, << pipeline.git.base_revision >>]
     jobs:
-      - helm-test:
-          name: Test chart
       - semantic-release:
           name: Semantic Release
           context: cicd-orchestrator
-          requires:
-            - Test chart
       - add-docker-images-to-snyk:
           name: Add Docker images to snyk
           context: cicd-orchestrator


### PR DESCRIPTION
Since all the checks are performed before merging the release branch, this step is not required