### PR TITLE
test: add branch filter for e2e tests (master only)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -824,6 +824,10 @@ workflows:
       - job-e2e-tests:
           name: Run end to end tests
           context: cicd-orchestrator
+          filters:
+            branches:
+              only:
+                - master
           post-steps:
               - slack/notify:
                   channel: C098YUEDMGE


### PR DESCRIPTION
This pull request makes a small configuration change to the CircleCI workflow. The change restricts the "Run end to end tests" job to only run on the `master` branch.