### PR TITLE
fix: add gateway RBAC to APIM values

### DIFF
--- a/hack/kind/apim/values.yaml
+++ b/hack/kind/apim/values.yaml
@@ -77,6 +77,8 @@ gateway:
     enabled: false
   ingressController:
     enabled: true
+  deployment:
+    serviceAccount: gravitee-gateway
   servers:
     - type: http
       port: 8082
@@ -105,6 +107,7 @@ gateway:
     sync:
       kubernetes:
         enabled: true
+        namespaces: ALL
   reporters:
     elasticsearch:
       enabled: false
@@ -131,3 +134,32 @@ installation:
     proxyPath:
       management: /management
       portal: /portal
+
+extraObjects:
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: gravitee-gateway
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: gravitee-gateway-role
+    rules:
+      - apiGroups: [""]
+        resources: ["configmaps", "secrets"]
+        verbs: ["get", "watch", "list"]
+      - apiGroups: ["gravitee.io"]
+        resources: ["apidefinitions"]
+        verbs: ["get", "watch", "list"]
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: gravitee-gateway-binding
+    subjects:
+      - kind: ServiceAccount
+        name: gravitee-gateway
+        namespace: default
+    roleRef:
+      kind: ClusterRole
+      name: gravitee-gateway-role
+      apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This PR updates the `hack/kind/apim/values.yaml` to set up RBAC resources and configuring the gateway to watch all namespaces for Kubernetes synchronization.

A CI job in CircleCI was failing on the "Update template and ingress" test with a 502 Bad Gateway. This most likely happened because values.yaml lacked the gateway ServiceAccount + RBAC that values-dbless.yaml already had. 
Without get/watch/list permissions on ConfigMaps and ApiDefinitions CRDs, the gateway couldn't detect ConfigMap updates when a template changed, causing it return 502.


