### PR TITLE
test: setup circleci to run chainsaw e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,17 @@ commands:
       - keeper/env-export:
           secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
           var-name: AZURE_SP_PASSWORD
+  cmd-setup-azure-login-e2e:
+    steps:
+      - keeper/env-export:
+          secret-url: keeper://ekjb4UzzzML0k3Qv_W8yqg/custom_field/AZURE_APPLICATION_ID
+          var-name: AZURE_APPLICATION_ID
+      - keeper/env-export:
+          secret-url: keeper://ekjb4UzzzML0k3Qv_W8yqg/custom_field/AZURE_TENANT
+          var-name: AZURE_TENANT
+      - keeper/env-export:
+          secret-url: keeper://ekjb4UzzzML0k3Qv_W8yqg/custom_field/AZURE_APPLICATION_SECRET
+          var-name: AZURE_APPLICATION_SECRET
 jobs:
   job-install-go-tools:
     docker:
@@ -257,16 +268,29 @@ jobs:
   job-e2e-tests:
     docker:
       - image: cimg/go:<< pipeline.parameters.go-version >>-node
+    environment:
+      APIM_GATEWAY: "https://apim-stable-gateway.team-gko.gravitee.dev"
     steps:
       - checkout
+      - kubernetes/install-kubectl
+      - azure-cli/install
+      - cmd-setup-azure-login-e2e
+      - run:
+          name: Run az job-azure-login-e2e
+          command: |
+            az login --service-principal -u $AZURE_APPLICATION_ID --tenant $AZURE_TENANT -p $AZURE_APPLICATION_SECRET
+            az aks get-credentials --admin --resource-group Devs-Gko-Hosted --name gravitee-devs-gko-aks-cluster
+      - run:
+          name: Create junit reports directory for e2e tests
+          command: mkdir -p "/tmp/junit/reports-e2e"
       - run:
           name: Install Chainsaw
           command: |
             GOBIN=$(pwd)/bin go install github.com/kyverno/chainsaw@latest
       - run:
-          name: Print Chainsaw help
+          name: Run Chainsaw tests
           command: |
-            bin/chainsaw -h
+            bin/chainsaw test --config test/e2e/chainsaw/config.yaml
 
   job-stage-image:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,6 +291,8 @@ jobs:
           name: Run Chainsaw tests
           command: |
             bin/chainsaw test --config test/e2e/chainsaw/config.yaml
+      - store_test_results:
+          path: /tmp/junit/reports-e2e
 
   job-stage-image:
     docker:

--- a/test/e2e/chainsaw/commands/callGateway.mjs
+++ b/test/e2e/chainsaw/commands/callGateway.mjs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-await dotenv.config('.env');
+await dotenv.config(`${__dirname}/../.env`);
 const { endpoint: endpointPath, status: expectedStatusCode } = argv;
 
 if (!endpointPath || !expectedStatusCode) {
@@ -35,7 +35,7 @@ const url = base.toString();
 
 console.log(`Testing connection to: ${url}`);
 
-const maxRetry = 20; // Maximum number of retries
+const maxRetry = 20; 
 const retryDelay = 500; // Delay in milliseconds between retries
 
 let attempt = 0;

--- a/test/e2e/chainsaw/config.yaml
+++ b/test/e2e/chainsaw/config.yaml
@@ -16,19 +16,18 @@
 apiVersion: chainsaw.kyverno.io/v1alpha2
 kind: Configuration
 metadata:
-  name: example
+  name: chainsaw-e2e-tests
 spec:
-  # discovery:
-  #   testFile: chainsaw-test
-  #   includeTestRegex: tests/v2api/invalid-v2api/.*
+  discovery:
+    testFile: chainsaw-test
   timeouts:
     apply: 5s
     assert: 5s
     cleanup: 10s
     delete: 15s
     error: 10s
-    exec: 30s     # for commands and scripts
-  # report:
-  #   format: XML
-  #   name: chainsaw-report
-  #   path: ./reports
+    exec: 30s     
+  report:
+    format: XML
+    name: chainsaw-junit-reports
+    path: /tmp/junit/reports-e2e


### PR DESCRIPTION
This PR includes several changes to the CI/CD pipeline and end-to-end (E2E) testing configuration to enable Chainsaw to start E2E tests.

### Most important changes:
- Added Azure login setup
- Updates to the Chainsaw test configuration



https://gravitee.atlassian.net/browse/GKO-1108
