### PR TITLE
chore(helm): restore checksum annotation on manager

### DIFF
--- a/helm/gko/templates/manager/deployment.yaml
+++ b/helm/gko/templates/manager/deployment.yaml
@@ -30,6 +30,7 @@ metadata:
     app.kubernetes.io/name: {{ template "helm.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    checksum/config: '{{ include (print $.Template.BasePath "/manager/config.yaml") . | sha256sum }}'
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
the annotation was forgotten in the process of moving to full helm instead of the kustomize / helm mix.