### PR TITLE
refactor: move up config check for dynamic apis retrieval

### DIFF
--- a/internal/admission/api/base/paths.go
+++ b/internal/admission/api/base/paths.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 
 	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/core"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/env"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/errors"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/k8s"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/k8s/dynamic"
@@ -75,8 +76,12 @@ func FindConflictingPath(ctx context.Context, api core.ApiDefinitionObject) (Con
 
 func getExistingPaths(ctx context.Context, api core.ApiDefinitionObject) ([]Conflict, error) {
 	existingPaths := make([]Conflict, 0)
+	lookupNs := api.GetNamespace()
+	if env.Config.CheckApiContextPathConflictInCluster {
+		lookupNs = ""
+	}
 	apis, err := dynamic.GetAPIs(ctx, dynamic.ListOptions{
-		Namespace: api.GetNamespace(),
+		Namespace: lookupNs,
 		Excluded: []core.ObjectRef{
 			api.GetRef(),
 		},

--- a/internal/k8s/dynamic/apis.go
+++ b/internal/k8s/dynamic/apis.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/gravitee-io/gravitee-kubernetes-operator/api/v1alpha1"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/core"
-	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/env"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -118,9 +117,6 @@ func isExcluded(item unstructured.Unstructured, opts ListOptions) bool {
 }
 
 func getAPIsResource(gvr schema.GroupVersionResource, ns string) dynamic.ResourceInterface {
-	if env.Config.CheckApiContextPathConflictInCluster {
-		return getResource(gvr, "")
-	}
 	return getResource(gvr, ns)
 }
 


### PR DESCRIPTION
This move the check checking for conflicting path up to the actual business method.

One of the reason is it might prove useful when we implement cross routes matching for the gateway API. The other one is that it makes the interface of `dynamic.GetAPIs` cleaner (the namespace is already defined in the list options)