### PR TITLE
test: add e2e test for changing member role

### DIFF
--- a/test/e2e/chainsaw/commands/createServiceAccount.mjs
+++ b/test/e2e/chainsaw/commands/createServiceAccount.mjs
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+const { name } = argv;
+if (!name) {
+    console.error('Usage: createServiceAccount.mjs --name <SERVICE_ACCOUNT_NAME>');
+    process.exit(1);
+}
+
+const API_URL = 'http://localhost:30083/management/organizations/DEFAULT/users';
+
+const newUser = {
+  lastname: name,
+  email: `${name}@graviteesource.com`,
+  service: true,
+};
+
+const res = await fetch(API_URL, {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'Authorization': 'Basic ' + btoa('admin:admin'),
+  },
+  body: JSON.stringify(newUser),
+});
+
+if (!res.ok) {
+  const err = await res.text();
+  throw new Error(`Failed to create service account user: ${res.status} ${err}`);
+}
+
+const createdUser = await res.json();
+console.log(JSON.stringify(createdUser));

--- a/test/e2e/chainsaw/tests/apis/changingMemberRole/v2/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/tests/apis/changingMemberRole/v2/chainsaw-test.yaml
@@ -1,0 +1,162 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: v2-changing-member-role
+spec:
+  bindings:
+    - name: apiName
+      value: (concat('v2-changing-member-role-', random('[a-z0-9]{5}')))
+    - name: service_account_name
+      value: (concat('service-account-', random('[a-z0-9]{5}')))
+    - name: commandDir
+      value: "../../../../commands"
+    - name: gkoNamespace
+      value: default
+    - name: exportedApiYaml
+      value: exportedApi.yaml  
+
+  steps:
+  - name: create-new-user
+    try:
+      - script:
+          env:
+            - name: COMMAND_DIR
+              value: ($commandDir)
+            - name: SERVICE_ACCOUNT_NAME
+              value: ($service_account_name)
+          content: |
+            npx zx $COMMAND_DIR/createServiceAccount.mjs --name $SERVICE_ACCOUNT_NAME
+          check:
+              ($error): ~
+              (contains($stdout, '@graviteesource.com')): true
+    catch:
+      - podLogs:
+          selector: "app.kubernetes.io/component=api"
+          namespace: ($gkoNamespace)
+  
+  - name: create-api-with-new-member
+    try:
+      - apply:
+          resource:
+            apiVersion: gravitee.io/v1alpha1
+            kind: ApiDefinition
+            metadata:
+              name: ($apiName)
+            spec:
+              name: ($apiName)
+              version: "1"
+              description: "V2 API with groups and members Gravitee Kubernetes Operator sample"
+              state: STARTED
+              contextRef:
+                name: "dev-ctx"
+                namespace: "default"
+              plans:
+                - name: "KEY_LESS"
+                  description: "FREE"
+                  security: "KEY_LESS"
+              proxy:
+                virtual_hosts:
+                  - path: (concat('/', $apiName))
+                groups:
+                  - endpoints:
+                      - name: "Default"
+                        target: "https://api.gravitee.io/echo"
+              local: false
+              notifyMembers: false
+              members:
+                - source: gravitee
+                  sourceId: ($service_account_name)
+                  role: USER
+      - assert:
+          resource:
+            apiVersion: gravitee.io/v1alpha1
+            kind: ApiDefinition
+            metadata:
+              name: ($apiName)
+            spec:
+              members:
+                - source: gravitee
+                  sourceId: ($service_account_name)
+                  role: USER
+            status:
+              processingStatus: Completed
+    catch:
+      - events: {}
+
+  - name: update-member-role
+    try:
+      - patch:
+          resource:
+            apiVersion: gravitee.io/v1alpha1
+            kind: ApiDefinition
+            metadata:
+              name: ($apiName)
+            spec:
+              version: "update"
+              members:
+                - source: gravitee
+                  sourceId: ($service_account_name)
+                  role: "REVIEWER"
+      - assert:
+          resource:
+            apiVersion: gravitee.io/v1alpha1
+            kind: ApiDefinition
+            metadata:
+              name: ($apiName)
+            spec:
+              members:
+                - source: gravitee
+                  sourceId: ($service_account_name)
+                  role: "REVIEWER"
+            status:
+              processingStatus: Completed   
+    catch:
+      - events: {}
+    
+  - name: export-api-as-yaml
+    try:
+      - script:
+          env:
+            - name: COMMAND_DIR
+              value: ($commandDir)
+            - name: API_NAME
+              value: ($apiName)
+            - name: RESOURCE_NAMESPACE
+              value: ($namespace)
+            - name: EXPORTED_API_YAML
+              value: ($exportedApiYaml)
+          content: |
+            API_ID=$(kubectl get apidefinitions.gravitee.io -n $RESOURCE_NAMESPACE $API_NAME -o jsonpath='{.status.id}')
+            npx zx $COMMAND_DIR/exportApiAsYaml.mjs --api_id $API_ID --api_version v2 > "$EXPORTED_API_YAML"
+
+  - name: assert-exported-changed-member-role
+    try:
+      - script:
+          env:
+            - name: SERVICE_ACCOUNT_NAME
+              value: ($service_account_name)
+            - name: EXPORTED_API_YAML
+              value: ($exportedApiYaml)
+          content: |
+            echo "MEMBER_COUNT=$(yq '.spec.members | length' "$EXPORTED_API_YAML")"
+            echo "ROLE=$(yq -r ".spec.members[] | select(.source==\"gravitee\" and .sourceId==\"$SERVICE_ACCOUNT_NAME\") | .role" "$EXPORTED_API_YAML")"
+            rm -f "$EXPORTED_API_YAML"
+          check:
+            (contains($stdout, 'MEMBER_COUNT=1')): true
+            (contains($stdout, 'ROLE=REVIEWER')): true
+

