### PR TITLE
fix: rollout on helm upgrades when config changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 bin
 testbin/*
 .env
+__debug_bin*
 
 # Test binary, build with `go test -c`
 *.test

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,6 +27,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
+        checksum/config: '{{ include (print $.Template.BasePath "/bundle-config.yaml") . | sha256sum }}'
       labels:
         control-plane: controller-manager
     spec:

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -384,6 +384,15 @@ The definition context is used to inform a management API instance that this API
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>enabled</b></td>
+        <td>boolean</td>
+        <td>
+          <br/>
+          <br/>
+            <i>Default</i>: true<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
         <td><b>condition</b></td>
         <td>string</td>
         <td>
@@ -393,13 +402,6 @@ The definition context is used to inform a management API instance that this API
       </tr><tr>
         <td><b><a href="#apidefinitionspecflowsindexconsumersindex">consumers</a></b></td>
         <td>[]object</td>
-        <td>
-          <br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>enabled</b></td>
-        <td>boolean</td>
         <td>
           <br/>
         </td>
@@ -874,6 +876,15 @@ The definition context is used to inform a management API instance that this API
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>enabled</b></td>
+        <td>boolean</td>
+        <td>
+          <br/>
+          <br/>
+            <i>Default</i>: true<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
         <td><b>condition</b></td>
         <td>string</td>
         <td>
@@ -883,13 +894,6 @@ The definition context is used to inform a management API instance that this API
       </tr><tr>
         <td><b><a href="#apidefinitionspecplansindexflowsindexconsumersindex">consumers</a></b></td>
         <td>[]object</td>
-        <td>
-          <br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>enabled</b></td>
-        <td>boolean</td>
         <td>
           <br/>
         </td>

--- a/helm/gko/crds/api-definition.yaml
+++ b/helm/gko/crds/api-definition.yaml
@@ -118,6 +118,7 @@ spec:
                           type: object
                         type: array
                       enabled:
+                        default: true
                         type: boolean
                       id:
                         type: string
@@ -185,6 +186,8 @@ spec:
                               type: string
                           type: object
                         type: array
+                    required:
+                      - enabled
                     type: object
                   type: array
                 gravitee:
@@ -287,6 +290,7 @@ spec:
                                 type: object
                               type: array
                             enabled:
+                              default: true
                               type: boolean
                             id:
                               type: string
@@ -354,6 +358,8 @@ spec:
                                     type: string
                                 type: object
                               type: array
+                          required:
+                            - enabled
                           type: object
                         type: array
                       id:

--- a/helm/gko/templates/bundle.yaml
+++ b/helm/gko/templates/bundle.yaml
@@ -332,6 +332,8 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: '{{ include (print $.Template.BasePath "/bundle-config.yaml") .
+          | sha256sum }}'
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager

--- a/helm/gko/tests/bundle-config_test.yaml
+++ b/helm/gko/tests/bundle-config_test.yaml
@@ -31,7 +31,6 @@ tests:
           path: metadata.namespace
           value: NAMESPACE
       - equal:
-          # It should not contain environment variable by default
           path: data.APPLY_CRDS
           value: "true"
 
@@ -44,7 +43,6 @@ tests:
       - hasDocuments:
           count: 1
       - equal:
-          # It should not contain environment variable by default
           path: data.DEV_MODE
           value: "true"
 
@@ -64,7 +62,6 @@ tests:
           path: metadata.name
           value: gko-config
       - equal:
-          # It should not contain environment variable by default
           path: data.NAMESPACE
           value: NAMESPACE
 


### PR DESCRIPTION
This is so that when a user updates its config and run a helm upgrade, the manager rolls out and load the config changes

see https://gravitee.atlassian.net/browse/APIM-2713