### PR TITLE
fix: allow support for http2 requests on ingresses

### DIFF
--- a/controllers/apim/ingress/internal/mapper/mapper.go
+++ b/controllers/apim/ingress/internal/mapper/mapper.go
@@ -50,8 +50,8 @@ const (
 	rootPath               = "/"
 )
 
-var hostCondition = el.Expression("#request.headers['Host'][0] == '%s'")
-var noHostCondition = el.Expression("#request.headers['Host'][0] != '%s'")
+var hostCondition = el.Expression("#request.host == '%s'")
+var noHostCondition = el.Expression("#request.host != '%s'")
 var pathCondition = el.Expression("#request.contextPath.startsWith('%s')")
 
 type Mapper struct {


### PR DESCRIPTION
⚠️ Requires apim 3.20.27 - 4.0.16 - 4.1.7 - 4.2.1 as an ingress runtime.