### PR TITLE
fix: make endpoint qos optional for V4 APIs

### DIFF
--- a/api/model/api/v4/listeners.go
+++ b/api/model/api/v4/listeners.go
@@ -199,6 +199,7 @@ type Entrypoint struct {
 	// +kubebuilder:validation:Required
 	Type string `json:"type"`
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default:=`AUTO`
 	Qos *QosType `json:"qos,omitempty"`
 	Dlq *DLQ     `json:"dlq,omitempty"`
 	// +kubebuilder:validation:Optional


### PR DESCRIPTION
see: https://gravitee.atlassian.net/browse/GKO-1029