### PR TITLE
ci: use exact tag in release link for slack notif

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -524,7 +524,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":kubernetes: Gravitee Kubernetes Operator - <https://github.com/gravitee-io/gravitee-kubernetes-operator/releases/latest|Version ${CIRCLE_TAG}> has been released 🎉"
+                    "text": ":kubernetes: Gravitee Kubernetes Operator - <https://github.com/gravitee-io/gravitee-kubernetes-operator/releases/tag/${CIRCLE_TAG}|Version ${CIRCLE_TAG}> has been released 🎉"
                   }
                 }
               ]


### PR DESCRIPTION
Now that we support several branch, we cannot just use latest anymore.