### PR TITLE
test: add mTLS option to run-kind script output

### DIFF
--- a/scripts/run-kind.mjs
+++ b/scripts/run-kind.mjs
@@ -132,6 +132,7 @@ LOG.magenta(`
 
     Available endpoints are:
         Gateway             http://localhost:30082
+        Gateway with mTLS   https://localhost:30084
         Management API      http://localhost:30083/management/organizations/DEFAULT
         Console             http://localhost:30080
 `);


### PR DESCRIPTION
This PR includes a small change to the `scripts/run-kind.mjs` file. The change adds a new endpoint for the Gateway with mTLS to the list of available endpoints.