### PR TITLE
fix: do not print context name column twice

### DIFF
--- a/api/v1alpha1/managementcontext_types.go
+++ b/api/v1alpha1/managementcontext_types.go
@@ -35,7 +35,6 @@ type ManagementContextStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
-// +kubebuilder:printcolumn:name="Name",type=string,JSONPath=`.metadata.name`
 // +kubebuilder:printcolumn:name="BaseUrl",type=string,JSONPath=`.spec.baseUrl`
 // +kubebuilder:resource:shortName=graviteecontexts
 type ManagementContext struct {

--- a/helm/gko/crds/gravitee.io_managementcontexts.yaml
+++ b/helm/gko/crds/gravitee.io_managementcontexts.yaml
@@ -31,9 +31,6 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .metadata.name
-      name: Name
-      type: string
     - jsonPath: .spec.baseUrl
       name: BaseUrl
       type: string


### PR DESCRIPTION
We do not need to add `name` as a custom column as it is added by default.