### PR TITLE
fix: ensure ns is set on context secret requests

### DIFF
--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -78,10 +78,14 @@ func ContextSecrets() *handler.Funcs {
 		}
 
 		if ctx.Spec.HasSecretRef() {
+			ns := ctx.Spec.Auth.SecretRef.Namespace
+			if ns == "" {
+				ns = ctx.Namespace
+			}
 			q.Add(reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      ctx.Spec.Auth.SecretRef.Name,
-					Namespace: ctx.Spec.Auth.SecretRef.Namespace,
+					Namespace: ns,
 				},
 			})
 		}


### PR DESCRIPTION
Because the management context secret namespace is not mandatory, we need to set it when queuing a reconcile, otherwise the latest version of controller runtime will throw an error if listening to a single namespace.