### PR TITLE
docs(helm): use bitnami readme generator

### DIFF
--- a/helm/gko/README.md
+++ b/helm/gko/README.md
@@ -2,40 +2,88 @@
 
 The Gravitee Kubernetes Operator Helm Chart
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)
-
 ## Installing the Chart
 
-To install the chart with the release name `graviteeio-gko`:
+To install the chart with the release name `gko`
 
 ```console
 $ helm repo add graviteeio https://helm.gravitee.io
-$ helm install graviteeio-gko graviteeio/gko
+$ helm install gko graviteeio/gko
+```
+
+## Upgrading the Operator
+
+Assuming that the repository as been aliased as graviteeio and that the release name is `gko`
+
+```console
+$ helm repo update graviteeio
+$ helm upgrade --install gko graviteeio/gko
 ```
 
 ## Requirements
 
-Kubernetes: `>=1.14.0-0`
+Kubernetes: `>=1.16.0-0`
 
-## Values
+## Parameters
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| httpClient.insecureSkipCertVerify | bool | `false` | If true, the manager HTTP client will not verify the certificate used by the Management API. |
-| ingress.templates.404.name | string | `""` | name of the config map storing the HTTP 404 ingress response template. A default template is used if this entry is empty. The config map should contain a content key and a contentType key. The default template is used if one of the key is missing. |
-| ingress.templates.404.namespace | string | `""` | namespace of the config map storing the HTTP 404 ingress response template. A default template is used if this entry is empty. The config map should contain a content key and a contentType key. The default template is used if one of the key is missing.        |
-| manager.applyCRDs | bool | `true` | If true, the manager will apply Custom Resource Definitions on startup. Please be aware that this will apply to Custom Resource Definitions  (which are the Open API model for Custom Resources such as API Definitions),  not to Custom Resources themselves. Custom Resources will be reconciled if the manager restarts whatever the value of this flag is. Because helm upgrades do not update CRDs once they have been installed, it is recommended to set this flag to true. |
-| manager.configMap.name | string | `"gko-config"` | The name of the config map used to set the manager config from this values. |
-| manager.image.repository | string | `"graviteeio/kubernetes-operator"` | Specifies the docker registry and image name to use. |
-| manager.image.tag | string | `"latest"` | Specifies the docker image tag to use. |
-| manager.logs.json | bool | `true` | Whether to output manager logs in JSON format. |
-| manager.metrics.enabled | bool | `true` | If true, a metrics server will be created so that metrics can be scraped using prometheus. |
-| manager.scope.cluster | bool | `true` | If true, the manager listens to resources created in the whole cluster. Use false to listen only in the release namespace. |
-| rbac.create | bool | `true` | Specifies if RBAC resources should be created. |
-| rbac.skipClusterRoles | bool | `false` | Specifies if cluster roles should be created when RBAC resources are created. |
-| rbacProxy.enabled | bool | `true` | Specifies if the kube-rbac-proxy sidecar should be enabled.  Note that if this is disabled, the prometheus metrics endpoint will be exposed with no access control at all. |
-| rbacProxy.image.repository | string | `"quay.io/brancz/kube-rbac-proxy"` | Specifies the docker registry and image name to use. |
-| rbacProxy.image.tag | string | `"v0.14.3"` | Specifies the docker image tag to use. |
-| serviceAccount.create | bool | `true` | Specifies if a service account should be created for the manager pod. |
-| serviceAccount.name | string | `"gko-controller-manager"` | Specifies the service account name to use. |
+### RBAC
 
