### PR TITLE
fix: bump default version of kube rbac proxy to 0.18.0

### DIFF
--- a/helm/gko/README.md
+++ b/helm/gko/README.md
@@ -47,7 +47,7 @@ Kube RBAC Proxy is deployed as a sidecar container and restricts access to the p
 | ---------------------------- | ------------------------------------------------------------ | -------------------------------- |
 | `rbacProxy.enabled`          | Specifies if the kube-rbac-proxy sidecar should be enabled.  | `true`                           |
 | `rbacProxy.image.repository` | Specifies the docker registry and image name to use.         | `quay.io/brancz/kube-rbac-proxy` |
-| `rbacProxy.image.tag`        | Specifies the docker image tag to use.                       | `v0.16.0`                        |
+| `rbacProxy.image.tag`        | Specifies the docker image tag to use.                       | `v0.18.0`                        |
 
 ### Controller Manager
 

--- a/helm/gko/values.yaml
+++ b/helm/gko/values.yaml
@@ -40,7 +40,7 @@ rbacProxy:
     ## @param rbacProxy.image.repository Specifies the docker registry and image name to use.
     repository: quay.io/brancz/kube-rbac-proxy
     ## @param rbacProxy.image.tag Specifies the docker image tag to use.
-    tag: v0.16.0
+    tag: v0.18.0
 
 ## @section Controller Manager
 ## @descriptionStart


### PR DESCRIPTION
see https://github.com/gravitee-io/issues/issues/9818