### PR TITLE
docs: add example of api v4 with shared endpoint config

### DIFF
--- a/examples/apim/api_definition/v4/api-v4-with-shared-endpoint-configuration.yml
+++ b/examples/apim/api_definition/v4/api-v4-with-shared-endpoint-configuration.yml
@@ -1,0 +1,91 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: "gravitee.io/v1alpha1"
+kind: "ApiV4Definition"
+metadata:
+  name: "shared-endpoint-configuration"
+spec:
+  contextRef:
+    name: dev-ctx
+  name: "shared-endpoint-configuration"
+  version: "1"
+  type: "PROXY"
+  description: "Endpoints inheriting their configuration from their endpoint group"
+  listeners:
+  - type: "HTTP"
+    paths:
+    - path: "/echo-shared/"
+      overrideAccess: false
+    entrypoints:
+    - type: "http-proxy"
+      qos: "AUTO"
+  endpointGroups:
+  - name: "Default HTTP proxy group"
+    type: "http-proxy"
+    loadBalancer:
+      type: "ROUND_ROBIN"
+    sharedConfiguration:
+      proxy:
+        useSystemProxy: false
+        enabled: false
+      http:
+        keepAliveTimeout: 30000
+        keepAlive: true
+        propagateClientHost: false
+        followRedirects: false
+        readTimeout: 10000
+        idleTimeout: 60000
+        connectTimeout: 3000
+        useCompression: true
+        maxConcurrentConnections: 20
+        version: "HTTP_1_1"
+        pipelining: false
+      ssl:
+        keyStore:
+          type: ""
+        hostnameVerifier: true
+        trustStore:
+          type: ""
+        trustAll: false
+    endpoints:
+    - name: "echo-1"
+      type: "http-proxy"
+      weight: 1
+      inheritConfiguration: true
+      configuration:
+        target: "https://api.gravitee.io/echo"
+      services: {}
+      secondary: false
+    - name: "echo-2"
+      type: "http-proxy"
+      weight: 1
+      inheritConfiguration: true
+      configuration:
+        target: "https://api.gravitee.io/echo"
+      services: {}
+      secondary: false
+  plans:
+    KeyLess:
+      name: "Free plan"
+      description: "Free unsecured plan"
+      security:
+        type: "KEY_LESS"
+      order: 1
+      status: "PUBLISHED"
+      type: "API"
+      validation: "MANUAL"
+      mode: "STANDARD"
+


### PR DESCRIPTION
We had a question coming from a user about the shared configuration object