+Required RBAC resources are created by default for all components involved in the release.
+
+| Name                    | Description                                                                   | Value                    |
+| ----------------------- | ----------------------------------------------------------------------------- | ------------------------ |
+| `serviceAccount.create` | Specifies if a service account should be created for the manager pod.         | `true`                   |
+| `serviceAccount.name`   | Specifies the service account name to use.                                    | `gko-controller-manager` |
+| `rbac.create`           | Specifies if RBAC resources should be created.                                | `true`                   |
+| `rbac.skipClusterRoles` | Specifies if cluster roles should be created when RBAC resources are created. | `false`                  |
+
+### RBAC Proxy
+
+Kube RBAC Proxy is deployed as a sidecar container and restricts access to the prometheus metrics endpoint.
+
+⚠️ If this is disabled, the prometheus metrics endpoint will be exposed with no access control at all.
+
+| Name                         | Description                                                  | Value                            |
+| ---------------------------- | ------------------------------------------------------------ | -------------------------------- |
+| `rbacProxy.enabled`          | Specifies if the kube-rbac-proxy sidecar should be enabled.  | `true`                           |
+| `rbacProxy.image.repository` | Specifies the docker registry and image name to use.         | `quay.io/brancz/kube-rbac-proxy` |
+| `rbacProxy.image.tag`        | Specifies the docker image tag to use.                       | `v0.14.3`                        |
+
+### Controller Manager
+
+This is where you can configure the deployment itself and the way the operator will interact with APIM and Custom Resources in your cluster.
+
+| Name                                        | Description                                                                                  | Value                            |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------- | -------------------------------- |
+| `manager.image.repository`                  | Specifies the docker registry and image name to use.                                         | `graviteeio/kubernetes-operator` |
+| `manager.image.tag`                         | Specifies the docker image tag to use.                                                       | `latest`                         |
+| `manager.logs.json`                         | Whether to output manager logs in JSON format.                                               | `true`                           |
+| `manager.configMap.name`                    | The name of the config map used to set the manager config from this values.                  | `gko-config`                     |
+| `manager.scope.cluster`                     | Use false to listen only in the release namespace.                                           | `true`                           |
+| `manager.applyCRDs`                         | If true, the manager will patch Custom Resource Definitions on startup.                      | `true`                           |
+| `manager.metrics.enabled`                   | If true, a metrics server will be created so that metrics can be scraped using prometheus.   | `true`                           |
+| `manager.httpClient.insecureSkipCertVerify` | If true, the manager HTTP client will not verify the certificate used by the Management API. | `false`                          |
+
+### ingress
+
+Configure the behavior of the ingress controller.
+
+When storing templates stored in config maps, the config map should contain a content key and a contentType key e.g.
+```yaml
+content: '{ "message": "Not Found" }'
+contentType: application/json
+```
+
+| Name                              | Description                                                                      | Value |
+| --------------------------------- | -------------------------------------------------------------------------------- | ----- |
+| `ingress.templates.404.name`      | Name of the config map storing the HTTP 404 ingress response template.           | `""`  |
+| `ingress.templates.404.namespace` | Namespace of the config map storing the HTTP 404 ingress response template.      | `""`  |
+
+### HTTP Client
+
+👎 This section is deprecated and will be removed in version 1.0.0 The httpClient property
+should now be set under the manager section instead.
+
+| Name                                | Description                                   | Value   |
+| ----------------------------------- | --------------------------------------------- | ------- |
+| `httpClient.insecureSkipCertVerify` | see manager.httpClient.insecureSkipCertVerify | `false` |

--- a/helm/gko/templates/manager/config.yaml
+++ b/helm/gko/templates/manager/config.yaml
@@ -45,6 +45,6 @@ data:
   {{- if $template404.namespace }}
   TEMPLATE_404_CONFIG_MAP_NAMESPACE: {{ $template404.namespace }}
   {{- end }}
-  {{- if .Values.httpClient.insecureSkipCertVerify }}
+  {{- if or .Values.manager.httpClient.insecureSkipCertVerify .Values.httpClient.insecureSkipCertVerify }}
   INSECURE_SKIP_CERT_VERIFY: "true"
   {{- end }}

--- a/helm/gko/values.yaml
+++ b/helm/gko/values.yaml
@@ -12,70 +12,93 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+## @section RBAC
+## @descriptionStart
+## Required RBAC resources are created by default for all components involved in the release.
+## @descriptionEnd
 serviceAccount:
-  # -- Specifies if a service account should be created for the manager pod.
+  ## @param serviceAccount.create Specifies if a service account should be created for the manager pod.
   create: true
-  # -- Specifies the service account name to use.
+  ## @param serviceAccount.name Specifies the service account name to use.
   name: gko-controller-manager
 rbac:
