### PR TITLE
E2e local false test

### DIFF
--- a/test/e2e/chainsaw/tests/apis/localFalse/v2/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/tests/apis/localFalse/v2/chainsaw-test.yaml
@@ -1,0 +1,66 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: local-false-test-v2
+spec:
+  bindings:
+    - name: apiName
+      value: v2-api-with-local-false
+    - name: commandDir
+      value: "../../../../commands"
+    - name: gkoNamespace
+      value: default
+
+  steps:
+  - name: Create API with local=false
+    try:
+      - create:
+          file: v2-api-with-local-false.yml
+      - wait:
+          apiVersion: gravitee.io/v1alpha1
+          kind: ApiDefinition
+          name: ($apiName)
+          for:
+            condition:
+              name: Accepted
+              value: "True"
+
+  - name: Config Map should not exist
+    try:
+      - error:
+          resource:
+            apiVersion: v1
+            kind: ConfigMap
+            metadata:
+              name: ($apiName)
+              namespace: ($namespace)
+
+  - name: Call started API and expect 200
+    try:
+        - script:
+            env:
+            - name: COMMAND_DIR
+              value: ($commandDir)
+            - name: API_NAME
+              value: ($apiName)
+            content: |
+              npx zx $COMMAND_DIR/callGateway.mjs --endpoint $API_NAME --status 200
+    catch:
+        - podLogs:
+            selector: "app.kubernetes.io/component=gateway"
+            namespace: ($gkoNamespace)

--- a/test/e2e/chainsaw/tests/apis/localFalse/v2/v2-api-with-local-false.yml
+++ b/test/e2e/chainsaw/tests/apis/localFalse/v2/v2-api-with-local-false.yml
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: gravitee.io/v1alpha1
+kind: ApiDefinition
+metadata:
+  name: v2-api-with-local-false
+spec:
+  contextRef:
+    name: dev-ctx
+    namespace: default
+  name: v2-api-with-local-false
+  version: "1.1"
+  description: "Deploying API with local false - Created by Chainsaw E2E test"
+  plans:
+    - name: "KEY_LESS"
+      description: "FREE"
+      security: "KEY_LESS"
+  proxy:
+    virtual_hosts:
+      - path: "/v2-api-with-local-false"
+    groups:
+      - endpoints:
+          - name: "Default"
+            target: "https://api.gravitee.io/echo"
+  local: false
+  notifyMembers: false

--- a/test/e2e/chainsaw/tests/apis/localFalse/v4/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/tests/apis/localFalse/v4/chainsaw-test.yaml
@@ -1,0 +1,66 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: local-false-test-v4
+spec:
+  bindings:
+    - name: apiName
+      value: v4-api-with-local-false
+    - name: commandDir
+      value: "../../../../commands"
+    - name: gkoNamespace
+      value: default
+
+  steps:
+  - name: Create API with local=false
+    try:
+      - create:
+          file: v4-api-with-local-false.yml
+      - wait:
+          apiVersion: gravitee.io/v1alpha1
+          kind: ApiV4Definition
+          name: ($apiName)
+          for:
+            condition:
+              name: Accepted
+              value: "True"
+
+  - name: Config Map should not exist
+    try:
+      - error:
+          resource:
+            apiVersion: v1
+            kind: ConfigMap
+            metadata:
+              name: ($apiName)
+              namespace: ($namespace)
+
+  - name: Call started API and expect 200
+    try:
+        - script:
+            env:
+            - name: COMMAND_DIR
+              value: ($commandDir)
+            - name: API_NAME
+              value: ($apiName)
+            content: |
+              npx zx $COMMAND_DIR/callGateway.mjs --endpoint $API_NAME --status 200
+    catch:
+        - podLogs:
+            selector: "app.kubernetes.io/component=gateway"
+            namespace: ($gkoNamespace)

--- a/test/e2e/chainsaw/tests/apis/localFalse/v4/v4-api-with-local-false.yml
+++ b/test/e2e/chainsaw/tests/apis/localFalse/v4/v4-api-with-local-false.yml
@@ -1,0 +1,58 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: gravitee.io/v1alpha1
+kind: ApiV4Definition
+metadata:
+  name: v4-api-with-local-false
+spec:
+  contextRef:
+    name: "dev-ctx"
+    namespace: "default"
+  name: "api-v4-with-one-group"
+  description: "Deploying API with a group - Created by Chainsaw E2E test"
+  version: "1.0"
+  type: PROXY
+  state: STARTED
+  definitionContext:
+    origin: KUBERNETES
+    syncFrom: MANAGEMENT
+  listeners:
+    - type: HTTP
+      paths:
+        - path: "/v4-api-with-local-false"
+      entrypoints:
+        - type: http-proxy
+          qos: AUTO
+  endpointGroups:
+    - name: Default HTTP proxy group
+      type: http-proxy
+      endpoints:
+        - name: Default HTTP proxy
+          type: http-proxy
+          inheritConfiguration: false
+          configuration:
+            target: https://api.gravitee.io/echo
+          secondary: false
+  flowExecution:
+    mode: DEFAULT
+    matchRequired: false
+  plans:
+    KeyLess:
+      name: "Free plan"
+      description: "This plan does not require any authentication"
+      security:
+        type: "KEY_LESS"
+

--- a/test/integration/apidefinition/v2/create_withContext_andLocalFalse_test.go
+++ b/test/integration/apidefinition/v2/create_withContext_andLocalFalse_test.go
@@ -40,6 +40,10 @@ var _ = Describe("Create", labels.WithContext, func() {
 	ctx := context.Background()
 
 	It("should not create a config map and sync from management API", func() {
+		Skip(`
+			This test was migrated and moved to e2e test suite
+		`)
+
 		fixtures := fixture.Builder().
 			WithAPI(constants.ApiWithSyncFromAPIM).
 			WithContext(constants.ContextWithSecretFile).

--- a/test/integration/apidefinition/v4/create_withContext_andLocalFalse_test.go
+++ b/test/integration/apidefinition/v4/create_withContext_andLocalFalse_test.go
@@ -40,6 +40,10 @@ var _ = Describe("Create", labels.WithContext, func() {
 	ctx := context.Background()
 
 	It("should not create a config map and sync from management API", func() {
+		Skip(`
+			This test was migrated and moved to e2e test suite
+		`)
+
 		fixtures := fixture.Builder().
 			WithAPIv4(constants.ApiV4WithSyncFromAPIM).
 			WithContext(constants.ContextWithSecretFile).


### PR DESCRIPTION
This PR migrates integration tests for APIs with `local: false` (`syncFrom: MANAGEMENT` for v4)  from the integration test suite to the e2e test suite. 

See: https://gravitee.atlassian.net/browse/GKO-1482