### PR TITLE
refactor: rename plan crd name to displayName

### DIFF
--- a/api/model/api/base/plan.go
+++ b/api/model/api/base/plan.go
@@ -36,8 +36,6 @@ type Plan struct {
 	// This field is used to identify plans defined for an API
 	// that has been promoted between different environments.
 	CrossId string `json:"crossId,omitempty"`
-	// Plan name
-	Name string `json:"name"`
 	// Plan Description
 	Description string `json:"description"`
 	// List of plan tags
@@ -61,9 +59,8 @@ type Plan struct {
 	ExcludedGroups []string `json:"excluded_groups,omitempty"`
 }
 
-func NewPlan(name, description string) *Plan {
+func NewPlan(description string) *Plan {
 	return &Plan{
-		Name:            name,
 		Description:     description,
 		Tags:            []string{},
 		Characteristics: []string{},

--- a/api/model/api/v2/plan.go
+++ b/api/model/api/v2/plan.go
@@ -33,6 +33,8 @@ type Consumer struct {
 
 type Plan struct {
 	*base.Plan `json:",inline"`
+	// Plan name
+	Name string `json:"name"`
 	// Plan Security
 	Security string `json:"security"`
 	// Plan Security definition
@@ -53,6 +55,11 @@ func NewPlan(base *base.Plan) *Plan {
 		Flows: []Flow{},
 		Paths: make(map[string][]Rule),
 	}
+}
+
+func (plan *Plan) WithName(name string) *Plan {
+	plan.Name = name
+	return plan
 }
 
 func (plan *Plan) WithSecurity(security string) *Plan {

--- a/api/model/api/v4/api.go
+++ b/api/model/api/v4/api.go
@@ -37,10 +37,10 @@ type Api struct {
 	// and define whether the API definition should be synchronized
 	// from an API instance or from a config map created in the cluster (which is the default)
 	DefinitionContext *DefinitionContext `json:"definitionContext,omitempty"`
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:default:=`CREATED`
 	// API life cycle state can be one of the values CREATED, PUBLISHED, UNPUBLISHED, DEPRECATED, ARCHIVED
-	LifecycleState base.LifecycleState `json:"lifecycleState"`
+	LifecycleState base.LifecycleState `json:"lifecycleState,omitempty"`
 	// +kubebuilder:validation:Required
 	// Api Type (proxy or message)
 	Type ApiType `json:"type"`
@@ -53,7 +53,9 @@ type Api struct {
 	// List of Endpoint groups
 	EndpointGroups []*EndpointGroup `json:"endpointGroups"`
 	// +kubebuilder:validation:Optional
-	// List of API plans
+	// A map of plan identifiers to plan
+	// Keys uniquely identify plans and are used to keep them in sync
+	// when using a management context.
 	Plans map[string]*Plan `json:"plans"`
 	// API Flow Execution
 	FlowExecution *FlowExecution `json:"flowExecution,omitempty"`

--- a/api/model/api/v4/plan.go
+++ b/api/model/api/v4/plan.go
@@ -31,6 +31,10 @@ const (
 type Plan struct {
 	*base.Plan `json:",inline"`
 
+	// Plan display name, this will be the name displayed in the UI
+	// if a management context is used to sync the API with APIM
+	DisplayName string `json:"displayName"`
+
 	// Plan definition version
 	DefinitionVersion definitionVersion `json:"definitionVersion,omitempty"`
 
@@ -38,10 +42,10 @@ type Plan struct {
 	Security PlanSecurity `json:"security,omitempty"`
 
 	// The plan mode
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:default:=`STANDARD`
 	// +kubebuilder:validation:Enum=STANDARD;PUSH;
-	Mode PlanMode `json:"mode"`
+	Mode PlanMode `json:"mode,omitempty"`
 
 	// Plan selection rule
 	SelectionRule string `json:"selectionRule,omitempty"`

--- a/api/v1alpha1/apidefinitionv4_types.go
+++ b/api/v1alpha1/apidefinitionv4_types.go
@@ -141,9 +141,9 @@ func (api *ApiDefinitionV4) PickPlanIDs() map[string]*v4.Plan {
 
 // GetOrGenerateEmptyPlanCrossID For each plan, generate a CrossId from Api Id & Plan Name if not defined.
 func (api *ApiDefinitionV4) GetOrGenerateEmptyPlanCrossID() {
-	for _, plan := range api.Spec.Plans {
+	for name, plan := range api.Spec.Plans {
 		if plan.CrossId == "" {
-			plan.CrossId = uuid.FromStrings(api.Spec.ID, "/", plan.Name)
+			plan.CrossId = uuid.FromStrings(api.PickCrossID(), "/", name)
 		}
 	}
 }

--- a/controllers/apim/ingress/internal/api_definition_template.go
+++ b/controllers/apim/ingress/internal/api_definition_template.go
@@ -95,12 +95,12 @@ func defaultApiDefinitionTemplate() *v1alpha1.ApiDefinition {
 			Api: v2.Api{
 				Plans: []*v2.Plan{
 					v2.NewPlan(
-						base.NewPlan("Default keyless plan", "").
+						base.NewPlan("Default ingress keyless plan").
 							WithStatus(base.PublishedPlanStatus),
-					).WithSecurity("KEY_LESS"),
+					).WithSecurity("KEY_LESS").WithName("Key Less"),
 				},
 				ApiBase: &base.ApiBase{
-					Description: "A default keyless API",
+					Description: "This API was generated on behalf of an Kubernetes ingress resource",
 					Version:     "1.0.0",
 				},
 			},

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -3931,16 +3931,6 @@ ApiDefinitionV4Spec ApiDefinitionSpec defines the desired state of ApiDefinition
         </td>
         <td>true</td>
       </tr><tr>
-        <td><b>lifecycleState</b></td>
-        <td>enum</td>
-        <td>
-          API life cycle state can be one of the values CREATED, PUBLISHED, UNPUBLISHED, DEPRECATED, ARCHIVED<br/>
-          <br/>
-            <i>Enum</i>: CREATED, PUBLISHED, UNPUBLISHED, DEPRECATED, ARCHIVED<br/>
-            <i>Default</i>: CREATED<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>listeners</b></td>
         <td>[]object</td>
         <td>
@@ -4054,6 +4044,16 @@ field of the resource.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>lifecycleState</b></td>
+        <td>enum</td>
+        <td>
+          API life cycle state can be one of the values CREATED, PUBLISHED, UNPUBLISHED, DEPRECATED, ARCHIVED<br/>
+          <br/>
+            <i>Enum</i>: CREATED, PUBLISHED, UNPUBLISHED, DEPRECATED, ARCHIVED<br/>
+            <i>Default</i>: CREATED<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#apidefinitionv4specmetadataindex">metadata</a></b></td>
         <td>[]object</td>
         <td>
@@ -4071,7 +4071,9 @@ field of the resource.<br/>
         <td><b><a href="#apidefinitionv4specplanskey">plans</a></b></td>
         <td>map[string]object</td>
         <td>
-          List of API plans<br/>
+          A map of plan identifiers to plan
+Keys uniquely identify plans and are used to keep them in sync
+when using a management context.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -5628,19 +5630,11 @@ API Flow Execution
         </td>
         <td>true</td>
       </tr><tr>
-        <td><b>mode</b></td>
+        <td><b>displayName</b></td>
         <td>string</td>
         <td>
-          The plan mode<br/>
-          <br/>
-            <i>Default</i>: STANDARD<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>name</b></td>
-        <td>string</td>
-        <td>
-          Plan name<br/>
+          Plan display name, this will be the name displayed in the UI
+if a management context is used to sync the API with APIM<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -5694,6 +5688,15 @@ that has been promoted between different environments.<br/>
         <td>string</td>
         <td>
           Plan ID<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>mode</b></td>
+        <td>string</td>
+        <td>
+          The plan mode<br/>
+          <br/>
+            <i>Default</i>: STANDARD<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/examples/apim/api_definition/api-v4-with-context.yml
+++ b/examples/apim/api_definition/api-v4-with-context.yml
@@ -16,10 +16,10 @@
 apiVersion: gravitee.io/v1alpha1
 kind: ApiDefinitionV4
 metadata:
-  name: v4-api-with-context
+  name: api-v4-with-context
 spec:
-  name: "K8s Basic Example V4"
-  description: "Basic api V4 managed by Gravitee Kubernetes Operator"
+  name: "api-v4-with-context"
+  description: "V4 API managed by Gravitee Kubernetes Operator"
   version: "1.0"
   contextRef:
     name: "dev-ctx"
@@ -76,8 +76,8 @@ spec:
     mode: DEFAULT
     matchRequired: false
   plans:
-    "KEY_LESS":
-      name: "KEY_LESS"
-      description: "Updated KEY LESS Plan"
+    KeyLess:
+      displayName: "Free plan (updated)"
+      description: "This plan does not require any authentication"
       security:
         type: "KEY_LESS"

--- a/examples/apim/api_definition/api-v4.yml
+++ b/examples/apim/api_definition/api-v4.yml
@@ -16,10 +16,10 @@
 apiVersion: gravitee.io/v1alpha1
 kind: ApiDefinitionV4
 metadata:
-  name: v4-basic-v4api-example
+  name: api-v4
 spec:
-  name: "K8s V4 Basic Example"
-  description: "Basic V4 api managed by Gravitee Kubernetes Operator"
+  name: "api-v4"
+  description: "API v4 managed by Gravitee Kubernetes Operator"
   version: "1.0"
   type: PROXY
   listeners:
@@ -72,8 +72,8 @@ spec:
     mode: DEFAULT
     matchRequired: false
   plans:
-    "KEY_LESS":
-      name: "KEY_LESS"
-      description: "FREE"
+    KeyLess:
+      displayName: "Free plan"
+      description: "This plan does not require any authentication"
       security:
         type: "KEY_LESS"

--- a/helm/gko/crds/gravitee.io_apidefinitionv4s.yaml
+++ b/helm/gko/crds/gravitee.io_apidefinitionv4s.yaml
@@ -745,6 +745,11 @@ spec:
                     description:
                       description: Plan Description
                       type: string
+                    displayName:
+                      description: |-
+                        Plan display name, this will be the name displayed in the UI
+                        if a management context is used to sync the API with APIM
+                      type: string
                     excluded_groups:
                       description: List of excluded groups for this plan
                       items:
@@ -927,9 +932,6 @@ spec:
                       default: STANDARD
                       description: The plan mode
                       type: string
-                    name:
-                      description: Plan name
-                      type: string
                     order:
                       description: Plan order
                       type: integer
@@ -980,10 +982,12 @@ spec:
                       type: string
                   required:
                   - description
-                  - mode
-                  - name
+                  - displayName
                   type: object
-                description: List of API plans
+                description: |-
+                  A map of plan identifiers to plan
+                  Keys uniquely identify plans and are used to keep them in sync
+                  when using a management context.
                 type: object
               primaryOwner:
                 description: Specify the primary member that owns the API
@@ -1119,7 +1123,6 @@ spec:
                 type: string
             required:
             - endpointGroups
-            - lifecycleState
             - listeners
             - type
             - version

--- a/kind/kind.yaml
+++ b/kind/kind.yaml
@@ -15,6 +15,8 @@
 apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 name: gravitee
+networking:
+  apiServerPort: 6443
 nodes:
   - role: control-plane
     extraPortMappings:

--- a/test/integration/apidefinition/update_withoutContext_asTemplate_test.go
+++ b/test/integration/apidefinition/update_withoutContext_asTemplate_test.go
@@ -78,9 +78,9 @@ var _ = Describe("Delete", labels.WithoutContext, func() {
 		updated := fixtures.API.DeepCopy()
 		updated.Spec.Plans = append(updated.Spec.Plans,
 			v2.NewPlan(
-				base.NewPlan("Default keyless plan", "").
+				base.NewPlan("Default keyless plan").
 					WithStatus(base.PublishedPlanStatus),
-			).WithSecurity("KEY_LESS"),
+			).WithSecurity("KEY_LESS").WithName("Key Less"),
 		)
 
 		Eventually(func() error {


### PR DESCRIPTION
This is to clearly state the difference between plan map keys, and the name property

see https://gravitee.atlassian.net/browse/GKO-21

relies on https://github.com/gravitee-io/gravitee-api-management/pull/7231