### PR TITLE
Improve platform-test helpers

### DIFF
--- a/test/platform-test/src/assertions/apim/mapi.ts
+++ b/test/platform-test/src/assertions/apim/mapi.ts
@@ -40,8 +40,8 @@ export class Mapi {
   /** @internal */
   readonly http: HttpClient;
 
-  constructor(config: MapiConfig, fetchFn?: FetchFn) {
-    this.http = new HttpClient(config, fetchFn);
+  constructor(config: MapiConfig) {
+    this.http = new HttpClient(config);
   }
 
   // ── API Assertions ──────────────────────────────────────────
@@ -316,6 +316,6 @@ export class Mapi {
 }
 
 /** Convenience factory */
-export function createMapi(config: MapiConfig, fetchFn?: FetchFn): Mapi {
-  return new Mapi(config, fetchFn);
+export function createMapi(config: MapiConfig): Mapi {
+  return new Mapi(config);
 }

--- a/test/platform-test/src/types/match.ts
+++ b/test/platform-test/src/types/match.ts
@@ -25,7 +25,7 @@ export type DeepPartial<T> = T extends object
  * A single field-level assertion failure.
  */
 export interface AssertionFailure {
-  path: string;
+  jsonPath: string;
   message: string;
   expected: unknown;
   actual: unknown;

--- a/test/platform-test/src/utils/http/http.ts
+++ b/test/platform-test/src/utils/http/http.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import type { FetchFn, HttpClientConfig, HttpResponse } from "../../types/http.js";
+import type { HttpClientConfig, HttpResponse } from "../../types/http.js";
 
 /**
  * Internal HTTP client for Gravitee management APIs.
  *
- * Uses native fetch by default. The fetch function can be replaced
- * (e.g. with undici's fetch for TLS client certificates in GKO scenarios)
- * via the `fetchFn` option — but this is never exposed to library consumers.
+ * Uses native fetch. The management API is always reached over plain HTTP
+ * with basic/bearer/cookie auth in our test scenarios — mTLS only applies
+ * to the data plane, which has its own injectable fetch on `Gateway`.
  */
 export class HttpClient {
   private readonly baseUrl: string;
@@ -29,14 +29,12 @@ export class HttpClient {
   private readonly timeoutMs: number;
   private readonly defaultHeaders: Record<string, string>;
   private readonly authHeader: Record<string, string>;
-  private readonly fetchImpl: FetchFn;
 
-  constructor(config: HttpClientConfig, fetchFn?: FetchFn) {
+  constructor(config: HttpClientConfig) {
     this.baseUrl = config.baseUrl.replace(/\/+$/, "");
     this.envId = config.envId ?? "DEFAULT";
     this.timeoutMs = config.timeoutMs ?? 10_000;
     this.defaultHeaders = config.headers ?? {};
-    this.fetchImpl = fetchFn ?? globalThis.fetch;
 
     // Pre-compute auth header
     const { auth } = config;
@@ -92,7 +90,7 @@ export class HttpClient {
 
     const start = performance.now();
 
-    const response = await this.fetchImpl(url, {
+    const response = await fetch(url, {
       method,
       headers,
       body: body !== undefined ? JSON.stringify(body) : undefined,

--- a/test/platform-test/src/utils/match/partial.ts
+++ b/test/platform-test/src/utils/match/partial.ts
@@ -23,24 +23,23 @@ import type { AssertionFailure, AssertionReport } from "../../types/match.js";
 export function deepPartialMatch(
   actual: unknown,
   expected: unknown,
-  path: string = "$",
 ): AssertionReport {
   const failures: AssertionFailure[] = [];
-  collect(actual, expected, path, failures);
+  collect(actual, expected, "$", failures);
   return { pass: failures.length === 0, failures, actual };
 }
 
 function collect(
   actual: unknown,
   expected: unknown,
-  path: string,
+  jsonPath: string,
   failures: AssertionFailure[],
 ): void {
   // Primitives and null: strict equality
   if (expected === null || expected === undefined || typeof expected !== "object") {
     if (!Object.is(actual, expected)) {
       failures.push({
-        path,
+        jsonPath,
         message: `Expected ${JSON.stringify(expected)} but got ${JSON.stringify(actual)}`,
         expected,
         actual,
@@ -52,7 +51,7 @@ function collect(
   // Expected is object but actual isn't
   if (actual === null || actual === undefined || typeof actual !== "object") {
     failures.push({
-      path,
+      jsonPath,
       message: `Expected an object but got ${JSON.stringify(actual)}`,
       expected,
       actual,
@@ -64,7 +63,7 @@ function collect(
   if (Array.isArray(expected)) {
     if (!Array.isArray(actual)) {
       failures.push({
-        path,
+        jsonPath,
         message: `Expected an array but got ${typeof actual}`,
         expected,
         actual,
@@ -74,14 +73,14 @@ function collect(
     for (let i = 0; i < expected.length; i++) {
       if (i >= actual.length) {
         failures.push({
-          path: `${path}[${i}]`,
+          jsonPath: `${jsonPath}[${i}]`,
           message: `Array index ${i} missing (array has ${actual.length} elements)`,
           expected: expected[i],
           actual: undefined,
         });
         continue;
       }
-      collect(actual[i], expected[i], `${path}[${i}]`, failures);
+      collect(actual[i], expected[i], `${jsonPath}[${i}]`, failures);
     }
     return;
   }
@@ -91,10 +90,10 @@ function collect(
   const actualObj = actual as Record<string, unknown>;
 
   for (const key of Object.keys(expectedObj)) {
-    const childPath = path === "$" ? `$.${key}` : `${path}.${key}`;
+    const childPath = jsonPath === "$" ? `$.${key}` : `${jsonPath}.${key}`;
     if (!(key in actualObj)) {
       failures.push({
-        path: childPath,
+        jsonPath: childPath,
         message: `Property "${key}" missing from actual object`,
         expected: expectedObj[key],
         actual: undefined,

--- a/test/platform-test/src/utils/match/result.ts
+++ b/test/platform-test/src/utils/match/result.ts
@@ -26,7 +26,7 @@ export function throwIfFailed(report: AssertionReport): void {
 
   const lines = report.failures.map(
     (f) =>
-      `  path:     ${f.path}\n  expected: ${JSON.stringify(f.expected)}\n  actual:   ${JSON.stringify(f.actual)}`,
+      `  jsonPath: ${f.jsonPath}\n  expected: ${JSON.stringify(f.expected)}\n  actual:   ${JSON.stringify(f.actual)}`,
   );
 
   throw new AssertionError({

--- a/test/platform-test/test/apim/apim.test.ts
+++ b/test/platform-test/test/apim/apim.test.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { AssertionError } from "node:assert";
 import { Mapi } from "../../src/assertions/apim/index.js";
 
-/** Create a Mapi with a mocked fetch that returns the given body. */
+/** Create a Mapi with globalThis.fetch stubbed to return the given body. */
 function createMockMapi(body: unknown, status = 200) {
   const mockFetch = vi.fn<typeof fetch>().mockResolvedValue(
     new Response(JSON.stringify(body), {
@@ -27,19 +27,20 @@ function createMockMapi(body: unknown, status = 200) {
       headers: { "Content-Type": "application/json" },
     }),
   );
+  vi.stubGlobal("fetch", mockFetch);
 
-  const mapi = new Mapi(
-    {
-      baseUrl: "http://localhost:8083",
-      auth: { type: "basic", username: "admin", password: "admin" },
-    },
-    mockFetch,
-  );
+  const mapi = new Mapi({
+    baseUrl: "http://localhost:8083",
+    auth: { type: "basic", username: "admin", password: "admin" },
+  });
 
   return { mapi, mockFetch };
 }
 
 describe("Mapi", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
   const fakeApi = {
     id: "api-1",
     name: "Petstore API",

--- a/test/platform-test/test/cmd/assert-api.test.ts
+++ b/test/platform-test/test/cmd/assert-api.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { AssertionError } from "node:assert";
 import { buildPartial } from "../../src/cmd/assert-api.js";
 import { parseArgs } from "../../src/cmd/index.js";
@@ -158,6 +158,10 @@ describe("buildPartial with matchContent", () => {
 // ── assertApiCommand (mocked fetch) ──────────────────────────
 
 describe("assertApiCommand via Mapi", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   const fakeApi = {
     id: "api-1",
     name: "My API",
@@ -184,10 +188,11 @@ describe("assertApiCommand via Mapi", () => {
         headers: { "Content-Type": "application/json" },
       }),
     );
-    const apim = new Mapi(
-      { baseUrl: "http://localhost:8083", auth: { type: "basic", username: "admin", password: "admin" } },
-      mockFetch,
-    );
+    vi.stubGlobal("fetch", mockFetch);
+    const apim = new Mapi({
+      baseUrl: "http://localhost:8083",
+      auth: { type: "basic", username: "admin", password: "admin" },
+    });
     return { apim, mockFetch };
   }
 

--- a/test/platform-test/test/cmd/config.test.ts
+++ b/test/platform-test/test/cmd/config.test.ts
@@ -148,27 +148,28 @@ describe("createMapiFromConfig", () => {
         headers: { "Content-Type": "application/json" },
       }),
     );
+    vi.stubGlobal("fetch", mockFetch);
 
-    const config = {
-      apim: {
-        baseUrl: "http://testhost:8083",
-        envId: "MY_ENV",
-        auth: { username: "user", password: "pass" },
-      },
-    };
+    try {
+      const config = {
+        apim: {
+          baseUrl: "http://testhost:8083",
+          envId: "MY_ENV",
+          auth: { username: "user", password: "pass" },
+        },
+      };
 
-    // Pass mockFetch to Mapi directly for this test
-    const mapi = new Mapi(
-      {
+      const mapi = new Mapi({
         baseUrl: config.apim.baseUrl,
         envId: config.apim.envId,
         auth: { type: "basic", username: config.apim.auth.username, password: config.apim.auth.password },
-      },
-      mockFetch,
-    );
+      });
 
-    await mapi.fetchApi("api-1");
-    const url = mockFetch.mock.calls[0][0] as string;
-    expect(url).toBe("http://testhost:8083/management/v2/environments/MY_ENV/apis/api-1");
+      await mapi.fetchApi("api-1");
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe("http://testhost:8083/management/v2/environments/MY_ENV/apis/api-1");
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/test/platform-test/test/match/partial.test.ts
+++ b/test/platform-test/test/match/partial.test.ts
@@ -28,7 +28,7 @@ describe("deepPartialMatch", () => {
     const result = deepPartialMatch({ name: "foo" }, { name: "bar" });
     expect(result.pass).toBe(false);
     expect(result.failures).toHaveLength(1);
-    expect(result.failures[0].path).toBe("$.name");
+    expect(result.failures[0].jsonPath).toBe("$.name");
     expect(result.failures[0].expected).toBe("bar");
     expect(result.failures[0].actual).toBe("foo");
   });
@@ -44,7 +44,7 @@ describe("deepPartialMatch", () => {
     const expected = { a: { b: { c: 99 } } };
     const result = deepPartialMatch(actual, expected);
     expect(result.pass).toBe(false);
-    expect(result.failures[0].path).toBe("$.a.b.c");
+    expect(result.failures[0].jsonPath).toBe("$.a.b.c");
   });
 
   it("matches arrays element-by-element", () => {
@@ -56,19 +56,19 @@ describe("deepPartialMatch", () => {
   it("fails when array element mismatches", () => {
     const result = deepPartialMatch({ items: ["a", "x"] }, { items: ["a", "b"] });
     expect(result.pass).toBe(false);
-    expect(result.failures[0].path).toBe("$.items[1]");
+    expect(result.failures[0].jsonPath).toBe("$.items[1]");
   });
 
   it("fails when expected array is longer than actual", () => {
     const result = deepPartialMatch({ items: ["a"] }, { items: ["a", "b"] });
     expect(result.pass).toBe(false);
-    expect(result.failures[0].path).toBe("$.items[1]");
+    expect(result.failures[0].jsonPath).toBe("$.items[1]");
   });
 
   it("fails when a property is missing from actual", () => {
     const result = deepPartialMatch({ a: 1 }, { a: 1, b: 2 });
     expect(result.pass).toBe(false);
-    expect(result.failures[0].path).toBe("$.b");
+    expect(result.failures[0].jsonPath).toBe("$.b");
   });
 
   it("matches null explicitly", () => {

--- a/test/platform-test/test/match/result.test.ts
+++ b/test/platform-test/test/match/result.test.ts
@@ -29,7 +29,7 @@ describe("throwIfFailed", () => {
       throwIfFailed({
         pass: false,
         failures: [
-          { path: "$.name", message: "mismatch", expected: "foo", actual: "bar" },
+          { jsonPath: "$.name", message: "mismatch", expected: "foo", actual: "bar" },
         ],
         actual: { name: "bar" },
       }),
@@ -41,8 +41,8 @@ describe("throwIfFailed", () => {
       throwIfFailed({
         pass: false,
         failures: [
-          { path: "$.name", message: "m1", expected: "a", actual: "b" },
-          { path: "$.state", message: "m2", expected: "STARTED", actual: "STOPPED" },
+          { jsonPath: "$.name", message: "m1", expected: "a", actual: "b" },
+          { jsonPath: "$.state", message: "m2", expected: "STARTED", actual: "STOPPED" },
         ],
         actual: { name: "b", state: "STOPPED" },
       });


### PR DESCRIPTION
This PR ...
1. Cleans up the platform-test helper library: drops the unused fetchFn dependency injection on Mapi/HttpClient
2. Renames AssertionFailure.path → jsonPath to better distinguish from URL/filesystem paths
3. Removes deepPartialMatch's jsonPath parameter from its public signature