-  # -- Specifies if RBAC resources should be created.
+  ## @param rbac.create Specifies if RBAC resources should be created.
   create: true
-  # -- Specifies if cluster roles should be created when RBAC resources are created.
+  ## @param rbac.skipClusterRoles Specifies if cluster roles should be created when RBAC resources are created.
   skipClusterRoles: false
 
+## @section RBAC Proxy
+## @descriptionStart 
+## Kube RBAC Proxy is deployed as a sidecar container and restricts access to the prometheus metrics endpoint.
+## 
+## ⚠️ If this is disabled, the prometheus metrics endpoint will be exposed with no access control at all.
+## @descriptionEnd
 rbacProxy:
-  # -- Specifies if the kube-rbac-proxy sidecar should be enabled. 
-  # Note that if this is disabled, the prometheus metrics endpoint
-  # will be exposed with no access control at all.
+  ## @param rbacProxy.enabled Specifies if the kube-rbac-proxy sidecar should be enabled. 
   enabled: true
   image:
-    # -- Specifies the docker registry and image name to use.
+    ## @param rbacProxy.image.repository Specifies the docker registry and image name to use.
     repository: quay.io/brancz/kube-rbac-proxy
-    # -- Specifies the docker image tag to use.
+    ## @param rbacProxy.image.tag Specifies the docker image tag to use.
     tag: v0.14.3
 
+## @section Controller Manager
+## @descriptionStart
+## This is where you can configure the deployment itself and the way the operator will interact with APIM and Custom Resources in your cluster.
+## @descriptionEnd
 manager:
   image:
-    # -- Specifies the docker registry and image name to use.
+    ## @param manager.image.repository Specifies the docker registry and image name to use.
     repository: graviteeio/kubernetes-operator
-    # -- Specifies the docker image tag to use.
+    ## @param manager.image.tag Specifies the docker image tag to use.
     tag: latest
   logs:
-    # -- Whether to output manager logs in JSON format.
+    ## @param manager.logs.json Whether to output manager logs in JSON format.
     json: true
   configMap:
-    # -- The name of the config map used to set the manager config from this values.
+    ## @param manager.configMap.name The name of the config map used to set the manager config from this values.
     name: gko-config
   scope:
-    # -- If true, the manager listens to resources created in the whole cluster.
-    # Use false to listen only in the release namespace.
+    ## @param manager.scope.cluster Use false to listen only in the release namespace.
     cluster: true
-  # -- If true, the manager will apply Custom Resource Definitions on startup.
-  # Please be aware that this will apply to Custom Resource Definitions 
-  # (which are the Open API model for Custom Resources such as API Definitions), 
-  # not to Custom Resources themselves.
-  # Custom Resources will be reconciled if the manager restarts whatever the value
-  # of this flag is. Because helm upgrades do not update CRDs once they have been
-  # installed, it is recommended to set this flag to true.
+  ## @param manager.applyCRDs If true, the manager will patch Custom Resource Definitions on startup.
+  ## Please be aware that this will apply to Custom Resource Definitions 
+  ## (which are the Open API model for Custom Resources such as API Definitions), 
+  ## not to Custom Resources themselves.
+  ## Custom Resources will be reconciled if the manager restarts whatever the value
+  ## of this flag is. Because helm upgrades do not update CRDs once they have been
+  ## installed, it is recommended to set this flag to true.
   applyCRDs: true
   metrics:
-  # -- If true, a metrics server will be created so that metrics can be scraped using prometheus.
-
+   ## @param manager.metrics.enabled If true, a metrics server will be created so that metrics can be scraped using prometheus.
     enabled: true
+  httpClient:
+    ## @param manager.httpClient.insecureSkipCertVerify If true, the manager HTTP client will not verify the certificate used by the Management API.
+    insecureSkipCertVerify: false
 
+## @section ingress
+## @descriptionStart
+## Configure the behavior of the ingress controller.
+## 
+## When storing templates stored in config maps, the config map should contain a content key and a contentType key e.g.
+## ```yaml
+##   content: '{ "message": "Not Found" }'
+##   contentType: application/json
+## ```
+## @descriptionEnd
 ingress:
   templates:
     404:
