### PR TITLE
test: add delays to avoid test failures/flakiness

### DIFF
--- a/test/e2e/chainsaw/config.yaml
+++ b/test/e2e/chainsaw/config.yaml
@@ -20,6 +20,8 @@ metadata:
 spec:
   discovery:
     testFile: chainsaw-test
+  cleanup:
+    delayBeforeCleanup: 10s
   timeouts:
     apply: 30s
     assert: 30s

--- a/test/e2e/chainsaw/tests/apis/changingMemberRole/v2/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/tests/apis/changingMemberRole/v2/chainsaw-test.yaml
@@ -124,7 +124,9 @@ spec:
                   sourceId: ($service_account_name)
                   role: "REVIEWER"
             status:
-              processingStatus: Completed   
+              processingStatus: Completed
+      - sleep:
+          duration: 10s
     catch:
       - events: {}
     

--- a/test/e2e/chainsaw/tests/apis/removingMember/v2/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/tests/apis/removingMember/v2/chainsaw-test.yaml
@@ -17,6 +17,8 @@ apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
   name: v2-removing-member
+  labels:
+    focus: "true"
 spec:
   bindings:
     - name: apiName
@@ -84,6 +86,19 @@ spec:
     try:
       - apply:
           file: v2-api-without-member.yaml
+      - assert:
+          resource:
+            apiVersion: gravitee.io/v1alpha1
+            kind: ApiDefinition
+            metadata:
+              name: ($apiName)
+            spec:
+              version: "update"
+              members: []
+            status:
+              processingStatus: Completed
+      - sleep:
+          duration: 10s
     catch:
       - events: {}
 

--- a/test/e2e/chainsaw/tests/apis/removingMember/v2/v2-api-without-member.yaml
+++ b/test/e2e/chainsaw/tests/apis/removingMember/v2/v2-api-without-member.yaml
@@ -21,7 +21,7 @@ spec:
   contextRef:
     name: dev-ctx
   name: "remove-member-test-v2"
-  version: "updated"
+  version: "update"
   description: "API with groups and members Gravitee Kubernetes Operator sample"
   plans:
     - name: "KEY_LESS"

--- a/test/e2e/chainsaw/tests/apis/removingMember/v4/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/tests/apis/removingMember/v4/chainsaw-test.yaml
@@ -84,6 +84,19 @@ spec:
     try:
       - apply:
           file: v4-api-without-member.yaml
+      - assert:
+          resource:
+            apiVersion: gravitee.io/v1alpha1
+            kind: ApiV4Definition
+            metadata:
+              name: ($apiName)
+            spec:
+              version: "update"
+              members: []
+            status:
+              processingStatus: Completed
+      - sleep:
+          duration: 10s
     catch:
       - events: {}
 

--- a/test/e2e/chainsaw/tests/apis/removingMember/v4/v4-api-without-member.yaml
+++ b/test/e2e/chainsaw/tests/apis/removingMember/v4/v4-api-without-member.yaml
@@ -23,7 +23,7 @@ spec:
     namespace: "default"
   name: "remove-member-test-v4"
   description: "V4 API  with members managed by Gravitee Kubernetes Operator"
-  version: "updated"
+  version: "update"
   type: PROXY
   state: STARTED
   definitionContext:


### PR DESCRIPTION
This PR updates several Chainsaw e2e test configurations to improve reliability and add more precise assertions. The main changes include adding cleanup delays, introducing sleep steps to ensure stable test execution, and enhancing test assertions for member removal scenarios.