### PR TITLE
feat: allow http route to shortcut api controller

### DIFF
--- a/api/model/api/base/plan.go
+++ b/api/model/api/base/plan.go
@@ -66,6 +66,9 @@ func NewPlan() *Plan {
 	return &Plan{
 		Tags:            []string{},
 		Characteristics: []string{},
+		Status:          PublishedPlanStatus,
+		Validation:      "AUTO",
+		Type:            "API",
 	}
 }
 

--- a/api/model/api/v4/plan.go
+++ b/api/model/api/v4/plan.go
@@ -81,7 +81,11 @@ func (plan *Plan) GetSecurityType() string {
 
 func NewPlan() *Plan {
 	return &Plan{
-		Plan: base.NewPlan(),
+		Plan:              base.NewPlan(),
+		DefinitionVersion: PlanDefinitionVersion,
+		Mode:              "STANDARD",
+		Flows:             []*Flow{},
+		ExcludedGroups:    []string{},
 	}
 }
 

--- a/controllers/gateway-api/httproute/controller.go
+++ b/controllers/gateway-api/httproute/controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gravitee-io/gravitee-kubernetes-operator/controllers/gateway-api/httproute/internal"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/controllers/gateway-api/httproute/internal/mapper"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/core"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/env"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/event"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/k8s"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/log"
@@ -99,8 +100,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 				ctx = mapper.WithGatewayCache(ctx, mapper.GatewayCache(cache))
 
-				if err := internal.Program(ctx, dc); err != nil {
-					return err
+				if env.Config.GatewayAPISkipAPIDefinition {
+					if err := internal.ProgramConfigMap(ctx, dc); err != nil {
+						return err
+					}
+				} else {
+					if err := internal.Program(ctx, dc); err != nil {
+						return err
+					}
 				}
 				return nil
 			})

--- a/controllers/gateway-api/httproute/internal/mapper/mapper.go
+++ b/controllers/gateway-api/httproute/internal/mapper/mapper.go
@@ -105,9 +105,7 @@ func buildAPIName(route *gwAPIv1.HTTPRoute) string {
 }
 
 func newKeyLessPlan() *v4.Plan {
-	plan := v4.NewPlan().WithSecurity(&keyLessSecurity)
-	plan.Status = base.PublishedPlanStatus
-	return plan
+	return v4.NewPlan().WithSecurity(&keyLessSecurity)
 }
 
 func buildTags(route *gwAPIv1.HTTPRoute) []string {

--- a/controllers/gateway-api/httproute/internal/program.go
+++ b/controllers/gateway-api/httproute/internal/program.go
@@ -16,13 +16,36 @@ package internal
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
 
 	"github.com/gravitee-io/gravitee-kubernetes-operator/controllers/gateway-api/httproute/internal/mapper"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/core"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/k8s"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/uuid"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwAPIv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const (
+	configMapPrefix    = "httproute-"
+	maxK8sNameLength   = 253
+	hashSuffixLength   = 8
+	definitionKey      = "definition"
+	apiDefVersionKey   = "apiDefinitionVersion"
+	apiDefVersionValue = "4.0.0"
+	orgKey             = "organizationId"
+	envKey             = "environmentId"
+	defaultOrgID       = "DEFAULT"
+	defaultEnvID       = "DEFAULT"
+	managedByKey       = "managed-by"
+	gioTypeKey         = "gio-type"
 )
 
 func Program(ctx context.Context, route *gwAPIv1.HTTPRoute) error {
@@ -45,6 +68,75 @@ func Program(ctx context.Context, route *gwAPIv1.HTTPRoute) error {
 			return nil
 		})
 	})
