### PR TITLE
refactor: move the `local` flag from base to v1alpha1

### DIFF
--- a/api/model/api/base/api.go
+++ b/api/model/api/base/api.go
@@ -38,18 +38,6 @@ type ApiBase struct {
 	Metadata          []*MetadataEntry                        `json:"metadata,omitempty"`
 	ResponseTemplates map[string]map[string]*ResponseTemplate `json:"response_templates,omitempty"`
 	Resources         []*ResourceOrRef                        `json:"resources,omitempty"`
-	// local defines if the api is local or not.
-	//
-	// If true, the Operator will create the ConfigMaps for the Gateway and pushes the API to the Management API
-	// but without setting the update flag in the datastore.
-	//
-	// If false, the Operator will not create the ConfigMaps for the Gateway.
-	// Instead, it pushes the API to the Management API and forces it to update the event in the datastore.
-	// This will cause Gateways to fetch the APIs from the datastore
-	//
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default:=true
-	IsLocal bool `json:"local"`
 }
 
 // +kubebuilder:validation:Enum=PUBLIC;PRIVATE;

--- a/api/v1alpha1/apidefinition_types.go
+++ b/api/v1alpha1/apidefinition_types.go
@@ -35,6 +35,18 @@ import (
 type ApiDefinitionSpec struct {
 	v2.Api  `json:",inline"`
 	Context *refs.NamespacedName `json:"contextRef,omitempty"`
+	// local defines if the api is local or not.
+	//
+	// If true, the Operator will create the ConfigMaps for the Gateway and pushes the API to the Management API
+	// but without setting the update flag in the datastore.
+	//
+	// If false, the Operator will not create the ConfigMaps for the Gateway.
+	// Instead, it pushes the API to the Management API and forces it to update the event in the datastore.
+	// This will cause Gateways to fetch the APIs from the datastore
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default:=true
+	IsLocal bool `json:"local"`
 }
 
 // ApiDefinitionStatus defines the observed state of API Definition.

--- a/controllers/apim/ingress/internal/api_definition_template.go
+++ b/controllers/apim/ingress/internal/api_definition_template.go
@@ -101,10 +101,10 @@ func defaultApiDefinitionTemplate() *v1alpha1.ApiDefinition {
 				},
 				ApiBase: &base.ApiBase{
 					Description: "A default keyless API",
-					IsLocal:     true,
 				},
 				Version: "1.0.0",
 			},
+			IsLocal: true,
 		},
 	}
 }

--- a/test/apidefinition_controller_create_test.go
+++ b/test/apidefinition_controller_create_test.go
@@ -309,7 +309,6 @@ var _ = Describe("Create", func() {
 					Description: "This is to mimic what happens when applying an existing API",
 					ID:          "258198cb-bd66-4010-b3d4-9f7bee97763b",
 					CrossID:     "1cac491c-acd2-4530-bf97-0627ccf94060",
-					IsLocal:     true,
 				},
 				Version: "1",
 				Plans: []*v2.Plan{


### PR DESCRIPTION
This flag may be replaced in v1beta1 and might not be available first because the v2 REST API is not ready for this yet

see https://gravitee.atlassian.net/browse/APIM-2427