### PR TITLE
test: adds e2e test to remove member from API

### DIFF
--- a/test/e2e/chainsaw/commands/deleteServiceAccount.mjs
+++ b/test/e2e/chainsaw/commands/deleteServiceAccount.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env zx
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mapiClient } from '../lib/mapiClient.mjs';
+
+const { name } = argv;
+if (!name) {
+  console.error('Usage: deleteServiceAccount.mjs --name <SERVICE_ACCOUNT_NAME>');
+  process.exit(1);
+}
+
+try {
+  const searchPath = `/management/organizations/DEFAULT/search/users?q=${encodeURIComponent(name)}`;
+  const resText = await mapiClient.get(searchPath);
+
+  let users;
+  try {
+    users = JSON.parse(resText);
+  } catch (parseErr) {
+    throw new Error(`Unexpected response while searching users (not JSON).`);
+  }
+
+  if (!Array.isArray(users)) {
+    throw new Error('Unexpected response format: expected an array of users.');
+  }
+
+const foundUser = users.find((u) => u && u.lastname === name);
+  if (!foundUser) {
+    console.error(`No user found with lastname exactly '${name}'.`);
+    process.exit(0);
+  }
+
+  await mapiClient.del(`/management/organizations/DEFAULT/users/${foundUser.id}`);
+  console.log(`Deleted service account user '${name}' (id: ${foundUser.id})`);
+} catch (e) {
+  console.error(`Failed to delete service account user: ${e.message}`);
+  process.exit(1);
+}

--- a/test/e2e/chainsaw/lib/mapiClient.mjs
+++ b/test/e2e/chainsaw/lib/mapiClient.mjs
@@ -53,7 +53,25 @@ async function get(path) {
   return res.text();
 }
 
+async function del(path) {
+  const url = new URL(path, BASE_URL_API).toString();
+  const res = await fetch(url, {
+    method: 'DELETE',
+    headers: {
+      'Authorization': AUTH_HEADER,
+    },
+  });
+
+  if (!res.ok) {
+    const err = await res.text().catch(() => '');
+    throw new Error(`Failed request to ${url}: ${res.status} ${err}`);
+  }
+
+  return res.text().catch(() => '');
+}
+
 export const mapiClient = {
   post,
   get,
+  del,
 };

--- a/test/e2e/chainsaw/tests/apis/removingMember/v2/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/tests/apis/removingMember/v2/chainsaw-test.yaml
@@ -1,0 +1,118 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: v2-removing-member
+spec:
+  bindings:
+    - name: apiName
+      value: remove-member-test-v2
+    - name: service_account_name
+      value: service-account-for-remove-member-test-v2
+    - name: commandDir
+      value: "../../../../commands"
+    - name: gkoNamespace
+      value: default
+    - name: exportedApiYaml
+      value: exportedApi.yaml  
+
+  steps:
+  - name: remove-pre-existing-service-account
+    try:
+      - script:
+          env:
+            - name: COMMAND_DIR
+              value: ($commandDir)
+            - name: SERVICE_ACCOUNT_NAME
+              value: ($service_account_name)
+          content: |
+            npx zx $COMMAND_DIR/deleteServiceAccount.mjs --name "$SERVICE_ACCOUNT_NAME"
+
+  - name: create-new-service-account
+    try:
+      - script:
+          env:
+            - name: COMMAND_DIR
+              value: ($commandDir)
+            - name: SERVICE_ACCOUNT_NAME
+              value: ($service_account_name)
+          content: |
+            npx zx $COMMAND_DIR/createServiceAccount.mjs --name $SERVICE_ACCOUNT_NAME
+          check:
+              ($error): ~
+              (contains($stdout, '@graviteesource.com')): true
+    catch:
+      - podLogs:
+          selector: "app.kubernetes.io/component=api"
+          namespace: ($gkoNamespace)
+  
+  - name: create-api-with-new-member
+    try:
+      - apply:
+          file: v2-api-with-member.yaml
+      - assert:
+          resource:
+            apiVersion: gravitee.io/v1alpha1
+            kind: ApiDefinition
+            metadata:
+              name: ($apiName)
+            spec:
+              members:
+                - source: gravitee
+                  sourceId: ($service_account_name)
+                  role: REVIEWER
+            status:
+              processingStatus: Completed
+    catch:
+      - events: {}
+
+  - name: update-api-with-removed-member
+    try:
+      - apply:
+          file: v2-api-without-member.yaml
+    catch:
+      - events: {}
+
+  - name: export-api-as-yaml
+    try:
+      - script:
+          env:
+            - name: COMMAND_DIR
+              value: ($commandDir)
+            - name: API_NAME
+              value: ($apiName)
+            - name: RESOURCE_NAMESPACE
+              value: ($namespace)
+            - name: EXPORTED_API_YAML
+              value: ($exportedApiYaml)
+          content: |
+            API_ID=$(kubectl get apidefinitions.gravitee.io -n $RESOURCE_NAMESPACE $API_NAME -o jsonpath='{.status.id}')
+            npx zx $COMMAND_DIR/exportApiAsYaml.mjs --api_id $API_ID --api_version v2 > $EXPORTED_API_YAML
+
+  - name: assert-export-for-removed-member
+    try:
+      - script:
+          env:
+            - name: SERVICE_ACCOUNT_NAME
+              value: ($service_account_name)
+            - name: EXPORTED_API_YAML
+              value: ($exportedApiYaml)
+          content: |
+            echo "MEMBER_COUNT=$(yq '.spec.members | length' "$EXPORTED_API_YAML")"
+            rm -f "$EXPORTED_API_YAML"
+          check:
+            (contains($stdout, 'MEMBER_COUNT=0')): true