+}
+
+// ProgramConfigMap creates a ConfigMap directly from the HTTPRoute, bypassing
+// the intermediate ApiV4Definition CR. This frees the CR name so a user-managed
+// ApiV4Definition with the same name can coexist.
+func ProgramConfigMap(ctx context.Context, route *gwAPIv1.HTTPRoute) error {
+	api, err := mapper.Map(ctx, route)
+	if err != nil {
+		return err
+	}
+
+	api.Spec.ID = uuid.FromStrings(string(route.UID))
+	api.Spec.CrossID = uuid.FromStrings(route.Namespace, route.Name)
+
+	if api.Spec.Plans != nil {
+		for key, plan := range *api.Spec.Plans {
+			plan.ID = uuid.FromStrings(api.Spec.ID, key)
+		}
+	}
+
+	gwDef := api.Spec.Api.ToGatewayDefinition()
+	jsonSpec, err := json.Marshal(gwDef)
+	if err != nil {
+		return err
+	}
+
+	cm := &v1.ConfigMap{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:            buildConfigMapName(route),
+			Namespace:       route.Namespace,
+			OwnerReferences: getOwnerReferences(route),
+			Labels: map[string]string{
+				managedByKey: core.CRDGroup,
+				gioTypeKey:   core.CRDApiDefinitionResource + "." + core.CRDGroup,
+			},
+		},
+		Data: map[string]string{
+			definitionKey:    string(jsonSpec),
+			apiDefVersionKey: apiDefVersionValue,
+			orgKey:           defaultOrgID,
+			envKey:           defaultEnvID,
+		},
+	}
+
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		existing := &v1.ConfigMap{}
+		err := k8s.GetClient().Get(ctx, client.ObjectKeyFromObject(cm), existing)
+		if errors.IsNotFound(err) {
+			return k8s.GetClient().Create(ctx, cm)
+		}
+		if err != nil {
+			return err
+		}
+		existing.Labels = cm.Labels
+		existing.Data = cm.Data
+		existing.SetOwnerReferences(cm.GetOwnerReferences())
+		return k8s.GetClient().Update(ctx, existing)
+	})
+}
+
+func buildConfigMapName(route *gwAPIv1.HTTPRoute) string {
+	name := configMapPrefix + route.Name
+	if len(name) <= maxK8sNameLength {
+		return name
+	}
+	h := sha256.Sum256([]byte(route.Name))
+	suffix := hex.EncodeToString(h[:])[:hashSuffixLength]
+	truncateAt := maxK8sNameLength - len(configMapPrefix) - 1 - hashSuffixLength
+	return fmt.Sprintf("%s%s-%s", configMapPrefix, route.Name[:truncateAt], suffix)
 }
 
 func getOwnerReferences(httpRoute *gwAPIv1.HTTPRoute) []metaV1.OwnerReference {

--- a/controllers/gateway-api/kafkaroute/internal/mapper/mapper.go
+++ b/controllers/gateway-api/kafkaroute/internal/mapper/mapper.go
@@ -109,7 +109,5 @@ func buildTag(route *v1alpha1.KafkaRoute, ref gwAPIv1.ParentReference) string {
 }
 
 func newKeyLessPlan() *v4.Plan {
-	plan := v4.NewPlan().WithSecurity(&keyLessSecurity)
-	plan.Status = base.PublishedPlanStatus
-	return plan
+	return v4.NewPlan().WithSecurity(&keyLessSecurity)
 }

--- a/docs/guides/gateway-api-with-apim-gateway/README.md
+++ b/docs/guides/gateway-api-with-apim-gateway/README.md
@@ -1,0 +1,213 @@
+# Using the Gateway API with a Dedicated APIM Gateway
+
+This guide describes how to use the Kubernetes Gateway API for ingress traffic routing while delegating API management concerns (policies, plans, subscriptions, analytics, etc.) to a dedicated Gravitee APIM gateway.
+
+## Overview
+
+In this architecture, two gateways work together:
+
+- A **Gateway API gateway** deployed by the Gravitee Kubernetes Operator handles incoming
+  traffic and routes it based on standard `HTTPRoute` resources.
+- A **dedicated APIM gateway** deployed via Helm handles the heavy lifting: policy
+  enforcement, plan-based access control, rate limiting, subscriptions, and analytics
+  reporting.
+
+```
+                                        ┌─────────────────────┐
+  Client ─── HTTPRoute ───▶  Gateway API Gateway  ───▶  APIM Gateway  ───▶  Backend
+              (ingress)      (routing only)              (policies,         (httpbin, etc.)
+                                                          plans, etc.)
+                                        └─────────────────────┘
+```
+
+The HTTPRoute defines the ingress path and hostname, then forwards traffic to the APIM
+gateway service. An `ApiV4Definition` with the same name defines the actual API behavior
+(listeners, endpoints, plans, flows) on the APIM gateway.
+
+## Prerequisites
+
+- A Kubernetes cluster with the Gravitee Kubernetes Operator installed
+- An APIM gateway deployed via the Gravitee Helm chart
+- A `ManagementContext` resource configured to connect the operator to the APIM
+  management API
+
+## Configuration
+
+### 1. Enable `skipAPIDefinition` in GKO Helm values
+
+By default, the HTTPRoute reconciler creates an intermediate `ApiV4Definition` CR with the same name as the route. This conflicts with user-managed API definitions that share that name. Setting `skipAPIDefinition` to `true` makes the reconciler write a ConfigMap instead, leaving the CR name available for your own `ApiV4Definition`.
+
+```yaml
+gatewayAPI:
+  controller:
+    enabled: true
+    skipAPIDefinition: true
+```
+
+### 2. Prevent the APIM gateway from loading Gateway API definitions
+
+The ConfigMap created by the HTTPRoute reconciler contains an API definition tagged with
+the Gateway resource name (e.g. `gravitee/gravitee-gateway`). If the APIM gateway has
+Kubernetes sync enabled and no tag filtering, it will deploy this definition. Because the
+API's backend points back to the APIM gateway service itself (from the HTTPRoute
+`backendRef`), this creates a self-referencing loop that results in a 504 timeout.
+
+#### Option A: Disable Kubernetes sync (recommended)
+
+If the APIM gateway only needs to sync API definitions from the management API (which is the typical setup), disable Kubernetes sync entirely:
+
+```yaml
+# APIM Helm values
+gateway:
+  services:
+    sync:
+      kubernetes:
+        enabled: false
+```
+
+This is the simplest and safest default for a dedicated APIM gateway that receives its
+API definitions through a `ManagementContext`.
+
+#### Option B: Use sharding tags
+
+If the APIM gateway needs Kubernetes sync enabled for other purposes (e.g. other
+ConfigMap-based API definitions), use sharding tags to exclude Gateway API definitions:
+
+```yaml
+# APIM Helm values
+gateway:
+  sharding_tags: "!gravitee/gravitee-gateway"
+  services:
+    sync:
+      kubernetes:
+        enabled: true
+```
+
+The `!` prefix tells the gateway to exclude APIs tagged with
+`gravitee/gravitee-gateway`, while still allowing other ConfigMap-based definitions
+through.
+
+### 3. Deploy the Gateway API resources
+
+Apply the `GatewayClass`, `GatewayClassParameters`, and `Gateway`:
+
+```yaml
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: gravitee-gateway
+spec:
+  controllerName: apim.gravitee.io/gateway
+  parametersRef:
+    kind: GatewayClassParameters
+    group: gravitee.io
+    name: gravitee-gateway
+    namespace: gravitee
+```
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gravitee-gateway
+spec:
+  gatewayClassName: gravitee-gateway
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+```
+
+### 4. Define the HTTPRoute and ApiV4Definition together
+
+Both resources share the same `metadata.name`. The HTTPRoute handles ingress routing to the APIM gateway, and the `ApiV4Definition` configures the API behavior on it.
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: echo
+spec:
+  parentRefs:
+    - name: gravitee-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+      namespace: gravitee
+  hostnames:
+    - echo.apis.example.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /echo
+      backendRefs:
+        - kind: Service
+          group: ""
+          name: apim-gateway
+          port: 82
+---
+apiVersion: gravitee.io/v1alpha1
+kind: ApiV4Definition
+metadata:
+  name: echo
+spec:
+  contextRef:
+    name: "dev-ctx"
+  name: "echo"
+  description: "Echo API managed by Gravitee Kubernetes Operator"
+  version: "1.0"
+  type: PROXY
+  state: STARTED
+  listeners:
+    - type: HTTP
+      paths:
+        - path: "/echo/"
+          host: echo.apis.example.dev
+      entrypoints:
+        - type: http-proxy
+          qos: AUTO
+  endpointGroups:
+    - name: Default HTTP proxy group
+      type: http-proxy
+      endpoints:
+        - name: Default HTTP proxy
+          type: http-proxy
+          inheritConfiguration: false
+          configuration:
+            target: http://httpbin-1.gravitee.svc.cluster.local:8080
+          secondary: false
+          sharedConfigurationOverride:
+            http:
+              propagateClientHost: false
+  flowExecution:
+    mode: DEFAULT
+    matchRequired: false
+  plans:
+    KeyLess:
+      name: "Free plan"
+      description: "This plan does not require any authentication"
+      security:
+        type: "KEY_LESS"
+  notifyMembers: false
+```
+
+Key points:
+
+- The **HTTPRoute** `backendRef` targets the APIM gateway service (`apim-gateway:82`).
+  The Gateway API gateway will forward matching requests there.
+- The **ApiV4Definition** uses a `contextRef` to sync the API through the APIM management
+  plane. The APIM gateway picks it up through its regular sync mechanism and handles
+  policy enforcement, plan validation, and backend proxying.
+- The listener `host` in the `ApiV4Definition` must match the HTTPRoute `hostname` so
+  the APIM gateway can match incoming requests by virtual host.
+
+## Request flow
+
+1. A client sends `GET /echo/hostname` with `Host: echo.apis.example.dev`
+2. The **Gateway API gateway** matches the request via the HTTPRoute and proxies it to
+   `apim-gateway:82`
+3. The **APIM gateway** matches the request against the `echo` API (by path and virtual
+   host), applies plans and policies, then proxies to the backend
+   (`httpbin-1.gravitee.svc.cluster.local:8080`)
+4. The backend responds and the response flows back through both gateways to the client
+

