### PR TITLE
test: fix group tests for v2 APIs

### DIFF
--- a/test/integration/apidefinition/v2/update_withContext_createMultipleGroupsAndDeleteOne_test.go
+++ b/test/integration/apidefinition/v2/update_withContext_createMultipleGroupsAndDeleteOne_test.go
@@ -24,20 +24,21 @@ import (
 	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/constants"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/fixture"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/labels"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/manager"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/random"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Create", labels.WithContext, func() {
+var _ = Describe("Update", labels.WithContext, func() {
 	timeout := constants.EventualTimeout
 	interval := constants.Interval
 
 	ctx := context.Background()
 
 	It("should create an API with multiple groups and then remove one group", func() {
-		fixtures3GroupsAPI := fixture.
+		fixtures := fixture.
 			Builder().
 			WithAPI(constants.ApiWithMembersAndGroups).
 			WithContext(constants.ContextWithCredentialsFile).
@@ -53,41 +54,37 @@ var _ = Describe("Create", labels.WithContext, func() {
 		Expect(apim.Env.CreateGroup(&model.Group{Name: groupName3})).To(Succeed())
 
 		By("applying the API with created group")
-		fixtures3GroupsAPI.API.Spec.Groups = []string{groupName1, groupName2, groupName3}
-		fixtures3GroupsAPI = fixtures3GroupsAPI.Apply()
+		fixtures.API.Spec.Groups = []string{groupName1, groupName2, groupName3}
+		fixtures = fixtures.Apply()
 
 		By("verifying that groups were created")
 		expected3Groups := []string{groupName1, groupName2, groupName3}
 		Eventually(func() error {
-			apiExport, err := apim.Export.V2Api(fixtures3GroupsAPI.API.Status.ID)
+			apiExport, err := apim.Export.V2Api(fixtures.API.Status.ID)
 			if err != nil {
 				return err
 			}
 
 			exported3Groups := apiExport.Spec.Groups
 			return assert.SliceEqualsSorted("groups", expected3Groups, exported3Groups, strings.Compare)
-		}, timeout, interval).Should(Succeed(), fixtures3GroupsAPI.API.Name)
+		}, timeout, interval).Should(Succeed(), fixtures.API.Name)
 
 		By("removing one group")
-		fixtures2GroupsAPI := fixture.
-			Builder().
-			WithAPI(constants.ApiWithMembersAndGroups).
-			WithContext(constants.ContextWithCredentialsFile).
-			Build()
-
-		fixtures2GroupsAPI.API.Spec.Groups = []string{groupName1, groupName3}
-		fixtures2GroupsAPI = fixtures2GroupsAPI.Apply()
+		fixtures.API.Spec.Groups = []string{groupName1, groupName3}
+		Eventually(func() error {
+			return manager.UpdateSafely(ctx, fixtures.API)
+		}, timeout, interval).Should(Succeed(), fixtures.API.Name)
 
 		By("verifying that groups were updated")
 		expected2Groups := []string{groupName1, groupName3}
 		Eventually(func() error {
-			updatedApiExport, err := apim.Export.V2Api(fixtures2GroupsAPI.API.Status.ID)
+			updatedApiExport, err := apim.Export.V2Api(fixtures.API.Status.ID)
 			if err != nil {
 				return err
 			}
 
 			exported2Groups := updatedApiExport.Spec.Groups
 			return assert.SliceEqualsSorted("groups", expected2Groups, exported2Groups, strings.Compare)
-		}, timeout, interval).Should(Succeed(), fixtures2GroupsAPI.API.Name)
+		}, timeout, interval).Should(Succeed(), fixtures.API.Name)
 	})
 })


### PR DESCRIPTION
Key changes:

### Test File Renaming:
* Renaming file to take into account that it deletes a group and it's an update instead of creation

### Test Logic Updates:
* The test now uses `manager.UpdateSafely` to update the API safely instead of re-building the fixture


https://gravitee.atlassian.net/browse/GKO-716