--- a/test/e2e/chainsaw/tests/apis/removingMember/v2/v2-api-with-member.yaml
+++ b/test/e2e/chainsaw/tests/apis/removingMember/v2/v2-api-with-member.yaml
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: gravitee.io/v1alpha1
+kind: ApiDefinition
+metadata:
+  name: remove-member-test-v2
+spec:
+  contextRef:
+    name: dev-ctx
+    namespace: default
+  name: "remove-member-test-v2"
+  version: "1.1"
+  description: "API with groups and members Gravitee Kubernetes Operator sample"
+  plans:
+    - name: "KEY_LESS"
+      description: "FREE"
+      security: "KEY_LESS"
+  proxy:
+    virtual_hosts:
+      - path: "/remove-member-test-v2"
+    groups:
+      - endpoints:
+          - name: "Default"
+            target: "https://api.gravitee.io/echo"
+  local: true
+  groups:
+    - developers
+  members:
+    - source: gravitee
+      sourceId: service-account-for-remove-member-test-v2
+      role: REVIEWER
+  notifyMembers: false

--- a/test/e2e/chainsaw/tests/apis/removingMember/v2/v2-api-without-member.yaml
+++ b/test/e2e/chainsaw/tests/apis/removingMember/v2/v2-api-without-member.yaml
@@ -1,0 +1,38 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: gravitee.io/v1alpha1
+kind: ApiDefinition
+metadata:
+  name: remove-member-test-v2
+spec:
+  contextRef:
+    name: dev-ctx
+  name: "remove-member-test-v2"
+  version: "updated"
+  description: "API with groups and members Gravitee Kubernetes Operator sample"
+  plans:
+    - name: "KEY_LESS"
+      description: "FREE"
+      security: "KEY_LESS"
+  proxy:
+    virtual_hosts:
+      - path: "/remove-member-test-v2"
+    groups:
+      - endpoints:
+          - name: "Default"
+            target: "https://api.gravitee.io/echo"
+  local: true
+  members: []

--- a/test/e2e/chainsaw/tests/apis/removingMember/v4/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/tests/apis/removingMember/v4/chainsaw-test.yaml
@@ -1,0 +1,118 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: v4-removing-member
+spec:
+  bindings:
+    - name: apiName
+      value: remove-member-test-v4
+    - name: service_account_name
+      value: service-account-for-remove-member-test-v4
+    - name: commandDir
+      value: "../../../../commands"
+    - name: gkoNamespace
+      value: default
+    - name: exportedApiYaml
+      value: exportedApi.yaml  
+
+  steps:
+  - name: remove-pre-existing-service-account
+    try:
+      - script:
+          env:
+            - name: COMMAND_DIR
+              value: ($commandDir)
+            - name: SERVICE_ACCOUNT_NAME
+              value: ($service_account_name)
+          content: |
+            npx zx $COMMAND_DIR/deleteServiceAccount.mjs --name "$SERVICE_ACCOUNT_NAME"
+
+  - name: create-new-service-account
+    try:
+      - script:
+          env:
+            - name: COMMAND_DIR
+              value: ($commandDir)
+            - name: SERVICE_ACCOUNT_NAME
+              value: ($service_account_name)
+          content: |
+            npx zx $COMMAND_DIR/createServiceAccount.mjs --name $SERVICE_ACCOUNT_NAME
+          check:
+              ($error): ~
+              (contains($stdout, '@graviteesource.com')): true
+    catch:
+      - podLogs:
+          selector: "app.kubernetes.io/component=api"
+          namespace: ($gkoNamespace)
+  
+  - name: create-api-with-new-member
+    try:
+      - apply:
+          file: v4-api-with-member.yaml
+      - assert:
+          resource:
+            apiVersion: gravitee.io/v1alpha1
+            kind: ApiV4Definition
+            metadata:
+              name: ($apiName)
+            spec:
+              members:
+                - source: gravitee
+                  sourceId: ($service_account_name)
+                  role: REVIEWER
+            status:
+              processingStatus: Completed
+    catch:
+      - events: {}
+
+  - name: update-api-with-removed-member
+    try:
+      - apply:
+          file: v4-api-without-member.yaml
+    catch:
+      - events: {}
+
+  - name: export-api-as-yaml
+    try:
+      - script:
+          env:
+            - name: COMMAND_DIR
+              value: ($commandDir)
+            - name: API_NAME
+              value: ($apiName)
+            - name: RESOURCE_NAMESPACE
+              value: ($namespace)
+            - name: EXPORTED_API_YAML
+              value: ($exportedApiYaml)
+          content: |
+            API_ID=$(kubectl get apiv4definitions.gravitee.io -n $RESOURCE_NAMESPACE $API_NAME -o jsonpath='{.status.id}')
+            npx zx $COMMAND_DIR/exportApiAsYaml.mjs --api_id $API_ID --api_version v4 > $EXPORTED_API_YAML
+
+  - name: assert-export-for-removed-member
+    try:
+      - script:
+          env:
+            - name: SERVICE_ACCOUNT_NAME
+              value: ($service_account_name)
+            - name: EXPORTED_API_YAML
+              value: ($exportedApiYaml)
+          content: |
+            echo "MEMBER_COUNT=$(yq '.spec.members | length' "$EXPORTED_API_YAML")"
+            rm -f "$EXPORTED_API_YAML"
+          check:
+            (contains($stdout, 'MEMBER_COUNT=0')): true

