### PR TITLE
Deactivate migrated integration tests

### DIFF
--- a/test/integration/apidefinition/v2/create_withContext_andMemberWithoutRole_test.go
+++ b/test/integration/apidefinition/v2/create_withContext_andMemberWithoutRole_test.go
@@ -38,6 +38,9 @@ var _ = Describe("Update", labels.WithContext, func() {
 	ctx := context.Background()
 
 	It("should change the role of an API member", func() {
+		Skip(`
+			This test was migrated and moved to e2e test suite
+		`)
 		fixtures := fixture.
 			Builder().
 			WithAPI(constants.ApiWithMembersAndGroups).

--- a/test/integration/apidefinition/v2/update_withContext_changingMemberRole_test.go
+++ b/test/integration/apidefinition/v2/update_withContext_changingMemberRole_test.go
@@ -39,6 +39,9 @@ var _ = Describe("Update", labels.WithContext, func() {
 	ctx := context.Background()
 
 	It("should change the role of an API member", func() {
+		Skip(`
+			This test was migrated and moved to e2e test suite
+		`)
 		fixtures := fixture.
 			Builder().
 			WithAPI(constants.ApiWithMembersAndGroups).

--- a/test/integration/apidefinition/v2/update_withContext_removingMember_test.go
+++ b/test/integration/apidefinition/v2/update_withContext_removingMember_test.go
@@ -39,6 +39,9 @@ var _ = Describe("Update", labels.WithContext, func() {
 	ctx := context.Background()
 
 	It("should remove an API member", func() {
+		Skip(`
+			This test was migrated and moved to e2e test suite
+		`)
 		fixtures := fixture.
 			Builder().
 			WithAPI(constants.ApiWithMembersAndGroups).

--- a/test/integration/apidefinition/v4/create_withContext_andMemberWithoutRole_test.go
+++ b/test/integration/apidefinition/v4/create_withContext_andMemberWithoutRole_test.go
@@ -38,6 +38,9 @@ var _ = Describe("Create", labels.WithContext, func() {
 	ctx := context.Background()
 
 	It("should change the role of an API member", func() {
+		Skip(`
+			This test was migrated and moved to e2e test suite
+		`)
 		fixtures := fixture.
 			Builder().
 			WithAPIv4(constants.ApiV4).

--- a/test/integration/apidefinition/v4/update_withContext_changingMemberRole_test.go
+++ b/test/integration/apidefinition/v4/update_withContext_changingMemberRole_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Update", labels.WithContext, func() {
 
 	It("should change the role of an API member", func() {
 		Skip(`
-			This test has been skipped because it is flaky and will move to e2e suite
+			This test has been skipped because it is flaky and was migrated to e2e suite
 		`)
 
 		fixtures := fixture.

--- a/test/integration/apidefinition/v4/update_withContext_removingMember_test.go
+++ b/test/integration/apidefinition/v4/update_withContext_removingMember_test.go
@@ -39,6 +39,9 @@ var _ = Describe("Update", labels.WithContext, func() {
 	ctx := context.Background()
 
 	It("should remove an API member", func() {
+		Skip(`
+			This test was migrated and moved to e2e test suite
+		`)
 		fixtures := fixture.
 			Builder().
 			WithAPIv4(constants.ApiV4).


### PR DESCRIPTION
This PR updates the integration test suite by skipping tests that have already been migrated to the e2e test suite, as part of the completed migration of member-related Ginkgo tests.

See migration tickets:
- https://gravitee.atlassian.net/browse/GKO-1372
- https://gravitee.atlassian.net/browse/GKO-1402
- https://gravitee.atlassian.net/browse/GKO-1404
