### PR TITLE
GKO-1177 overlapping routes mode

### DIFF
--- a/controllers/gateway-api/httproute/internal/mapper/endpoints.go
+++ b/controllers/gateway-api/httproute/internal/mapper/endpoints.go
@@ -52,7 +52,7 @@ func buildEndpointGroup(
 }
 
 func buildEndpointGroupName(index int) string {
-	return fmt.Sprintf("rule-%d", index)
+	return fmt.Sprintf("endpoints-%d", index)
 }
 
 func buildEndpoints(

--- a/controllers/gateway-api/httproute/internal/mapper/mapper.go
+++ b/controllers/gateway-api/httproute/internal/mapper/mapper.go
@@ -24,8 +24,11 @@ import (
 	gwAPIv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
+const (
+	rootPath = "/"
+)
+
 var (
-	rootPath        = "/"
 	keyLessSecurity = v4.NewPlanSecurity("KEY_LESS")
 )
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-1176

## Fix

* Be more restrictive with path matching in selectors
* renaming rules to endpoints for clarity
* see https://github.com/gravitee-io/gravitee-api-management/pull/11731

