### PR TITLE
fix: set default policy execution mode to v4-emulation-engine

### DIFF
--- a/api/model/api.go
+++ b/api/model/api.go
@@ -53,7 +53,8 @@ type Api struct {
 	Visibility   ApiVisibility `json:"visibility,omitempty"`
 	Metadata     []*Metadata   `json:"metadata,omitempty"`
 	PrimaryOwner *Member       `json:"primaryOwner,omitempty"`
-
+	// +kubebuilder:default:=v4-emulation-engine
+	ExecutionMode string `json:"execution_mode,omitempty"`
 	// local defines if the api is local or not.
 	//
 	// If true, the Operator will create the ConfigMaps for the Gateway and pushes the API to the Management API

--- a/config/crd/bases/gravitee.io_apidefinitions.yaml
+++ b/config/crd/bases/gravitee.io_apidefinitions.yaml
@@ -80,6 +80,9 @@ spec:
                 type: integer
               description:
                 type: string
+              execution_mode:
+                default: v4-emulation-engine
+                type: string
               flow_mode:
                 default: DEFAULT
                 enum:

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -127,6 +127,15 @@ The API definition is the main resource handled by the Kubernetes Operator Most 
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>execution_mode</b></td>
+        <td>string</td>
+        <td>
+          <br/>
+          <br/>
+            <i>Default</i>: v4-emulation-engine<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>flow_mode</b></td>
         <td>enum</td>
         <td>

--- a/helm/gko/crds/api-definition.yaml
+++ b/helm/gko/crds/api-definition.yaml
@@ -97,6 +97,9 @@ spec:
                   type: integer
                 description:
                   type: string
+                execution_mode:
+                  default: v4-emulation-engine
+                  type: string
                 flow_mode:
                   default: DEFAULT
                   enum:


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/APIM-2498

Not setting execution_mode to `v4-emulation-engine` in our model makes execution policy behaviour inconsistent between an API created from the operator and the same API created from the UI.

Tested on 3.20.x and setting this field with this value falls back to v3 there. So that should not introduce any backward compatibility issue.

Waiting confirmation from ENR before making this ready to review.