--- a/test/e2e/chainsaw/tests/apis/changingMemberRole/v4/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/tests/apis/changingMemberRole/v4/chainsaw-test.yaml
@@ -1,0 +1,176 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: v4-changing-member-role
+spec:
+  bindings:
+    - name: apiName
+      value: (concat('v4-changing-member-role-', random('[a-z0-9]{5}')))
+    - name: service_account_name
+      value: (concat('service-account-', random('[a-z0-9]{5}')))
+    - name: commandDir
+      value: "../../../../commands"
+    - name: gkoNamespace
+      value: default
+    - name: exportedApiYaml
+      value: exportedApi.yaml  
+
+  steps:
+  - name: create-new-user
+    try:
+      - script:
+          env:
+            - name: COMMAND_DIR
+              value: ($commandDir)
+            - name: SERVICE_ACCOUNT_NAME
+              value: ($service_account_name)
+          content: |
+            npx zx $COMMAND_DIR/createServiceAccount.mjs --name $SERVICE_ACCOUNT_NAME
+          check:
+              ($error): ~
+              (contains($stdout, '@graviteesource.com')): true
+    catch:
+      - podLogs:
+          selector: "app.kubernetes.io/component=api"
+          namespace: ($gkoNamespace)
+  
+  - name: create-api-with-new-member
+    try:
+      - apply:
+          resource:
+            apiVersion: gravitee.io/v1alpha1
+            kind: ApiV4Definition
+            metadata:
+              name: ($apiName)
+            spec:
+              contextRef:
+                name: "dev-ctx"
+                namespace: "default"
+              name: ($apiName)
+              description: "keyless v4 API - Created by Chainsaw E2E test"
+              version: "1.0"
+              type: PROXY
+              listeners:
+                - type: HTTP
+                  paths:
+                    - path: (concat('/', $apiName))
+                  entrypoints:
+                    - type: http-proxy
+                      qos: AUTO
+              endpointGroups:
+                - name: Default HTTP proxy group
+                  type: http-proxy
+                  endpoints:
+                    - name: Default HTTP proxy
+                      type: http-proxy
+                      inheritConfiguration: false
+                      configuration:
+                        target: https://api.gravitee.io/echo
+                      secondary: false
+              flowExecution:
+                mode: DEFAULT
+                matchRequired: false
+              plans:
+                KeyLess:
+                  name: "Free plan"
+                  description: "This plan does not require any authentication"
+                  security:
+                    type: "KEY_LESS"
+              members:
+                - source: gravitee
+                  sourceId: ($service_account_name)
+                  role: USER
+      - assert:
+          resource:
+            apiVersion: gravitee.io/v1alpha1
+            kind: ApiV4Definition
+            metadata:
+              name: ($apiName)
+            spec:
+              members:
+                - source: gravitee
+                  sourceId: ($service_account_name)
+                  role: USER
+            status:
+              processingStatus: Completed
+    catch:
+      - events: {}
+
+  - name: update-member-role
+    try:
+      - sleep:
+          duration: 5s
+      - patch:
+          resource:
+            apiVersion: gravitee.io/v1alpha1
+            kind: ApiV4Definition
+            metadata:
+              name: ($apiName)
+            spec:
+              version: "update"
+              members:
+                - source: gravitee
+                  sourceId: ($service_account_name)
+                  role: "REVIEWER"
+      - assert:
+          resource:
+            apiVersion: gravitee.io/v1alpha1
+            kind: ApiV4Definition
+            metadata:
+              name: ($apiName)
+            spec:
+              members:
+                - source: gravitee
+                  sourceId: ($service_account_name)
+                  role: "REVIEWER"
+            status:
+              processingStatus: Completed   
+    catch:
+      - events: {}
+    
+  - name: export-api-as-yaml
+    try:
+      - script:
+          env:
+            - name: COMMAND_DIR
+              value: ($commandDir)
+            - name: API_NAME
+              value: ($apiName)
+            - name: RESOURCE_NAMESPACE
+              value: ($namespace)
+            - name: EXPORTED_API_YAML
+              value: ($exportedApiYaml)
+          content: |
+            API_ID=$(kubectl get apiv4definitions.gravitee.io -n $RESOURCE_NAMESPACE $API_NAME -o jsonpath='{.status.id}')
+            npx zx $COMMAND_DIR/exportApiAsYaml.mjs --api_id $API_ID --api_version v4 > "$EXPORTED_API_YAML"
+
+  - name: assert-exported-changed-member-role
+    try:
+      - script:
+          env:
+            - name: SERVICE_ACCOUNT_NAME
+              value: ($service_account_name)
+            - name: EXPORTED_API_YAML
+              value: ($exportedApiYaml)
+          content: |
+            echo "MEMBER_COUNT=$(yq '.spec.members | length' "$EXPORTED_API_YAML")"
+            echo "ROLE=$(yq -r ".spec.members[] | select(.source==\"gravitee\" and .sourceId==\"$SERVICE_ACCOUNT_NAME\") | .role" "$EXPORTED_API_YAML")"
+            rm -f "$EXPORTED_API_YAML"
+          check:
+            (contains($stdout, 'MEMBER_COUNT=1')): true
+            (contains($stdout, 'ROLE=REVIEWER')): true


### PR DESCRIPTION
This PR adds new end-to-end Chainsaw tests to verify that API member roles can be changed for both v2 and v4 APIs.

**New Chainsaw E2E tests for member role changes:**

* Added `chainsaw-test.yaml` for v2 APIs to test creating an API with a service account member, updating the member's role, and verifying the exported API YAML reflects the change.
* Added `chainsaw-test.yaml` for v4 APIs with similar steps as v2, including creation, role update, and export verification for member roles.

**New service account creation command:**

* Added `createServiceAccount.mjs` script to automate creation of service account users for use in E2E tests.

See: https://gravitee.atlassian.net/browse/GKO-1372
