### PR TITLE
test: add status expectation to fix flaky test

### DIFF
--- a/test/application_controller_create_test.go
+++ b/test/application_controller_create_test.go
@@ -102,8 +102,8 @@ var _ = Describe("Creating an Application", func() {
 				return internal.AssertApplicationStatusIsSet(createdApplication)
 			}, timeout, interval).ShouldNot(HaveOccurred())
 
-			expectedApiName := applicationFixture.Name
-			Expect(createdApplication.Name).Should(Equal(expectedApiName))
+			expectedApplicationName := applicationFixture.Name
+			Expect(createdApplication.Name).Should(Equal(expectedApplicationName))
 
 			Expect(createdApplication.Spec.Name).Should(Equal(applicationFixture.Spec.Name))
 			Expect(len(*createdApplication.Spec.ApplicationMetaData)).Should(Equal(2))

--- a/test/application_controller_update_test.go
+++ b/test/application_controller_update_test.go
@@ -65,7 +65,10 @@ var _ = Describe("Update an Application", func() {
 			By("Getting created application and expect to find it")
 			createdApplication := &gio.Application{}
 			Eventually(func() error {
-				return k8sClient.Get(ctx, appLookupKey, createdApplication)
+				if err = k8sClient.Get(ctx, appLookupKey, createdApplication); err != nil {
+					return err
+				}
+				return internal.AssertApplicationStatusIsSet(createdApplication)
 			}, timeout, interval).ShouldNot(HaveOccurred())
 
 			expectedApplicationName := applicationFixture.Name

--- a/test/ingress_controller_delete_test.go
+++ b/test/ingress_controller_delete_test.go
@@ -150,14 +150,12 @@ var _ = Describe("Deleting an ingress", func() {
 			It("Should NOT delete the API Template", func() {
 				By("Deleting the API definition template")
 				Expect(k8sClient.Delete(ctx, apiDefinitionTemplate)).ToNot(HaveOccurred())
-				Eventually(func() error {
+				Consistently(func() error {
 					By("Expect the API Template to be still available")
 
 					savedAPITemplate := new(gio.ApiDefinition)
 					return k8sClient.Get(ctx, apiTemplateLookupKey, savedAPITemplate)
-				}).Should(Succeed())
-
-				Expect(k8sClient.Delete(ctx, createdIngress)).ToNot(HaveOccurred())
+				}, timeout).Should(Succeed())
 			})
 		})
 


### PR DESCRIPTION
I think we could also get rid of the create test, as the create is done in the update (the code is exactly the same until update kicks in)