### PR TITLE
test: add category tests for v4 APIs

### DIFF
--- a/test/integration/apidefinition/v4/create_withContext_andOneCategory_test.go
+++ b/test/integration/apidefinition/v4/create_withContext_andOneCategory_test.go
@@ -1,0 +1,68 @@
+// Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v4
+
+import (
+	"context"
+
+	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/apim/model"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/apim"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/assert"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/constants"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/fixture"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/labels"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/random"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Create", labels.WithContext, func() {
+	timeout := constants.EventualTimeout
+	interval := constants.Interval
+
+	ctx := context.Background()
+
+	It("should create a v4 API with a single category", func() {
+		fixtures := fixture.
+			Builder().
+			WithAPIv4(constants.ApiV4).
+			WithContext(constants.ContextWithCredentialsFile).
+			Build()
+
+		By("create a category in APIM")
+		categoryName := random.GetName()
+		apim := apim.NewClient(ctx)
+		Expect(apim.Env.CreateCategory(&model.Category{Name: categoryName})).To(Succeed())
+
+		By("applying the API with a category")
+		fixtures.APIv4.Spec.Categories = []string{categoryName}
+		fixtures = fixtures.Apply()
+
+		By("verifying that the category was added")
+		expectedCategories := []string{categoryName}
+
+		Eventually(func() error {
+			apiExport, err := apim.Export.V4Api(fixtures.APIv4.Status.ID)
+			if err != nil {
+				return err
+			}
+
+			exportedCategories := apiExport.Spec.Categories
+
+			return assert.Equals("categories", expectedCategories, exportedCategories)
+		}, timeout, interval).Should(Succeed(), fixtures.APIv4.Name)
+	})
+})

--- a/test/integration/apidefinition/v4/update_withContext_createMultipleCategoriesAndDeleteOne_test.go
+++ b/test/integration/apidefinition/v4/update_withContext_createMultipleCategoriesAndDeleteOne_test.go
@@ -1,0 +1,90 @@
+// Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v4
+
+import (
+	"context"
+	"strings"
+
+	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/apim/model"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/apim"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/assert"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/constants"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/fixture"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/labels"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/manager"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/random"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Update", labels.WithContext, func() {
+	timeout := constants.EventualTimeout
+	interval := constants.Interval
+
+	ctx := context.Background()
+
+	It("should create a v4 API with multiple categories and then remove one category", func() {
+		fixtures := fixture.
+			Builder().
+			WithAPIv4(constants.ApiV4).
+			WithContext(constants.ContextWithCredentialsFile).
+			Build()
+
+		By("create categories in APIM")
+		categoryName1 := random.GetName()
+		categoryName2 := random.GetName()
+		categoryName3 := random.GetName()
+		apim := apim.NewClient(ctx)
+		Expect(apim.Env.CreateCategory(&model.Category{Name: categoryName1})).To(Succeed())
+		Expect(apim.Env.CreateCategory(&model.Category{Name: categoryName2})).To(Succeed())
+		Expect(apim.Env.CreateCategory(&model.Category{Name: categoryName3})).To(Succeed())
+
+		By("applying the API with created category")
+		fixtures.APIv4.Spec.Categories = []string{categoryName1, categoryName2, categoryName3}
+		fixtures = fixtures.Apply()
+
+		By("verifying that categories were created")
+		expected3Categories := []string{categoryName1, categoryName2, categoryName3}
+		Eventually(func() error {
+			apiExport, err := apim.Export.V4Api(fixtures.APIv4.Status.ID)
+			if err != nil {
+				return err
+			}
+
+			exported3Categories := apiExport.Spec.Categories
+			return assert.SliceEqualsSorted("categories", expected3Categories, exported3Categories, strings.Compare)
+		}, timeout, interval).Should(Succeed(), fixtures.APIv4.Name)
+
+		By("removing one category")
+		fixtures.APIv4.Spec.Categories = []string{categoryName1, categoryName3}
+		Eventually(func() error {
+			return manager.UpdateSafely(ctx, fixtures.APIv4)
+		}, timeout, interval).Should(Succeed(), fixtures.APIv4.Name)
+
+		By("verifying that categories were updated")
+		expected2Categories := []string{categoryName1, categoryName3}
+		Eventually(func() error {
+			updatedApiExport, err := apim.Export.V4Api(fixtures.APIv4.Status.ID)
+			if err != nil {
+				return err
+			}
+
+			exported2categories := updatedApiExport.Spec.Categories
+			return assert.SliceEqualsSorted("categories", expected2Categories, exported2categories, strings.Compare)
+		}, timeout, interval).Should(Succeed(), fixtures.APIv4.Name)
+	})
+})

--- a/test/internal/integration/apim/export.go
+++ b/test/internal/integration/apim/export.go
@@ -36,3 +36,12 @@ func (svc *Export) V2Api(id string) (*v1alpha1.ApiDefinition, error) {
 	}
 	return exported, nil
 }
+
+func (svc *Export) V4Api(id string) (*v1alpha1.ApiV4Definition, error) {
+	url := svc.EnvV2Target("apis").WithPath(id).WithPath("/_export/crd")
+	exported := new(v1alpha1.ApiV4Definition)
+	if err := svc.HTTP.GetYAML(url.String(), &exported); err != nil {
+		return nil, err
+	}
+	return exported, nil
+}


### PR DESCRIPTION
This PR adds the following:

### New Test Cases for v4 APIs:
- with a single category
- with multiple categories and the ability to remove a category (update)

### New Method for v4 API Export:
* Added a new method `V4Api` to the `Export` service to export v4 API definitions

https://gravitee.atlassian.net/browse/GKO-721