-      # -- name of the config map storing the HTTP 404 ingress response template.
-      # A default template is used if this entry is empty.
-      # The config map should contain a content key and a contentType key.
-      # The default template is used if one of the key is missing.
+      ## @param ingress.templates.404.name Name of the config map storing the HTTP 404 ingress response template.
       name: ""
-      # -- namespace of the config map storing the HTTP 404 ingress response template.
-      # A default template is used if this entry is empty.
-      # The config map should contain a content key and a contentType key.
-      # The default template is used if one of the key is missing.       
+      ## @param ingress.templates.404.namespace Namespace of the config map storing the HTTP 404 ingress response template.     
       namespace: ""
+
+## @section HTTP Client
+## @descriptionStart
+## 👎 This section is deprecated and will be removed in version 1.0.0 The httpClient property
+## should now be set under the manager section instead.
+## @descriptionEnd
 httpClient:
-  # -- If true, the manager HTTP client will not verify the certificate used by the Management API.
+   ## @param httpClient.insecureSkipCertVerify see manager.httpClient.insecureSkipCertVerify
   insecureSkipCertVerify: false

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -32,7 +32,7 @@ k3d-push: ## Push the controller image to the k3d registry
 .PHONY: k3d-deploy
 k3d-deploy: ## Install operator helm chart to the k3d cluster
 	helm upgrade --install -n default --create-namespace gko helm/gko \
-	    --set httpClient.insecureSkipCertVerify=true \
+	    --set manager.httpClient.insecureSkipCertVerify=true \
 		--set manager.scope.cluster=false \
 		--set manager.image.repository=$(K3D_IMG) \
 		--set manager.image.tag=$(K3D_TAG)

--- a/make/doc.mk
+++ b/make/doc.mk
@@ -1,10 +1,9 @@
 ##@ 📄 Documentation
 
 .PHONY: reference
-reference: crdoc ## Generate the CRDs reference documentation
+reference: crdoc ## Generate the CRDs reference documentation 
 	$(CRDOC) --resources config/crd/bases --output docs/api/reference.md
 
-
-.PHONY: helm-reference
-helm-reference: helm-docs ## Generates helm chart documentation
-	@$(HELMDOCS) --chart-search-root=helm --dry-run > helm/gko/README.md
+.PHONY:
+helm-reference: ## Generates helm chart documentation
+	npx @bitnami/readme-generator-for-helm -v helm/gko/values.yaml -r helm/gko/README.md

--- a/make/tool.mk
+++ b/make/tool.mk
@@ -13,9 +13,8 @@ GINKGO ?= $(LOCALBIN)/ginkgo
 CRDOC ?= $(LOCALBIN)/crdoc
 GOLANGCILINT ?= $(LOCALBIN)/golangci-lint
 ADDLICENSE ?= $(LOCALBIN)/addlicense
-HELMDOCS ?= $(LOCALBIN)/helm-docs
 
-ALL_TOOLS = kustomize controller-gen envtest ginkgo crdoc golangci-lint addlicense helm-docs helm-unittest
+ALL_TOOLS = kustomize controller-gen envtest ginkgo crdoc golangci-lint addlicense helm-unittest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v4.5.7
@@ -64,12 +63,6 @@ addlicense: $(ADDLICENSE) ## Download addlicense cli locally if necessary.
 $(ADDLICENSE): $(LOCALBIN)
 	@echo "Installing addlicense ..."
 	@GOBIN=$(LOCALBIN) go install github.com/google/addlicense@latest
-
-.PHONY: helm-docs
-helm-docs: $(HELMDOCS) ## Download helmdocs cli locally if necessary.
-$(HELMDOCS): $(LOCALBIN)
-	@echo "Installing helm-docs ..."
-	@GOBIN=$(LOCALBIN) go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
 
 .PHONY: helm-unittest
 helm-unittest: ## Install helm-unittest plugin if necessary.


### PR DESCRIPTION
Bitnami readme generator allow to organise Helm documentation into sections, which makes the document somehow more readable.

⚠️ To keep sections consistants, the `httpClient` value has been moved to the manager section.

Which means this should be released in 1.0.0 only and documented as a breaking change.