### PR TITLE
ci: store E2E coverage artifact for per-run inspection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,6 +241,9 @@ jobs:
           root: /tmp/junit/reports
           paths:
             - cover-unit.out
+      - store_artifacts:
+          path: /tmp/junit/reports/cover-unit.out
+          destination: cover-unit.out
       - go/save-build-cache:
           checksum: '{{ checksum "/tmp/gomod_checksum.md5" }}'
 
@@ -335,6 +338,9 @@ jobs:
           root: /tmp/junit/reports
           paths:
             - cover-conformance.out
+      - store_artifacts:
+          path: /tmp/junit/reports/cover-conformance.out
+          destination: cover-conformance.out
       - go/save-build-cache:
           checksum: '{{ checksum "/tmp/gomod_checksum.md5" }}'
 
@@ -408,6 +414,9 @@ jobs:
           root: /tmp/junit/reports
           paths:
             - cover-<< parameters.ginkgo-filter >>.out
+      - store_artifacts:
+          path: /tmp/junit/reports/cover-<< parameters.ginkgo-filter >>.out
+          destination: cover-<< parameters.ginkgo-filter >>.out
       - go/save-build-cache:
           checksum: '{{ checksum "/tmp/gomod_checksum.md5" }}'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -501,6 +501,9 @@ jobs:
       - store_artifacts:
           path: test/platform-test/playwright-report
           destination: playwright-report
+      - store_artifacts:
+          path: /tmp/junit/reports/cover-e2e.out
+          destination: cover-e2e.out
 
   job-stage-helm-chart:
     docker:


### PR DESCRIPTION
Minor update to the CircleCI config to keep the e2e coverage as it's not clear what the e2e tests actually cover, the Sonar UI only offers a cumulated view over all kind of tests.