### PR TITLE
test: add member tests for v4 APIs

### DIFF
--- a/api/model/api/base/member.go
+++ b/api/model/api/base/member.go
@@ -35,8 +35,8 @@ type Member struct {
 
 func (m *Member) String() string {
 	return fmt.Sprintf(
-		"{Source:%s,SourceID:%s,DisplayName:%s,Role:%s}",
-		m.Source, m.SourceID, *m.DisplayName, m.Role,
+		"{Source:%s,SourceID:%s,Role:%s}",
+		m.Source, m.SourceID, m.Role,
 	)
 }
 

--- a/test/internal/integration/assert/assert.go
+++ b/test/internal/integration/assert/assert.go
@@ -105,7 +105,20 @@ func SliceEqualsSorted[S ~[]E, E any](field string, expected S, given S, comp so
 	slices.SortFunc(ecp, comp)
 	copy(gcp, given)
 	slices.SortFunc(gcp, comp)
-	return Equals(field, ecp, gcp)
+	return Equals(field, callStringerIfExists(ecp), callStringerIfExists(gcp))
+}
+
+func callStringerIfExists[E any](stringersOrNot []E) []any {
+	stringified := make([]any, len(stringersOrNot))
+	for i := range stringersOrNot {
+		stringerOrNot := stringersOrNot[i]
+		if stringer, ok := any(stringerOrNot).(fmt.Stringer); ok {
+			stringified[i] = stringer.String()
+		} else {
+			stringified[i] = stringerOrNot
+		}
+	}
+	return stringified
 }
 
 func NotEmptySlice[T any](field string, value []T) error {


### PR DESCRIPTION
### Additions of new test files:

* Check the default role assignment for a member without a role
* Verify the role change of an API member
* Verify the removal of an API member


### Changes to `Member` struct:

* [`api/model/api/base/member.go`](diffhunk://#diff-c8e2d1ab38c7d4633f896849376f427f638115f9e9abee49a81bb7e218076116L37-R38): Removed the `DisplayName` field from the `String` method of the `Member` struct.

### Modifications to existing test cases:

* [`test/integration/apidefinition/v2/update_withContext_removingMember_test.go`](diffhunk://#diff-07ec1003528bd10bf40a6be5c59017b6e0f1183cba54104b7461b49be7aa0adbL66-R66): Updated test descriptions to reflect changes in the number of members being checked. [[1]](diffhunk://#diff-07ec1003528bd10bf40a6be5c59017b6e0f1183cba54104b7461b49be7aa0adbL66-R66) [[2]](diffhunk://#diff-07ec1003528bd10bf40a6be5c59017b6e0f1183cba54104b7461b49be7aa0adbL88-R88)

### Utility function enhancement:

* [`test/internal/integration/assert/assert.go`](diffhunk://#diff-8b32900a954606e322187787faa24fd8cd3431ad58b159a6b81b868581b779b8L108-R121): Added a helper function `callStringerIfExists` to handle the conversion of elements to strings if they implement the `fmt.Stringer` interface.



https://gravitee.atlassian.net/browse/GKO-719