--- a/helm/gko/README.md
+++ b/helm/gko/README.md
@@ -132,10 +132,11 @@ When storing templates stored in config maps, the config map should contain a co
 Configure Kubernetes Gateway API support.
 
 
-| Name                            | Description                                                  | Value   |
-| ------------------------------- | ------------------------------------------------------------ | ------- |
-| `gatewayAPI.applyCRDs`          | If true, the manager will apply Gateway API CRDs on startup. | `true`  |
-| `gatewayAPI.controller.enabled` | Set to true to enable experimental gateway api support.      | `false` |
+| Name                                      | Description                                                                                                                                                         | Value   |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `gatewayAPI.applyCRDs`                    | If true, the manager will apply Gateway API CRDs on startup.                                                                                                        | `true`  |
+| `gatewayAPI.controller.enabled`           | Set to true to enable experimental gateway api support.                                                                                                             | `false` |
+| `gatewayAPI.controller.skipAPIDefinition` | If true, the HTTPRoute reconciler creates a ConfigMap directly instead of an intermediate ApiV4Definition CR, freeing the CR name for user-managed API definitions. | `false` |
 
 ### HTTP Client
 

--- a/helm/gko/templates/manager/config.yaml
+++ b/helm/gko/templates/manager/config.yaml
@@ -71,6 +71,9 @@ data:
   {{- if .Values.gatewayAPI.controller.enabled }}
   ENABLE_GATEWAY_API: "true"
   {{- end }}
