### PR TITLE
Use v1 API for Applications

### DIFF
--- a/internal/apim/service/applications.go
+++ b/internal/apim/service/applications.go
@@ -92,7 +92,7 @@ func (svc *Applications) DryRunCreateOrUpdate(spec *application.Application) (*a
 }
 
 func (svc *Applications) createOrUpdate(spec *application.Application, dryRun bool) (*application.Status, error) {
-	url := svc.EnvV2Target(applicationsPath).
+	url := svc.EnvV1Target(applicationsPath).
 		WithPath("/_import/crd").
 		WithQueryParam("dryRun", strconv.FormatBool(dryRun))
 


### PR DESCRIPTION
Applications are only accessible by the v1 API. The v2 API does not contain any application endpoints.

Reference: https://documentation.gravitee.io/apim/management-api/management-api-reference