### PR TITLE
ci: disable api notifiers

### DIFF
--- a/scripts/util/helm.mjs
+++ b/scripts/util/helm.mjs
@@ -84,6 +84,7 @@ helm install \
     --set "api.startupProbe.timeoutSeconds=10" \
     --set "api.image.tag=${env.APIM_IMAGE_TAG}" \
     --set "api.image.repository=${K3D_IMAGES_REGISTRY}/apim-management-api" \
+    --set "api.notifiers.smtp.enabled=false" \
     --set "ui.ingress.hosts[0]=localhost" \
     --set "ui.ingress.tls=false" \
     --set "ui.autoscaling.enabled=false" \


### PR DESCRIPTION
Looks like a bug occurred on master regarding email notifications. While we are looking at this on the APIM side, this revision disables the notifier so that our IT tests continue passing.