+  {{- if .Values.gatewayAPI.controller.skipAPIDefinition }}
+  GATEWAY_API_SKIP_API_DEFINITION: "true"
+  {{- end }}
   {{- if .Values.gatewayAPI.applyCRDs }}
   APPLY_GATEWAY_API_CRDS: "true"
   {{- end }}

--- a/helm/gko/values.yaml
+++ b/helm/gko/values.yaml
@@ -234,6 +234,8 @@ gatewayAPI:
   controller:
     ## @param gatewayAPI.controller.enabled Set to true to enable experimental gateway api support.
     enabled: false
+    ## @param gatewayAPI.controller.skipAPIDefinition If true, the HTTPRoute reconciler creates a ConfigMap directly instead of an intermediate ApiV4Definition CR, freeing the CR name for user-managed API definitions.
+    skipAPIDefinition: false
 
 ## @section HTTP Client
 ## @descriptionStart

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -38,6 +38,7 @@ const (
 	EnableIngress                        = "ENABLE_INGRESS"
 	EnableWebhook                        = "ENABLE_WEBHOOK"
 	EnableGatewayAPI                     = "ENABLE_GATEWAY_API"
+	GatewayAPISkipAPIDefinition          = "GATEWAY_API_SKIP_API_DEFINITION"
 	ApplyGatewayAPICRDs                  = "APPLY_GATEWAY_API_CRDS"
 	WebhookNS                            = "WEBHOOK_NAMESPACE"
 	WebhookServiceName                   = "WEBHOOK_SERVICE_NAME"
@@ -93,6 +94,7 @@ var Config = struct {
 	EnableIngress                        bool
 	EnableWebhook                        bool
 	EnableGatewayAPI                     bool
+	GatewayAPISkipAPIDefinition          bool
 	ApplyGatewayAPICRDs                  bool
 	WebhookNS                            string
 	WebhookService                       string
@@ -152,6 +154,7 @@ func init() {
 	Config.EnableIngress = os.Getenv(EnableIngress) == TrueString
 	Config.EnableWebhook = os.Getenv(EnableWebhook) == TrueString
 	Config.EnableGatewayAPI = os.Getenv(EnableGatewayAPI) == TrueString
+	Config.GatewayAPISkipAPIDefinition = os.Getenv(GatewayAPISkipAPIDefinition) == TrueString
 	Config.ApplyGatewayAPICRDs = os.Getenv(ApplyGatewayAPICRDs) == TrueString
 	Config.WebhookNS = os.Getenv(WebhookNS)
 	Config.WebhookService = os.Getenv(WebhookServiceName)

--- a/test/conformance/operator.values.yaml
+++ b/test/conformance/operator.values.yaml
@@ -15,6 +15,7 @@
 gatewayAPI:
   controller:
     enabled: true
+    skipAPIDefinition: true
 
 manager:
   image:


### PR DESCRIPTION
The idea is to allow users to define this kind of configuration where an HTTP route is set for ingress-ing trafic to a plain old APIv4Definition, avoiding to create the intermediate APIDefinition on HTTPRoutes that would cause a naming conflict:

```yaml
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: echo
spec:
  parentRefs:
  - name: gravitee-gateway
    kind: Gateway
    group: gateway.networking.k8s.io
  hostnames:
   - apis.example.com
  rules:
    - matches:
       - path:
           type: PathPrefix
           value: /echo
      filters: []
      backendRefs:
        - kind: Service
          group: ""
          name: echo
          port: 8080
---
apiVersion: "gravitee.io/v1alpha1"
kind: "ApiV4Definition"
metadata:
  name: "echo"
spec:
  contextRef:
    name: dev-ctx
  name: "echo"
  version: "1"
  type: "PROXY"
  description: "Gravitee echo API"
  listeners:
    - type: HTTP
      paths:
        - path: "/echo"
          host: "apis.example.com"
      entrypoints:
        - type: http-proxy
          qos: AUTO
  endpointGroups:
    - name: "Default HTTP proxy group"
      type: "http-proxy"
      endpoints:
        - name: "Default HTTP proxy"
          type: "http-proxy"
          configuration:
            target: "https://api.gravitee.io/echo"
          inheritConfiguration: false
          secondary: false
  analytics:
    enabled: true
  plans:
    JWT:
      name: "jwt"
      security:
        type: "JWT"
        configuration:
          signature: "RSA_RS256"
          publicKeyResolver: "GIVEN_KEY"
          resolverParameter: "[[ secret `jwt/public.key` ]]"
          userClaim: "sub"
          clientIdClaim: "client_id"
      status: "PUBLISHED"
```

This change is conditioned by a helm value flag that defaults to false

```yaml
gatewayAPI:
  controller:
    skipAPIDefinition: false
```

when true, the HTTPRoute controller will shortcut the APIv4 controller and proceed himself to create the config map.
