### PR TITLE
refactor: move deployed at to v2

### DIFF
--- a/api/model/api/base/api.go
+++ b/api/model/api/base/api.go
@@ -20,7 +20,6 @@ type ApiBase struct {
 	CrossID     string `json:"crossId,omitempty"`
 	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`
-	DeployedAt  uint64 `json:"deployedAt,omitempty"`
 	// +kubebuilder:validation:Required
 	// The definition context is used to inform a management API instance that this API definition
 	// is managed using a kubernetes operator

--- a/api/model/api/v2/api.go
+++ b/api/model/api/v2/api.go
@@ -21,6 +21,7 @@ import (
 
 type Api struct {
 	*base.ApiBase `json:",inline"`
+	DeployedAt    uint64 `json:"deployedAt,omitempty"`
 	// +kubebuilder:default:=`2.0.0`
 	DefinitionVersion base.DefinitionVersion `json:"gravitee,omitempty"`
 	// +kubebuilder:validation:Required


### PR DESCRIPTION
There is no point into having this field in the spec as we have no control over it. Will be kept in v1alpha1 as it has been here from day 1, but will be removed from v1beta1.

Note: For v1beta1 its would be a useful info to put in our status.