### PR TITLE
test: add e2e test for starting a stopped v2 API

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -16,15 +16,13 @@ Install and have in PATH:
 
 A local kind cluster is used (created by provided make target).
 
-## 2. Install Chainsaw binary
+## 2. Install Go / helper tooling
 
-Install the Chainsaw test runner locally into the repository `bin/` directory:
+This installs required Go-based tools into `bin/` at repo root.
 
 ```sh
-GOBIN=$(pwd)/bin go install github.com/kyverno/chainsaw@v0.2.13
+make install-go-tools
 ```
-
-
 
 ## 3. Start a local cluster with APIM 
 
@@ -133,8 +131,8 @@ Recreate via section 3 when needed.
 ## 10. Summary of core commands
 
 ```sh
-# Install Chainsaw
-GOBIN=$(pwd)/bin go install github.com/kyverno/chainsaw@v0.2.13
+# Install tools
+make install-go-tools
 
 # Start cluster + APIM
 APIM_IMAGE_REGISTRY=graviteeio.azurecr.io APIM_IMAGE_TAG=master-latest make start-cluster

--- a/test/e2e/chainsaw/config.yaml
+++ b/test/e2e/chainsaw/config.yaml
@@ -28,7 +28,7 @@ spec:
     cleanup: 30s
     delete: 30s
     error: 30s
-    exec: 30s     
+    exec: 35s     
 # re-activate when reporting is fixed
   # report:
   #   format: XML

--- a/test/e2e/chainsaw/tests/apis/startStopApi/v2/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/tests/apis/startStopApi/v2/chainsaw-test.yaml
@@ -1,0 +1,94 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: v2-start-stopped-api
+spec:
+  bindings:
+    - name: apiName
+      value: start-stopped-api-test-v2
+    - name: commandDir
+      value: "../../../../commands"
+    - name: gkoNamespace
+      value: default
+
+  steps: 
+  - name: Deploy a started API
+    try:
+      - create:
+          file: v2-started-api.yaml
+    catch:
+      - events: {}
+
+  - name: Call started API and expect 200
+    try:
+        - script:
+            env:
+            - name: COMMAND_DIR
+              value: ($commandDir)
+            - name: API_NAME
+              value: ($apiName)
+            content: |
+              npx zx $COMMAND_DIR/callGateway.mjs --endpoint $API_NAME --status 200
+    catch:
+        - podLogs:
+            selector: "app.kubernetes.io/component=gateway"
+            namespace: ($gkoNamespace)
+
+  - name: Update as stopped API
+    try:
+      - apply:
+          file: v2-stopped-api.yaml
+    catch:
+      - events: {}
+
+  - name: Call stopped API and expect 404
+    try:
+        - script:
+            env:
+            - name: COMMAND_DIR
+              value: ($commandDir)
+            - name: API_NAME
+              value: ($apiName)
+            content: |
+              npx zx $COMMAND_DIR/callGateway.mjs --endpoint $API_NAME --status 404
+    catch:
+        - podLogs:
+            selector: "app.kubernetes.io/component=gateway"
+            namespace: ($gkoNamespace)
+
+  - name: Update a stopped API to started
+    try:
+      - apply:
+          file: v2-started-api.yaml
+    catch:
+      - events: {}
+
+  - name: Call re-started API and expect 200
+    try:
+        - script:
+            env:
+            - name: COMMAND_DIR
+              value: ($commandDir)
+            - name: API_NAME
+              value: ($apiName)
+            content: |
+              npx zx $COMMAND_DIR/callGateway.mjs --endpoint $API_NAME --status 200
+    catch:
+        - podLogs:
+            selector: "app.kubernetes.io/component=gateway"
+            namespace: ($gkoNamespace)

--- a/test/e2e/chainsaw/tests/apis/startStopApi/v2/v2-started-api.yaml
+++ b/test/e2e/chainsaw/tests/apis/startStopApi/v2/v2-started-api.yaml
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: gravitee.io/v1alpha1
+kind: ApiDefinition
+metadata:
+  name: start-stopped-api-test-v2
+spec:
+  state: STARTED
+  contextRef:
+    name: dev-ctx
+    namespace: default
+  name: "start-stopped-api-test-v2"
+  version: "started"
+  description: "Chainsaw E2E Test, testing the start and stop of APIs and their accessibility over the Gateway during these states"
+  plans:
+    - name: "KEY_LESS"
+      description: "FREE"
+      security: "KEY_LESS"
+  proxy:
+    virtual_hosts:
+      - path: "/start-stopped-api-test-v2"
+    groups:
+      - endpoints:
+          - name: "Default"
+            target: "https://api.gravitee.io/echo"
+  local: true

--- a/test/e2e/chainsaw/tests/apis/startStopApi/v2/v2-stopped-api.yaml
+++ b/test/e2e/chainsaw/tests/apis/startStopApi/v2/v2-stopped-api.yaml
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: gravitee.io/v1alpha1
+kind: ApiDefinition
+metadata:
+  name: start-stopped-api-test-v2
+spec:
+  state: STOPPED
+  contextRef:
+    name: dev-ctx
+    namespace: default
+  name: "start-stopped-api-test-v2"
+  version: "stopped"
+  description: "Chainsaw E2E Test, testing the start and stop of APIs and their accessibility over the Gateway during these states"
+  plans:
+    - name: "KEY_LESS"
+      description: "FREE"
+      security: "KEY_LESS"
+  proxy:
+    virtual_hosts:
+      - path: "/start-stopped-api-test-v2"
+    groups:
+      - endpoints:
+          - name: "Default"
+            target: "https://api.gravitee.io/echo"
+  local: true

--- a/test/e2e/chainsaw/tests/apis/startStopApi/v4/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/tests/apis/startStopApi/v4/chainsaw-test.yaml
@@ -1,0 +1,94 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: v4-start-stopped-api
+spec:
+  bindings:
+    - name: apiName
+      value: start-stopped-api-test-v4
+    - name: commandDir
+      value: "../../../../commands"
+    - name: gkoNamespace
+      value: default
+
+  steps: 
+  - name: Deploy a started API
+    try:
+      - create:
+          file: v4-started-api.yaml
+    catch:
+      - events: {}
+
+  - name: Call started API and expect 200
+    try:
+        - script:
+            env:
+            - name: COMMAND_DIR
+              value: ($commandDir)
+            - name: API_NAME
+              value: ($apiName)
+            content: |
+              npx zx $COMMAND_DIR/callGateway.mjs --endpoint $API_NAME --status 200
+    catch:
+        - podLogs:
+            selector: "app.kubernetes.io/component=gateway"
+            namespace: ($gkoNamespace)
+
+  - name: Update as stopped API
+    try:
+      - apply:
+          file: v4-stopped-api.yaml
+    catch:
+      - events: {}
+
+  - name: Call stopped API and expect 404
+    try:
+        - script:
+            env:
+            - name: COMMAND_DIR
+              value: ($commandDir)
+            - name: API_NAME
+              value: ($apiName)
+            content: |
+              npx zx $COMMAND_DIR/callGateway.mjs --endpoint $API_NAME --status 404
+    catch:
+        - podLogs:
+            selector: "app.kubernetes.io/component=gateway"
+            namespace: ($gkoNamespace)
+
+  - name: Update a stopped API to started
+    try:
+      - apply:
+          file: v4-started-api.yaml
+    catch:
+      - events: {}
+
+  - name: Call re-started API and expect 200
+    try:
+        - script:
+            env:
+            - name: COMMAND_DIR
+              value: ($commandDir)
+            - name: API_NAME
+              value: ($apiName)
+            content: |
+              npx zx $COMMAND_DIR/callGateway.mjs --endpoint $API_NAME --status 200
+    catch:
+        - podLogs:
+            selector: "app.kubernetes.io/component=gateway"
+            namespace: ($gkoNamespace)

--- a/test/e2e/chainsaw/tests/apis/startStopApi/v4/v4-started-api.yaml
+++ b/test/e2e/chainsaw/tests/apis/startStopApi/v4/v4-started-api.yaml
@@ -1,0 +1,58 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: gravitee.io/v1alpha1
+kind: ApiV4Definition
+metadata:
+  name: start-stopped-api-test-v4
+spec:
+  contextRef:
+    name: "dev-ctx"
+    namespace: "default"
+  name: "start-stopped-api-test-v4"
+  description: "Chainsaw E2E Test, testing the start and stop of APIs and their accessibility over the Gateway during these states"
+  version: "started"
+  type: PROXY
+  state: STARTED
+  definitionContext:
+    origin: KUBERNETES
+    syncFrom: MANAGEMENT
+  listeners:
+    - type: HTTP
+      paths:
+        - path: "/start-stopped-api-test-v4"
+      entrypoints:
+        - type: http-proxy
+          qos: AUTO
+  endpointGroups:
+    - name: Default HTTP proxy group
+      type: http-proxy
+      endpoints:
+        - name: Default HTTP proxy
+          type: http-proxy
+          inheritConfiguration: false
+          configuration:
+            target: https://api.gravitee.io/echo
+          secondary: false
+  flowExecution:
+    mode: DEFAULT
+    matchRequired: false
+  plans:
+    KeyLess:
+      name: "Free plan"
+      description: "This plan does not require any authentication"
+      security:
+        type: "KEY_LESS"
+  members: []

--- a/test/e2e/chainsaw/tests/apis/startStopApi/v4/v4-stopped-api.yaml
+++ b/test/e2e/chainsaw/tests/apis/startStopApi/v4/v4-stopped-api.yaml
@@ -1,0 +1,58 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: gravitee.io/v1alpha1
+kind: ApiV4Definition
+metadata:
+  name: start-stopped-api-test-v4
+spec:
+  contextRef:
+    name: "dev-ctx"
+    namespace: "default"
+  name: "start-stopped-api-test-v4"
+  description: "Chainsaw E2E Test, testing the start and stop of APIs and their accessibility over the Gateway during these states"
+  version: "stopped"
+  type: PROXY
+  state: STOPPED
+  definitionContext:
+    origin: KUBERNETES
+    syncFrom: MANAGEMENT
+  listeners:
+    - type: HTTP
+      paths:
+        - path: "/start-stopped-api-test-v4"
+      entrypoints:
+        - type: http-proxy
+          qos: AUTO
+  endpointGroups:
+    - name: Default HTTP proxy group
+      type: http-proxy
+      endpoints:
+        - name: Default HTTP proxy
+          type: http-proxy
+          inheritConfiguration: false
+          configuration:
+            target: https://api.gravitee.io/echo
+          secondary: false
+  flowExecution:
+    mode: DEFAULT
+    matchRequired: false
+  plans:
+    KeyLess:
+      name: "Free plan"
+      description: "This plan does not require any authentication"
+      security:
+        type: "KEY_LESS"
+  members: []

--- a/test/e2e/chainsaw/tests/setup/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/tests/setup/chainsaw-test.yaml
@@ -16,10 +16,25 @@ apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
   name: pre-test-setup
+  labels:
+    focus: "true"
 spec:
   concurrent: false            # Chainsaw always executes every non-concurrent test first
-  skipDelete: true           
+  skipDelete: true
+  bindings:
+    - name: gkoNamespace
+      value: default     
   steps:
+    - name: Verify a running operator
+      try:
+      - assert:
+          resource:
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              namespace: ($gkoNamespace)
+              labels:
+                control-plane: controller-manager
     - name: setup-management-context
       try:
       - apply:               

--- a/test/integration/apidefinition/v2/start_withContext_test.go
+++ b/test/integration/apidefinition/v2/start_withContext_test.go
@@ -39,6 +39,9 @@ var _ = Describe("Start", labels.WithContext, func() {
 	ctx := context.Background()
 
 	It("should start API", func() {
+		Skip(`
+			This test was migrated and moved to e2e test suite
+		`)
 		fixtures := fixture.Builder().
 			WithAPI(constants.ApiWithStateStopped).
 			WithContext(constants.ContextWithSecretFile).

--- a/test/integration/apidefinition/v2/stop_withContext_test.go
+++ b/test/integration/apidefinition/v2/stop_withContext_test.go
@@ -39,6 +39,9 @@ var _ = Describe("Stop", labels.WithContext, func() {
 	ctx := context.Background()
 
 	It("should start API", func() {
+		Skip(`
+			This test was migrated and moved to e2e test suite
+		`)
 		fixtures := fixture.Builder().
 			WithAPI(constants.Api).
 			WithContext(constants.ContextWithSecretFile).

--- a/test/integration/apidefinition/v4/start_withContext_test.go
+++ b/test/integration/apidefinition/v4/start_withContext_test.go
@@ -39,6 +39,9 @@ var _ = Describe("Start", labels.WithContext, func() {
 	ctx := context.Background()
 
 	It("should start API V4", func() {
+		Skip(`
+			This test was migrated and moved to e2e test suite
+		`)
 		fixtures := fixture.Builder().
 			WithAPIv4(constants.ApiV4WithStateStopped).
 			WithContext(constants.ContextWithSecretFile).

--- a/test/integration/apidefinition/v4/stop_withContext_test.go
+++ b/test/integration/apidefinition/v4/stop_withContext_test.go
@@ -39,6 +39,9 @@ var _ = Describe("Stop", labels.WithContext, func() {
 	ctx := context.Background()
 
 	It("should start API V4", func() {
+		Skip(`
+			This test was migrated and moved to e2e test suite
+		`)
 		fixtures := fixture.Builder().
 			WithAPIv4(constants.ApiV4).
 			WithContext(constants.ContextWithSecretFile).


### PR DESCRIPTION
This PR migrates the API start/stop tests for both v2 and v4 definitions from the integration test suite to the e2e test suite, adds new Chainsaw-based e2e tests for these scenarios, and updates setup and tooling instructions for running tests. 

See:
- https://gravitee.atlassian.net/browse/GKO-1405
- https://gravitee.atlassian.net/browse/GKO-1406