### PR TITLE
ci: fix jira query for changelog generation

### DIFF
--- a/hack/scripts/generate-changelog.mjs
+++ b/hack/scripts/generate-changelog.mjs
@@ -74,11 +74,16 @@ async function getJiraVersion(versionName) {
 }
 
 async function getJiraIssues(versionId) {
-  const query = `jql=project=${JIRA_PROJECT} AND fixVersion=${versionId}`;
-
-  const issues = await fetch(`${JIRA_BASE}/search?${query}`, {
-    method: "GET",
-    headers: JIRA_HEADERS,
+  const issues = await fetch("${JIRA_BASE}/search/jql", {
+    method: "POST",
+    headers: {
+      ...JIRA_HEADERS,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      jql: `project = ${JIRA_PROJECT} AND fixVersion = "${versionId}"`,
+      fields: ["issuetype", "summary", "components", "customfield_10115"],
+    }),
   })
     .then((response) => response.json())
     .then((body) => body.issues);


### PR DESCRIPTION
During last APIM / GKO releases, change log generation failed. 

Apparently there is a breaking change in Jira REST API v3 that leads to an error when we query Jira to get the support issues that should be included in the change log.

This PR replicates what as been done for APIM in https://github.com/gravitee-io/gravitee-api-management/pull/13225 in our release pipeline.