### PR TITLE
fix: set config namespace to release namespace

### DIFF
--- a/helm/gko/templates/bundle-config.yaml
+++ b/helm/gko/templates/bundle-config.yaml
@@ -16,6 +16,7 @@ kind: ConfigMap
 apiVersion: v1 
 metadata:
   name: {{ .Values.manager.configMap.name }}
+  namespace: {{ .Release.Namespace }}
 data:
   {{- if not .Values.manager.scope.cluster }}
   NAMESPACE: {{ .Release.Namespace }}

--- a/helm/gko/tests/bundle-config_test.yaml
+++ b/helm/gko/tests/bundle-config_test.yaml
@@ -28,6 +28,9 @@ tests:
           path: metadata.name
           value: gko-config
       - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+      - equal:
           # It should not contain environment variable by default
           path: data.APPLY_CRDS
           value: "true"


### PR DESCRIPTION
Otherwise, the namespace is not set when rendering the chart with `helm template`

see https://gravitee.atlassian.net/browse/APIM-2450