### PR TITLE
fix: use a specific file for package level markers

### DIFF
--- a/api/model/api/base/api.go
+++ b/api/model/api/base/api.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +kubebuilder:object:generate=true
 package base
 
 import (

--- a/api/model/api/base/package_markers.go
+++ b/api/model/api/base/package_markers.go
@@ -12,15 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package status
+// +kubebuilder:object:generate=true
 
-type Errors struct {
-	// warning errors do not block object reconciliation,
-	// most of the time because the value is ignored or defaulted
-	// when the API gets synced with APIM
-	Warning []string `json:"warning,omitempty"`
-	// severe errors do not pass admission and will block reconcile
-	// hence, this field should always be during the admission phase
-	// and is very unlikely to be persisted in the status
-	Severe []string `json:"severe,omitempty"`
-}
+package base
+
+// placeholder files for package level markers

--- a/api/model/api/v2/api.go
+++ b/api/model/api/v2/api.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +kubebuilder:object:generate=true
 package v2
 
 import (

--- a/api/model/api/v2/package_markers.go
+++ b/api/model/api/v2/package_markers.go
@@ -12,15 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package status
+// +kubebuilder:object:generate=true
 
-type Errors struct {
-	// warning errors do not block object reconciliation,
-	// most of the time because the value is ignored or defaulted
-	// when the API gets synced with APIM
-	Warning []string `json:"warning,omitempty"`
-	// severe errors do not pass admission and will block reconcile
-	// hence, this field should always be during the admission phase
-	// and is very unlikely to be persisted in the status
-	Severe []string `json:"severe,omitempty"`
-}
+package v2
+
+// placeholder files for package level markers

--- a/api/model/api/v4/api.go
+++ b/api/model/api/v4/api.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +kubebuilder:object:generate=true
 package v4
 
 import (

--- a/api/model/api/v4/package_markers.go
+++ b/api/model/api/v4/package_markers.go
@@ -12,15 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package status
+// +kubebuilder:object:generate=true
 
-type Errors struct {
-	// warning errors do not block object reconciliation,
-	// most of the time because the value is ignored or defaulted
-	// when the API gets synced with APIM
-	Warning []string `json:"warning,omitempty"`
-	// severe errors do not pass admission and will block reconcile
-	// hence, this field should always be during the admission phase
-	// and is very unlikely to be persisted in the status
-	Severe []string `json:"severe,omitempty"`
-}
+package v4
+
+// placeholder files for package level markers

--- a/api/model/application/application.go
+++ b/api/model/application/application.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +kubebuilder:object:generate=true
 package application
 
 import (

--- a/api/model/application/package_markers.go
+++ b/api/model/application/package_markers.go
@@ -12,15 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package status
+// +kubebuilder:object:generate=true
 
-type Errors struct {
-	// warning errors do not block object reconciliation,
-	// most of the time because the value is ignored or defaulted
-	// when the API gets synced with APIM
-	Warning []string `json:"warning,omitempty"`
-	// severe errors do not pass admission and will block reconcile
-	// hence, this field should always be during the admission phase
-	// and is very unlikely to be persisted in the status
-	Severe []string `json:"severe,omitempty"`
-}
+package application
+
+// placeholder files for package level markers

--- a/api/model/group/group.go
+++ b/api/model/group/group.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +kubebuilder:object:generate=true
 package group
 
 import (

--- a/api/model/group/package_markers.go
+++ b/api/model/group/package_markers.go
@@ -12,15 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package status
+// +kubebuilder:object:generate=true
 
-type Errors struct {
-	// warning errors do not block object reconciliation,
-	// most of the time because the value is ignored or defaulted
-	// when the API gets synced with APIM
-	Warning []string `json:"warning,omitempty"`
-	// severe errors do not pass admission and will block reconcile
-	// hence, this field should always be during the admission phase
-	// and is very unlikely to be persisted in the status
-	Severe []string `json:"severe,omitempty"`
-}
+package group
+
+// placeholder files for package level markers

--- a/api/model/management/context.go
+++ b/api/model/management/context.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +kubebuilder:object:generate=true
 package management
 
 import (

--- a/api/model/management/package_markers.go
+++ b/api/model/management/package_markers.go
@@ -12,15 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package status
+// +kubebuilder:object:generate=true
 
-type Errors struct {
-	// warning errors do not block object reconciliation,
-	// most of the time because the value is ignored or defaulted
-	// when the API gets synced with APIM
-	Warning []string `json:"warning,omitempty"`
-	// severe errors do not pass admission and will block reconcile
-	// hence, this field should always be during the admission phase
-	// and is very unlikely to be persisted in the status
-	Severe []string `json:"severe,omitempty"`
-}
+package management
+
+// placeholder files for package level markers

--- a/api/model/policygroups/package_markers.go
+++ b/api/model/policygroups/package_markers.go
@@ -12,15 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package status
+// +kubebuilder:object:generate=true
 
-type Errors struct {
-	// warning errors do not block object reconciliation,
-	// most of the time because the value is ignored or defaulted
-	// when the API gets synced with APIM
-	Warning []string `json:"warning,omitempty"`
-	// severe errors do not pass admission and will block reconcile
-	// hence, this field should always be during the admission phase
-	// and is very unlikely to be persisted in the status
-	Severe []string `json:"severe,omitempty"`
-}
+package policygroups
+
+// placeholder files for package level markers

--- a/api/model/policygroups/sharedpolicygroups.go
+++ b/api/model/policygroups/sharedpolicygroups.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +kubebuilder:object:generate=true
 package policygroups
 
 import (

--- a/api/model/refs/namespace.go
+++ b/api/model/refs/namespace.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +kubebuilder:object:generate=true
 package refs
 
 import (

--- a/api/model/refs/package_markers.go
+++ b/api/model/refs/package_markers.go
@@ -12,15 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package status
+// +kubebuilder:object:generate=true
 
-type Errors struct {
-	// warning errors do not block object reconciliation,
-	// most of the time because the value is ignored or defaulted
-	// when the API gets synced with APIM
-	Warning []string `json:"warning,omitempty"`
-	// severe errors do not pass admission and will block reconcile
-	// hence, this field should always be during the admission phase
-	// and is very unlikely to be persisted in the status
-	Severe []string `json:"severe,omitempty"`
-}
+package refs
+
+// placeholder files for package level markers

--- a/api/model/status/package_markers.go
+++ b/api/model/status/package_markers.go
@@ -12,15 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +kubebuilder:object:generate=true
+
 package status
 
-type Errors struct {
-	// warning errors do not block object reconciliation,
-	// most of the time because the value is ignored or defaulted
-	// when the API gets synced with APIM
-	Warning []string `json:"warning,omitempty"`
-	// severe errors do not pass admission and will block reconcile
-	// hence, this field should always be during the admission phase
-	// and is very unlikely to be persisted in the status
-	Severe []string `json:"severe,omitempty"`
-}
+// placeholder files for package level markers

--- a/api/model/subscription/package_markers.go
+++ b/api/model/subscription/package_markers.go
@@ -12,15 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package status
+// +kubebuilder:object:generate=true
 
-type Errors struct {
-	// warning errors do not block object reconciliation,
-	// most of the time because the value is ignored or defaulted
-	// when the API gets synced with APIM
-	Warning []string `json:"warning,omitempty"`
-	// severe errors do not pass admission and will block reconcile
-	// hence, this field should always be during the admission phase
-	// and is very unlikely to be persisted in the status
-	Severe []string `json:"severe,omitempty"`
-}
+package subscription
+
+// placeholder files for package level markers

--- a/api/model/subscription/subscription.go
+++ b/api/model/subscription/subscription.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +kubebuilder:object:generate=true
 package subscription
 
 import (

--- a/api/model/utils/maps.go
+++ b/api/model/utils/maps.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// +kubebuilder:object:generate=true
+
 package utils
 
 import (

--- a/api/model/utils/package_markers.go
+++ b/api/model/utils/package_markers.go
@@ -12,15 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package status
+// +kubebuilder:object:generate=true
 
-type Errors struct {
-	// warning errors do not block object reconciliation,
-	// most of the time because the value is ignored or defaulted
-	// when the API gets synced with APIM
-	Warning []string `json:"warning,omitempty"`
-	// severe errors do not pass admission and will block reconcile
-	// hence, this field should always be during the admission phase
-	// and is very unlikely to be persisted in the status
-	Severe []string `json:"severe,omitempty"`
-}
+package utils
+
+// placeholder files for package level markers


### PR DESCRIPTION
## Issue 

`// +kubebuilder:object:generate=true` was set in one the package file. Moved to a specific file named `package_markers.go`