--- a/test/e2e/chainsaw/tests/apis/removingMember/v4/v4-api-with-member.yaml
+++ b/test/e2e/chainsaw/tests/apis/removingMember/v4/v4-api-with-member.yaml
@@ -1,0 +1,61 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: gravitee.io/v1alpha1
+kind: ApiV4Definition
+metadata:
+  name: remove-member-test-v4
+spec:
+  contextRef:
+    name: "dev-ctx"
+    namespace: "default"
+  name: "remove-member-test-v4"
+  description: "V4 API  with members managed by Gravitee Kubernetes Operator"
+  version: "1.0"
+  type: PROXY
+  state: STARTED
+  definitionContext:
+    origin: KUBERNETES
+    syncFrom: MANAGEMENT
+  listeners:
+    - type: HTTP
+      paths:
+        - path: "/remove-member-test-v4"
+      entrypoints:
+        - type: http-proxy
+          qos: AUTO
+  endpointGroups:
+    - name: Default HTTP proxy group
+      type: http-proxy
+      endpoints:
+        - name: Default HTTP proxy
+          type: http-proxy
+          inheritConfiguration: false
+          configuration:
+            target: https://api.gravitee.io/echo
+          secondary: false
+  flowExecution:
+    mode: DEFAULT
+    matchRequired: false
+  plans:
+    KeyLess:
+      name: "Free plan"
+      description: "This plan does not require any authentication"
+      security:
+        type: "KEY_LESS"
+  members:
+    - source: gravitee
+      sourceId: service-account-for-remove-member-test-v4
+      role: REVIEWER

--- a/test/e2e/chainsaw/tests/apis/removingMember/v4/v4-api-without-member.yaml
+++ b/test/e2e/chainsaw/tests/apis/removingMember/v4/v4-api-without-member.yaml
@@ -1,0 +1,58 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: gravitee.io/v1alpha1
+kind: ApiV4Definition
+metadata:
+  name: remove-member-test-v4
+spec:
+  contextRef:
+    name: "dev-ctx"
+    namespace: "default"
+  name: "remove-member-test-v4"
+  description: "V4 API  with members managed by Gravitee Kubernetes Operator"
+  version: "updated"
+  type: PROXY
+  state: STARTED
+  definitionContext:
+    origin: KUBERNETES
+    syncFrom: MANAGEMENT
+  listeners:
+    - type: HTTP
+      paths:
+        - path: "/remove-member-test-v4"
+      entrypoints:
+        - type: http-proxy
+          qos: AUTO
+  endpointGroups:
+    - name: Default HTTP proxy group
+      type: http-proxy
+      endpoints:
+        - name: Default HTTP proxy
+          type: http-proxy
+          inheritConfiguration: false
+          configuration:
+            target: https://api.gravitee.io/echo
+          secondary: false
+  flowExecution:
+    mode: DEFAULT
+    matchRequired: false
+  plans:
+    KeyLess:
+      name: "Free plan"
+      description: "This plan does not require any authentication"
+      security:
+        type: "KEY_LESS"
+  members: []


### PR DESCRIPTION
This PR adds a new end-to-end test to verify correct behavior when removing a member from an API definition.

see: https://gravitee.atlassian.net/browse/GKO-1404
