### PR TITLE
fix: add `ROOT` type to page types

### DIFF
--- a/api/model/api/base/page.go
+++ b/api/model/api/base/page.go
@@ -51,7 +51,7 @@ type Page struct {
 	// This field can be edited safely if you want to rename a page.
 	Name string `json:"name,omitempty"`
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=MARKDOWN;SWAGGER;ASYNCAPI;ASCIIDOC;FOLDER;SYSTEM_FOLDER
+	// +kubebuilder:validation:Enum=MARKDOWN;SWAGGER;ASYNCAPI;ASCIIDOC;FOLDER;SYSTEM_FOLDER;ROOT
 	// The type of the documentation page or folder.
 	Type string `json:"type"`
 	// +kubebuilder:validation:Optional

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -1080,7 +1080,7 @@ List of path operators
         <td>
           The type of the documentation page or folder.<br/>
           <br/>
-            <i>Enum</i>: MARKDOWN, SWAGGER, ASYNCAPI, ASCIIDOC, FOLDER, SYSTEM_FOLDER<br/>
+            <i>Enum</i>: MARKDOWN, SWAGGER, ASYNCAPI, ASCIIDOC, FOLDER, SYSTEM_FOLDER, ROOT<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -6622,7 +6622,7 @@ APIM exports and can be safely ignored.<br/>
         <td>
           The type of the documentation page or folder.<br/>
           <br/>
-            <i>Enum</i>: MARKDOWN, SWAGGER, ASYNCAPI, ASCIIDOC, FOLDER, SYSTEM_FOLDER<br/>
+            <i>Enum</i>: MARKDOWN, SWAGGER, ASYNCAPI, ASCIIDOC, FOLDER, SYSTEM_FOLDER, ROOT<br/>
         </td>
         <td>true</td>
       </tr><tr>

--- a/helm/gko/crds/gravitee.io_apidefinitions.yaml
+++ b/helm/gko/crds/gravitee.io_apidefinitions.yaml
@@ -469,6 +469,7 @@ spec:
                       - ASCIIDOC
                       - FOLDER
                       - SYSTEM_FOLDER
+                      - ROOT
                       type: string
                     visibility:
                       default: PUBLIC

--- a/helm/gko/crds/gravitee.io_apiv4definitions.yaml
+++ b/helm/gko/crds/gravitee.io_apiv4definitions.yaml
@@ -827,6 +827,7 @@ spec:
                       - ASCIIDOC
                       - FOLDER
                       - SYSTEM_FOLDER
+                      - ROOT
                       type: string
                     visibility:
                       default: PUBLIC


### PR DESCRIPTION
This is required to be able to configure a multi file fetcher.