### PR TITLE
test: adding retries to callGateway script

### DIFF
--- a/test/e2e/chainsaw/tests/v2api/create-update-delete/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/tests/v2api/create-update-delete/chainsaw-test.yaml
@@ -55,7 +55,6 @@ spec:
             - name: COMMAND_DIR
               value: ($commandDir)
           content: |
-            sleep 10
             npx zx $COMMAND_DIR/callGateway.mjs --endpoint $ENDPOINT --status 200
     catch:
       - podLogs:
@@ -91,8 +90,6 @@ spec:
             - name: COMMAND_DIR
               value: ($commandDir)
           content: |
-            echo "Waiting 10s for API to be deployed and accessible ..."
-            sleep 10
             npx zx $COMMAND_DIR/callGateway.mjs --endpoint updated-path --status 200
     catch:
       - podLogs:
@@ -108,8 +105,6 @@ spec:
             - name: COMMAND_DIR
               value: ($commandDir)
           content: |
-            echo "Waiting 10s for API to be deployed and accessible ..."
-            sleep 10
             npx zx $COMMAND_DIR/callGateway.mjs --endpoint $ENDPOINT --status 404   
 
   - name: delete-api
@@ -139,8 +134,6 @@ spec:
             - name: COMMAND_DIR
               value: ($commandDir)
             content: |
-              echo "Waiting 10s for API to be deleted ..."
-              sleep 10
               npx zx $COMMAND_DIR/callGateway.mjs --endpoint updated-path --status 404
     catch:
         - podLogs:


### PR DESCRIPTION
To improve the efficiency of test runs I replaced the fixed sleep command with a more dynamic retry mechanism.
Now, for example, the create-update-delete test only needs around 19s (before: 49s)

Enhancement summary:
* Added retry logic to the `callGateway.mjs` script
* Removed sleep command to eliminate unnecessary waiting time 