### PR TITLE
fix: use selection_rule in plan mapping

### DIFF
--- a/api/model/api/v2/plan.go
+++ b/api/model/api/v2/plan.go
@@ -42,7 +42,7 @@ type Plan struct {
 	// Specify the API associated with this plan
 	Api string `json:"api,omitempty"`
 	// Plan selection rule
-	SelectionRule string `json:"selectionRule,omitempty"`
+	SelectionRule string `json:"selection_rule,omitempty"`
 	// List of different flows for this Plan
 	Flows []Flow `json:"flows,omitempty"`
 }

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -1060,7 +1060,7 @@ that has been promoted between different environments.<br/>
         </td>
         <td>false</td>
       </tr><tr>
-        <td><b>selectionRule</b></td>
+        <td><b>selection_rule</b></td>
         <td>string</td>
         <td>
           Plan selection rule<br/>

--- a/helm/gko/crds/gravitee.io_apidefinitions.yaml
+++ b/helm/gko/crds/gravitee.io_apidefinitions.yaml
@@ -536,7 +536,7 @@ spec:
                     securityDefinition:
                       description: Plan Security definition
                       type: string
-                    selectionRule:
+                    selection_rule:
                       description: Plan selection rule
                       type: string
                     status:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7590

## Description

Today it's not possible to export and then import an API using APIM and the GKO if the plan contains a selection rule