### PR TITLE
adding tests for member in v2 APIs

### DIFF
--- a/test/integration/apidefinition/create_withContext_MemberWithoutRole_test.go
+++ b/test/integration/apidefinition/create_withContext_MemberWithoutRole_test.go
@@ -1,0 +1,84 @@
+// Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apidefinition
+
+import (
+	"context"
+	"sort"
+
+	"github.com/gravitee-io/gravitee-kubernetes-operator/api/model/api/base"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/apim/model"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/apim"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/assert"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/constants"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/fixture"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/labels"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/random"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Update", labels.WithContext, func() {
+	timeout := constants.EventualTimeout
+	interval := constants.Interval
+
+	ctx := context.Background()
+
+	It("should change the role of an API member", func() {
+		fixtures := fixture.
+			Builder().
+			WithAPI(constants.ApiWithMembersAndGroups).
+			WithContext(constants.ContextWithCredentialsFile).
+			Build()
+
+		By("initializing a service account in current organization")
+
+		apim := apim.NewClient(ctx)
+		saName := random.GetName()
+		Expect(apim.Org.CreateUser(model.NewServiceAccount(saName))).To(Succeed())
+
+		By("applying the API with created service account as members")
+
+		primaryOwner := base.NewMemoryMember("admin", "PRIMARY_OWNER")
+		saMemberWithoutRole := base.NewGraviteeMember(saName, "")
+		fixtures.API.Spec.Members = []*base.Member{saMemberWithoutRole}
+		fixtures = fixtures.Apply()
+
+		By("setting up expected members")
+
+		expectedMemberWithDefaultRole := base.NewGraviteeMember(saName, "USER")
+		expectedMembers := []*base.Member{expectedMemberWithDefaultRole, primaryOwner}
+
+		By("checking that member without role has default role assigned in exported API")
+
+		Eventually(func() error {
+			apiExport, err := apim.APIs.ExportV2(fixtures.API.Status.ID)
+			if err != nil {
+				return err
+			}
+
+			exportedMembers := apiExport.Spec.Members
+
+			By("sorting exported API members by source")
+
+			sort.Slice(exportedMembers, func(i, j int) bool {
+				return exportedMembers[i].Source < exportedMembers[j].Source
+			})
+
+			return assert.Equals("members", expectedMembers, exportedMembers)
+		}, timeout, interval).Should(Succeed(), fixtures.API.Name)
+	})
+})

--- a/test/integration/apidefinition/update_withContext_changingMemberRole_test.go
+++ b/test/integration/apidefinition/update_withContext_changingMemberRole_test.go
@@ -1,0 +1,94 @@
+// Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apidefinition
+
+import (
+	"context"
+
+	"github.com/gravitee-io/gravitee-kubernetes-operator/api/model/api/base"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/apim/model"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/apim"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/assert"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/constants"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/fixture"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/labels"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/manager"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/random"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Update", labels.WithContext, func() {
+	timeout := constants.EventualTimeout
+	interval := constants.Interval
+
+	ctx := context.Background()
+
+	It("should change the role of an API member", func() {
+		fixtures := fixture.
+			Builder().
+			WithAPI(constants.ApiWithMembersAndGroups).
+			WithContext(constants.ContextWithCredentialsFile).
+			Build()
+
+		By("initializing a service account in current organization")
+
+		apim := apim.NewClient(ctx)
+
+		saName := random.GetName()
+
+		Expect(apim.Org.CreateUser(model.NewServiceAccount(saName))).To(Succeed())
+
+		By("applying the API with created service account as members")
+
+		primaryOwner := base.NewMemoryMember("admin", "PRIMARY_OWNER")
+
+		saMember := base.NewGraviteeMember(saName, "REVIEWER")
+
+		fixtures.API.Spec.Members = []*base.Member{saMember}
+
+		fixtures = fixtures.Apply()
+
+		By("checking that exported API has two members")
+
+		Eventually(func() error {
+			apiExport, err := apim.APIs.ExportV2(fixtures.API.Status.ID)
+			if err != nil {
+				return err
+			}
+			return assert.Equals("members", []*base.Member{primaryOwner, saMember}, apiExport.Spec.Members)
+		}, timeout, interval).Should(Succeed(), fixtures.API.Name)
+
+		By("changing role of API member from REVIEWER to USER")
+		saMember.Role = "USER"
+		expectedMembers := []*base.Member{primaryOwner, saMember}
+		fixtures.API.Spec.Members = expectedMembers
+
+		Eventually(func() error {
+			return manager.UpdateSafely(ctx, fixtures.API)
+		}, timeout, interval).Should(Succeed(), fixtures.API.Name)
+
+		By("checking that exported API has one member left")
+
+		Eventually(func() error {
+			apiExport, err := apim.APIs.ExportV2(fixtures.API.Status.ID)
+			if err != nil {
+				return err
+			}
+			return assert.Equals("members", expectedMembers, apiExport.Spec.Members)
+		}, timeout, interval).Should(Succeed(), fixtures.API.Name)
+	})
+})


### PR DESCRIPTION
This will add 2 tests for member in v2 APIs ([GKO-331](https://gravitee.atlassian.net/browse/GKO-331)):
- should change the role of an API member
- should change the role of an API member


**It's automating the following manual tests**
[GKO-308](https://gravitee.atlassian.net/browse/GKO-308)
[GKO-393](https://gravitee.atlassian.net/browse/GKO-393)

[GKO-331]: https://gravitee.atlassian.net/browse/GKO-331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GKO-308]: https://gravitee.atlassian.net/browse/GKO-308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GKO-393]: https://gravitee.atlassian.net/browse/GKO-393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