### PR TITLE
ci: fix helm chart deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -380,6 +380,7 @@ jobs:
               --set manager.scope.cluster=false \
               --set manager.image.repository=<< parameters.image >> \
               --set manager.image.tag=<< parameters.tag >> \
+              --set serviceAccount.name=gko-<< parameters.namespace >> \
               -n << parameters.namespace >>
       - run:
           name: Rollout controller deployment


### PR DESCRIPTION
As we don't use the release namespace and release name to name the cluster roles any more, the CI now deploys using a different service account name for each NS 
