### PR TITLE
Test/e2e tighten admission assertions and align fixtures

### DIFF
--- a/test/platform-test/e2e/fixtures/crds/applications/application-1382-long-name.yaml
+++ b/test/platform-test/e2e/fixtures/crds/applications/application-1382-long-name.yaml
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# GKO-1382: Edge case for application name length — APIM enforces a 50-char
-# limit on application names. spec.name is 60 chars here so the dry-run via
-# admission should reject (or warn, depending on APIM behavior).
+# GKO-1382: Edge case for application name length. APIM does not enforce a
+# hard length limit on application `name` — a 60-char name is accepted via
+# the CRD + dry-run path. The test asserts the full name is preserved in
+# APIM (no silent truncation or rename) rather than expecting rejection.
 apiVersion: gravitee.io/v1alpha1
 kind: Application
 metadata:
@@ -24,7 +25,7 @@ spec:
     name: dev-ctx
     namespace: default
   name: "e2e-1382-this-app-name-is-far-too-long-and-exceeds-fifty-chars"
-  description: "E2E test: application name exceeds APIM length limit"
+  description: "E2E test: long application name is preserved (no truncation)"
   settings:
     app:
       type: SIMPLE

--- a/test/platform-test/e2e/fixtures/crds/applications/application-579-spa-bad-grants.yaml
+++ b/test/platform-test/e2e/fixtures/crds/applications/application-579-spa-bad-grants.yaml
@@ -12,9 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# GKO-579: SPA (Single-Page Application) accepts only `authorization_code` and
-# `implicit` grant types. Any other grant (e.g. `client_credentials`) should
-# be rejected by APIM dryRun via the admission webhook.
+# GKO-579: The original Xray scenario describes "SPA" (Single-Page Application)
+# accepting only authorization_code / implicit grants. APIM no longer exposes
+# a distinct SPA application type — the supported values are BACKEND_TO_BACKEND,
+# NATIVE, BROWSER, and WEB. BROWSER is the current equivalent of a SPA
+# (browser-hosted public client) and has the same grant-type restriction: any
+# other grant (e.g. client_credentials) should be rejected by the admission
+# webhook / APIM dryRun.
 apiVersion: gravitee.io/v1alpha1
 kind: Application
 metadata:
@@ -24,10 +28,10 @@ spec:
     name: dev-ctx
     namespace: default
   name: e2e-app-579-spa-bad
-  description: "E2E test: SPA app with invalid grant_type"
+  description: "E2E test: browser-hosted app with disallowed grant_type"
   settings:
     oauth:
-      applicationType: SPA
+      applicationType: BROWSER
       grantTypes:
         - client_credentials
       redirectUris:

--- a/test/platform-test/e2e/fixtures/crds/mtls-certificates/h-2251-app-past-end.yaml
+++ b/test/platform-test/e2e/fixtures/crds/mtls-certificates/h-2251-app-past-end.yaml
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 # GKO-2251: Application with a client cert whose endsAt is in the past.
-# APIM accepts this (end date is informational); mAPI surfaces the endsAt.
+# APIM accepts the apply but filters the expired cert out of the active list
+# returned via settings.tls.client_certificates. The test asserts that the
+# active list is empty.
 apiVersion: gravitee.io/v1alpha1
 kind: Application
 metadata:
@@ -23,7 +25,7 @@ spec:
     name: dev-ctx
     namespace: default
   name: e2e-app-h-2251
-  description: "E2E test (bucket H): cert with past endsAt still visible"
+  description: "E2E test (bucket H): cert with past endsAt filtered out"
   settings:
     app:
       type: SIMPLE

--- a/test/platform-test/e2e/helpers/terraform.ts
+++ b/test/platform-test/e2e/helpers/terraform.ts
@@ -39,15 +39,25 @@ export interface TfWorkspace {
  * regularly exceeds the 30 s beforeAll timeout and occasionally hits GitHub
  * rate-limiting or transient network errors ("context deadline exceeded").
  *
- * Respects TF_PLUGIN_CACHE_DIR if the caller already set one; otherwise uses
- * the standard ~/.terraform.d/plugin-cache location (created if missing).
+ * Respects TF_PLUGIN_CACHE_DIR if the caller already set one. Otherwise tries
+ * the standard ~/.terraform.d/plugin-cache location, and falls back to a
+ * tmpdir-scoped cache when the home directory is read-only or otherwise
+ * unwritable (CI containers, synthetic HOME). The fallback is still shared
+ * across workspaces within a single test run.
  */
 async function resolvePluginCacheDir(): Promise<string> {
   const existing = process.env["TF_PLUGIN_CACHE_DIR"];
   if (existing) return existing;
-  const dir = path.join(homedir(), ".terraform.d", "plugin-cache");
-  await mkdir(dir, { recursive: true });
-  return dir;
+
+  const preferred = path.join(homedir(), ".terraform.d", "plugin-cache");
+  try {
+    await mkdir(preferred, { recursive: true });
+    return preferred;
+  } catch {
+    const fallback = path.join(tmpdir(), "e2e-tf-plugin-cache");
+    await mkdir(fallback, { recursive: true });
+    return fallback;
+  }
 }
 
 /**

--- a/test/platform-test/e2e/tests/gko/applications/application-admission-extended.test.ts
+++ b/test/platform-test/e2e/tests/gko/applications/application-admission-extended.test.ts
@@ -77,8 +77,9 @@ test.describe("Applications — admission & lifecycle (batch 8)", () => {
     kubectl,
   }) => {
     const stderr = await kubectl.applyExpectFailure(fixture(FIXTURE_578));
-    // Expect APIM dry-run rejection or admission rejection mentioning the URI.
-    expect(stderr.toLowerCase()).toMatch(/uri|redirect|invalid|denied/);
+    // Scoped to redirectUri-specific terms; a generic webhook failure (e.g.
+    // DNS/timeout) would no longer satisfy the assertion.
+    expect(stderr.toLowerCase()).toMatch(/uri|redirect/);
   });
 
   // ── GKO-579: SPA grant types restricted ──────────────────────
@@ -87,7 +88,7 @@ test.describe("Applications — admission & lifecycle (batch 8)", () => {
     kubectl,
   }) => {
     const stderr = await kubectl.applyExpectFailure(fixture(FIXTURE_579));
-    expect(stderr.toLowerCase()).toMatch(/grant|authorization_code|implicit|invalid|denied/);
+    expect(stderr.toLowerCase()).toMatch(/grant|authorization_code|implicit/);
   });
 
   // ── GKO-1382: name length edge case ──────────────────────────

--- a/test/platform-test/e2e/tests/gko/deployment-reconciliation/cr-managed-readonly.test.ts
+++ b/test/platform-test/e2e/tests/gko/deployment-reconciliation/cr-managed-readonly.test.ts
@@ -83,8 +83,13 @@ test.describe("CR-managed resources are read-only in APIM", () => {
   });
 
   // ── GKO-1234: Notification settings tagged origin=KUBERNETES
+  //
+  // Skipped pending Notification migration to the APIM Automation API. GKO's
+  // notification write path still goes through mAPI, so APIM reports
+  // origin=MANAGEMENT for CR-created notification settings. Re-enable when
+  // the Notification handler is migrated.
 
-  test(`Notification settings created via CR are origin=KUBERNETES ${XRAY.NOTIFICATIONS.CR_READONLY_VIA_MAPI} ${TAGS.REGRESSION}`, async ({
+  test.skip(`Notification settings created via CR are origin=KUBERNETES ${XRAY.NOTIFICATIONS.CR_READONLY_VIA_MAPI} ${TAGS.REGRESSION}`, async ({
     kubectl,
     mapi,
   }) => {

--- a/test/platform-test/e2e/tests/gko/import-export/v4-import-export-extended.test.ts
+++ b/test/platform-test/e2e/tests/gko/import-export/v4-import-export-extended.test.ts
@@ -93,7 +93,13 @@ test.describe("V4 Import/Export — Extended", () => {
   // will move off Accepted — neither of which the previous re-apply-original
   // formulation could catch.
 
-  test(`V4 CRD export/import round-trip preserves identity ${XRAY.IMPORT_EXPORT.V4_EXPORT_IMPORT_ROUND_TRIP} ${TAGS.REGRESSION}`, async ({
+  // Skipped pending APIM-13795: APIM emits `spec.analytics.reporterMetricsEnabled`
+  // on the shared Analytics schema for v4 proxy APIs, but the field is not
+  // declared on the GKO `ApiV4Definition` CRD. A round-trip re-apply fails
+  // with `strict decoding error: unknown field spec.analytics.reporterMetricsEnabled`
+  // on clusters with strict field validation (CircleCI). Re-enable once APIM
+  // stops leaking the native-only flag into the HTTP v4 response.
+  test.skip(`V4 CRD export/import round-trip preserves identity ${XRAY.IMPORT_EXPORT.V4_EXPORT_IMPORT_ROUND_TRIP} ${TAGS.REGRESSION}`, async ({
     kubectl,
     mapi,
   }) => {

--- a/test/platform-test/e2e/tests/gko/mtls-certificates/mtls-cert-admission.test.ts
+++ b/test/platform-test/e2e/tests/gko/mtls-certificates/mtls-cert-admission.test.ts
@@ -29,12 +29,9 @@
  *   GKO-2117: Bad PEM in deprecated clientCertificate
  *   GKO-2118: Both content and ref set on a clientCertificates entry
  *   GKO-2122: Cert startsAt == endsAt
- *   GKO-2124: Cert name exceeds APIM length limit
  *   GKO-2125: clientCertificates entry missing content/ref entirely
  *   GKO-2131: Cert with both dates in the past (already expired)
- *   GKO-2133: Cert name with invalid characters
  *   GKO-2135: Cert with endsAt before startsAt
- *   GKO-2143: Cert with empty name
  *   GKO-2146: Cert with explicit empty content (variant of 2125)
  *   GKO-2148: Cert with invalid date-format strings
  *
@@ -44,6 +41,17 @@
  * reject), document it as APIM-only and adjust during live-cluster
  * validation.
  *
+ * Deferred (not covered here):
+ *   GKO-2124: name exceeds APIM length limit
+ *   GKO-2133: name with invalid characters
+ *   GKO-2143: empty name
+ *   The GKO admission webhook rejects on PEM validity ("certificate is not
+ *   a valid pem") before any cert-name validator runs, so these name-rule
+ *   scenarios aren't reachable through the Application CRD path with the
+ *   current stub PEM. Exercising them requires a valid PEM plus confirmation
+ *   that APIM's dryRun actually enforces these name rules — tracked for a
+ *   follow-up batch alongside per-scenario PKI fixtures.
+ *
  * Preconditions:
  *   - APIM, Gateway, and GKO operator are running
  *   - A ManagementContext "dev-ctx" exists in the default namespace
@@ -51,84 +59,87 @@
 
 import { test, fixture, expect } from "../../../setup.js";
 import { XRAY, TAGS } from "../../../helpers/tags.js";
+import * as kubectlSafe from "../../../helpers/kubectl.js";
 
 const F = (name: string) => fixture(`crds/mtls-certificates/invalid/${name}.yaml`);
 
+// Every rejection regex is deliberately scoped to substrings that should
+// appear for the specific failure mode under test. Generic terms like
+// "invalid" or "denied" are intentionally excluded — they appear in almost
+// every admission/webhook error and would turn a real regression (e.g. the
+// admission path erroring for an unrelated reason) into a false pass.
 test.describe("mTLS — Application cert admission rejections (batch 8)", () => {
+  test.afterEach(async () => {
+    // Admission-rejected applies don't persist state, but be defensive in
+    // case a scenario ever slips past admission — the safety net matches the
+    // codebase's cleanup pattern.
+    await kubectlSafe.del(F("2117-bad-pem")).catch(() => {});
+    await kubectlSafe.del(F("2118-content-and-ref")).catch(() => {});
+    await kubectlSafe.del(F("2122-start-eq-end")).catch(() => {});
+    await kubectlSafe.del(F("2125-no-content-no-ref")).catch(() => {});
+    await kubectlSafe.del(F("2131-expired")).catch(() => {});
+    await kubectlSafe.del(F("2135-end-before-start")).catch(() => {});
+    await kubectlSafe.del(F("2146-missing-cert-content")).catch(() => {});
+    await kubectlSafe.del(F("2148-invalid-date-format")).catch(() => {});
+  });
+
   test(`Deprecated clientCertificate with non-PEM content is rejected ${XRAY.MTLS_CERTIFICATES.CRD_BAD_PEM} ${TAGS.REGRESSION}`, async ({
     kubectl,
   }) => {
     const stderr = await kubectl.applyExpectFailure(F("2117-bad-pem"));
-    expect(stderr.toLowerCase()).toMatch(/parse|certificate|pem|tls|invalid|denied/);
+    // validateSingleClientCertificate → "failed to parse TLS client certificate"
+    expect(stderr.toLowerCase()).toMatch(/parse|pem|tls client certificate/);
   });
 
   test(`clientCertificates with both content and ref is rejected ${XRAY.MTLS_CERTIFICATES.CRD_FORBIDDEN_FIELD_UPDATE} ${TAGS.REGRESSION}`, async ({
     kubectl,
   }) => {
     const stderr = await kubectl.applyExpectFailure(F("2118-content-and-ref"));
-    expect(stderr.toLowerCase()).toMatch(/content|ref|both|cannot|denied/);
+    // validateClientCertificates → "content and ref cannot both be set"
+    expect(stderr.toLowerCase()).toMatch(/content and ref|both|cannot/);
   });
 
   test(`clientCertificate with startsAt equal to endsAt is rejected ${XRAY.MTLS_CERTIFICATES.CRD_START_EQ_END} ${TAGS.REGRESSION}`, async ({
     kubectl,
   }) => {
     const stderr = await kubectl.applyExpectFailure(F("2122-start-eq-end"));
-    expect(stderr.toLowerCase()).toMatch(/date|window|valid|invalid|certificate|denied/);
-  });
-
-  test(`clientCertificate with overly long name is rejected ${XRAY.MTLS_CERTIFICATES.CRD_NAME_TOO_LONG} ${TAGS.REGRESSION}`, async ({
-    kubectl,
-  }) => {
-    const stderr = await kubectl.applyExpectFailure(F("2124-name-too-long"));
-    expect(stderr.toLowerCase()).toMatch(/name|length|too long|maximum|invalid|denied/);
+    expect(stderr.toLowerCase()).toMatch(/startsat|endsat|validity|window|never/);
   });
 
   test(`clientCertificates entry missing content and ref is rejected ${XRAY.MTLS_CERTIFICATES.CRD_MISSING_FIELDS} ${TAGS.REGRESSION}`, async ({
     kubectl,
   }) => {
     const stderr = await kubectl.applyExpectFailure(F("2125-no-content-no-ref"));
-    expect(stderr.toLowerCase()).toMatch(/content|ref|either|must be set|denied/);
+    // validateClientCertificates → "either content or ref must be set"
+    expect(stderr.toLowerCase()).toMatch(/either content or ref|must be set/);
   });
 
   test(`Already-expired clientCertificate is rejected ${XRAY.MTLS_CERTIFICATES.CRD_EXPIRED_REJECTED} ${TAGS.REGRESSION}`, async ({
     kubectl,
   }) => {
     const stderr = await kubectl.applyExpectFailure(F("2131-expired"));
-    expect(stderr.toLowerCase()).toMatch(/expired|date|past|invalid|certificate|denied/);
-  });
-
-  test(`clientCertificate name with invalid characters is rejected ${XRAY.MTLS_CERTIFICATES.CRD_INVALID_CHARS} ${TAGS.REGRESSION}`, async ({
-    kubectl,
-  }) => {
-    const stderr = await kubectl.applyExpectFailure(F("2133-invalid-chars"));
-    expect(stderr.toLowerCase()).toMatch(/name|character|invalid|denied/);
+    expect(stderr.toLowerCase()).toMatch(/expired|past|endsat/);
   });
 
   test(`clientCertificate with endsAt before startsAt is rejected ${XRAY.MTLS_CERTIFICATES.CRD_END_BEFORE_START} ${TAGS.REGRESSION}`, async ({
     kubectl,
   }) => {
     const stderr = await kubectl.applyExpectFailure(F("2135-end-before-start"));
-    expect(stderr.toLowerCase()).toMatch(/date|before|startsAt|endsAt|invalid|denied/);
-  });
-
-  test(`clientCertificate with empty name is rejected ${XRAY.MTLS_CERTIFICATES.CRD_MISSING_NAME} ${TAGS.REGRESSION}`, async ({
-    kubectl,
-  }) => {
-    const stderr = await kubectl.applyExpectFailure(F("2143-missing-name"));
-    expect(stderr.toLowerCase()).toMatch(/name|required|invalid|denied/);
+    expect(stderr.toLowerCase()).toMatch(/startsat|endsat|before|after/);
   });
 
   test(`clientCertificate with explicit empty content is rejected ${XRAY.MTLS_CERTIFICATES.CRD_MISSING_CERT_FIELD} ${TAGS.REGRESSION}`, async ({
     kubectl,
   }) => {
     const stderr = await kubectl.applyExpectFailure(F("2146-missing-cert-content"));
-    expect(stderr.toLowerCase()).toMatch(/content|ref|either|must be set|denied/);
+    // validateClientCertificates → "either content or ref must be set"
+    expect(stderr.toLowerCase()).toMatch(/either content or ref|must be set/);
   });
 
   test(`clientCertificate with invalid date-format strings is rejected ${XRAY.MTLS_CERTIFICATES.CRD_INVALID_DATA_DATES} ${TAGS.REGRESSION}`, async ({
     kubectl,
   }) => {
     const stderr = await kubectl.applyExpectFailure(F("2148-invalid-date-format"));
-    expect(stderr.toLowerCase()).toMatch(/date|format|parse|invalid|denied/);
+    expect(stderr.toLowerCase()).toMatch(/date|rfc3339|parse|format/);
   });
 });

--- a/test/platform-test/e2e/tests/gko/mtls-certificates/mtls-cert-subscription-updates.test.ts
+++ b/test/platform-test/e2e/tests/gko/mtls-certificates/mtls-cert-subscription-updates.test.ts
@@ -50,22 +50,6 @@ const APP_NO_CERTS = "crds/mtls-certificates/h-2219-app-no-certs.yaml";
 const APP_VALID_CERT = "crds/mtls-certificates/h-2223-app-valid-cert.yaml";
 const APP_PAST_END = "crds/mtls-certificates/h-2251-app-past-end.yaml";
 
-// mAPI serializes the certificate list in snake_case and uses epoch millis
-// for the validity window.
-interface AppClientCertView {
-  name?: string;
-  startsAt?: number;
-  endsAt?: number;
-  certificate?: string;
-}
-
-interface AppWithTls {
-  settings?: {
-    app?: { type?: string };
-    tls?: { client_certificates?: AppClientCertView[]; certificate_count?: number };
-  };
-}
-
 test.describe("mTLS — clientCertificates visibility via mAPI (batch 8)", () => {
   test.afterEach(async () => {
     await kubectlSafe.del(fixture(APP_NO_CERTS)).catch(() => {});
@@ -84,7 +68,7 @@ test.describe("mTLS — clientCertificates visibility via mAPI (batch 8)", () =>
     const appId = (await kubectl.getStatus<{ id: string }>("application", APP)).id;
     await mapi.waitForApplicationMatches(appId, { name: APP });
 
-    const raw = (await mapi.fetchApplication(appId)) as unknown as AppWithTls;
+    const raw = await mapi.fetchApplication(appId);
     const certs = raw.settings?.tls?.client_certificates ?? [];
     expect(certs).toEqual([]);
   });
@@ -102,7 +86,7 @@ test.describe("mTLS — clientCertificates visibility via mAPI (batch 8)", () =>
     await expect
       .poll(
         async () => {
-          const raw = (await mapi.fetchApplication(appId)) as unknown as AppWithTls;
+          const raw = await mapi.fetchApplication(appId);
           const cert = raw.settings?.tls?.client_certificates?.[0];
           return {
             name: cert?.name,
@@ -132,7 +116,7 @@ test.describe("mTLS — clientCertificates visibility via mAPI (batch 8)", () =>
     await expect
       .poll(
         async () => {
-          const raw = (await mapi.fetchApplication(appId)) as unknown as AppWithTls;
+          const raw = await mapi.fetchApplication(appId);
           return raw.settings?.tls?.client_certificates?.length ?? 0;
         },
         { timeout: 10_000, intervals: [1_000] },
@@ -150,15 +134,13 @@ test.describe("mTLS — clientCertificates visibility via mAPI (batch 8)", () =>
 
     const appId = (await kubectl.getStatus<{ id: string }>("application", APP)).id;
 
-    // APIM treats endsAt as a hard filter: certificates whose endsAt has
-    // passed are removed from the application's client_certificates list
-    // returned by the management API. This is the data the console's
-    // "expired certificate" indicator is derived from — the absence of
-    // the cert from the active list is the signal.
+    // APIM filters out certificates whose endsAt has passed: they're removed
+    // from settings.tls.client_certificates in the management API response.
+    // The UI's "expired" indicator is driven by this absence.
     await expect
       .poll(
         async () => {
-          const raw = (await mapi.fetchApplication(appId)) as unknown as AppWithTls;
+          const raw = await mapi.fetchApplication(appId);
           return raw.settings?.tls?.client_certificates ?? [];
         },
         { timeout: 10_000, intervals: [1_000] },

--- a/test/platform-test/e2e/tests/gko/notifications/notification-cross-version.test.ts
+++ b/test/platform-test/e2e/tests/gko/notifications/notification-cross-version.test.ts
@@ -34,7 +34,11 @@ const NOTIFICATION = "crds/notifications/notification-shared.yaml";
 const V4_API = "crds/notifications/v4-api-using-shared-notification.yaml";
 const V2_API = "crds/notifications/v2-api-using-shared-notification.yaml";
 
-test.describe("Notification CR — Cross Version", () => {
+// Skipped pending Notification migration to the APIM Automation API. GKO's
+// notification write path still goes through mAPI, so behavioural assertions
+// around notification settings no longer match the live data. Re-enable when
+// the Notification handler is migrated.
+test.describe.skip("Notification CR — Cross Version", () => {
   test.afterEach(async () => {
     await kubectlSafe.del(fixture(V2_API)).catch(() => {});
     await kubectlSafe.del(fixture(V4_API)).catch(() => {});

--- a/test/platform-test/e2e/tests/gko/notifications/notification-lifecycle.test.ts
+++ b/test/platform-test/e2e/tests/gko/notifications/notification-lifecycle.test.ts
@@ -47,7 +47,11 @@ async function createServiceAccount(mapi: { http: { managementV1Path(r: string):
   }
 }
 
-test.describe("Notification Lifecycle", () => {
+// Skipped pending Notification migration to the APIM Automation API. GKO's
+// notification write path still goes through mAPI, so behavioural assertions
+// around notification settings no longer match the live data. Re-enable when
+// the Notification handler is migrated.
+test.describe.skip("Notification Lifecycle", () => {
   test(`Remove notification from API ${XRAY.NOTIFICATIONS.REMOVE_NOTIFICATION}`, async ({
     kubectl,
     mapi,

--- a/test/platform-test/e2e/tests/gko/notifications/notification-recipients.test.ts
+++ b/test/platform-test/e2e/tests/gko/notifications/notification-recipients.test.ts
@@ -39,32 +39,12 @@ import { test, expect, fixture } from "../../../setup.js";
 import { XRAY, TAGS } from "../../../helpers/tags.js";
 import * as kubectlSafe from "../../../helpers/kubectl.js";
 
-interface ManagementHttp {
-  managementV1Path(rel: string): string;
-  post<T>(path: string, body: unknown): Promise<{ status: number; body: T }>;
-}
-
-async function createServiceAccount(
-  mapi: { http: ManagementHttp },
-  name: string,
-): Promise<void> {
-  const path = mapi.http.managementV1Path("/users");
-  const res = await mapi.http.post(path, {
-    firstname: name,
-    lastname: "Service",
-    email: `${name}@gravitee.io`,
-    source: "gravitee",
-    sourceId: name,
-  });
-  if (
-    res.status !== 200 &&
-    res.status !== 201 &&
-    res.status !== 400 &&
-    res.status !== 409
-  ) {
-    throw new Error(`Failed to create service account ${name}: ${res.status}`);
-  }
-}
+// Members referenced by the Group CRs (source=gravitee, sourceId=e2e-sa-…)
+// are declared only. APIM does not require a pre-existing user record for
+// group member declarations — the sourceId is resolved at auth time. An
+// earlier implementation POSTed to /users here but the call consistently
+// returned 400 (no matching IDP entry for source=gravitee in the test
+// cluster), which is harmless but also useless; it has been removed.
 
 const BASE_API = "crds/notifications/v4-api-batch8-base.yaml";
 const NOTIF_1219 = "crds/notifications/notification-1219-portal-target-user.yaml";
@@ -74,7 +54,11 @@ const NOTIF_1239 = "crds/notifications/notification-1239-group-members.yaml";
 const GROUP_1239 = "crds/notifications/group-1239-group-members.yaml";
 const API_1239 = "crds/notifications/v4-api-1239-with-group-members.yaml";
 
-test.describe("Notifications — recipients & visibility (batch 8)", () => {
+// Skipped pending Notification migration to the APIM Automation API. GKO's
+// notification write path still goes through mAPI, so behavioural assertions
+// around notification settings no longer match the live data. Re-enable when
+// the Notification handler is migrated.
+test.describe.skip("Notifications — recipients & visibility (batch 8)", () => {
   test.afterEach(async () => {
     // Reverse dependency order: API → Notification → Group
     await kubectlSafe.del(fixture(API_1239)).catch(() => {});
@@ -169,10 +153,6 @@ test.describe("Notifications — recipients & visibility (batch 8)", () => {
     const NAME = "e2e-v4-1219-portal-target";
     const GROUP_NAME = "e2e-group-1219-portal-target";
 
-    await test.step("Create service account for group", async () => {
-      await createServiceAccount(mapi, "e2e-sa-1219-portal-target");
-    });
-
     await test.step("Apply group, notification, then API", async () => {
       await kubectl.apply(fixture(GROUP_1219));
       await kubectl.waitForCondition("group", GROUP_NAME, "Accepted");
@@ -205,10 +185,6 @@ test.describe("Notifications — recipients & visibility (batch 8)", () => {
   }) => {
     const NAME = "e2e-v4-1239-group-members";
     const GROUP_NAME = "e2e-group-1239-group-members";
-
-    await test.step("Create service account for group", async () => {
-      await createServiceAccount(mapi, "e2e-sa-1239-group-members");
-    });
 
     await test.step("Apply group, notification, then API", async () => {
       await kubectl.apply(fixture(GROUP_1239));

--- a/test/platform-test/e2e/tests/gko/notifications/notifications-export.test.ts
+++ b/test/platform-test/e2e/tests/gko/notifications/notifications-export.test.ts
@@ -44,7 +44,11 @@ interface ExportedCrd {
   };
 }
 
-test.describe("Notifications — export & validation", () => {
+// Skipped pending Notification migration to the APIM Automation API. GKO's
+// notification write path still goes through mAPI, so behavioural assertions
+// around notification settings (origin, propagation, export) no longer match
+// the live data. Re-enable when the Notification handler is migrated.
+test.describe.skip("Notifications — export & validation", () => {
   test.afterEach(async () => {
     await kubectlSafe.del(fixture(V4_API_WITH_NOTIF)).catch(() => {});
     await kubectlSafe.del(fixture(DUPLICATE_API)).catch(() => {});

--- a/test/platform-test/e2e/tests/gko/subscriptions/v4-subscriptions-apikey.test.ts
+++ b/test/platform-test/e2e/tests/gko/subscriptions/v4-subscriptions-apikey.test.ts
@@ -87,6 +87,14 @@ test.describe("V4 API-Key Plan Subscriptions", () => {
     mapi,
     gateway,
   }) => {
+    // Budget: gateway.assertResponds polls for up to 30s waiting for the
+    // api-key plan to propagate from APIM to the gateway. Combined with the
+    // kubectl waits that precede it, the default 30s Playwright test timeout
+    // has no headroom and the test is killed mid-poll on slower CI runs.
+    // Locally the gateway sync is sub-second so 30s is plenty; in CI it can
+    // take 15–25s, pushing total test time well past 30s.
+    test.setTimeout(60_000);
+
     await kubectl.apply(fixture(API_APIKEY));
     await kubectl.apply(fixture(APP));
     await kubectl.waitForCondition("apiv4definition", API_NAME, "Accepted");
@@ -141,6 +149,11 @@ test.describe("V4 API-Key Plan Subscriptions", () => {
     mapi,
     gateway,
   }) => {
+    // Budget: see the comment on the GKO-2826 test above. This test has two
+    // gateway polls (one pre-delete, one post-delete), so the headroom need
+    // is even larger.
+    test.setTimeout(60_000);
+
     await kubectl.apply(fixture(API_APIKEY));
     await kubectl.apply(fixture(APP));
     await kubectl.waitForCondition("apiv4definition", API_NAME, "Accepted");
@@ -204,6 +217,18 @@ test.describe("V4 API-Key Plan Subscriptions", () => {
       await gateway.assertResponds(TWO_PLANS_API_PATH, {
         status: 200,
         headers: { "X-Gravitee-Api-Key": apiKey },
+      });
+    });
+
+    // Discriminator: a present but invalid api-key header is handled by the
+    // api-key plan (not keyless), so the gateway must reject. Without this
+    // step, the valid-key assertion above would pass even if api-key plan
+    // resolution regressed and keyless silently handled every header-bearing
+    // request.
+    await test.step("Api-key plan rejects traffic with an invalid api key header", async () => {
+      await gateway.assertNotResponds(TWO_PLANS_API_PATH, {
+        notStatus: 200,
+        headers: { "X-Gravitee-Api-Key": "bogus-invalid-key" },
       });
     });
   });

--- a/test/platform-test/e2e/tests/terraform/subscription-errors.test.ts
+++ b/test/platform-test/e2e/tests/terraform/subscription-errors.test.ts
@@ -54,7 +54,11 @@ test.describe("Terraform — subscription errors & app delete (batch 8)", () => 
         stderr = `${e.stderr ?? ""}\n${e.stdout ?? ""}\n${e.message ?? ""}`;
       }
       expect(succeeded, "expected `terraform apply` to fail for invalid subscription").toBe(false);
-      expect(stderr.toLowerCase()).toMatch(/api|plan|not found|subscription|invalid|404|error/);
+      // Scoped to terms tied to the missing api_hrid/plan_hrid lookup. A
+      // generic TF error (e.g. provider auth failure) would still include
+      // "error" but not these — dropping the catch-all keeps the assertion
+      // meaningful.
+      expect(stderr.toLowerCase()).toMatch(/api_hrid|plan_hrid|does-not-exist|not found|404/);
     } finally {
       if (ws) await terraform.destroyWorkspace(ws);
     }

--- a/test/platform-test/src/types/apim.ts
+++ b/test/platform-test/src/types/apim.ts
@@ -488,6 +488,24 @@ export interface Application extends BaseApplication {
 export interface ApplicationSettings {
   app?: ApplicationSimpleSettings;
   oauth?: ApplicationOAuthSettings;
+  tls?: ApplicationTlsSettings;
+}
+
+/**
+ * mTLS settings for an application, as returned by the v1/v2 management API.
+ * Wire format is snake_case; epoch-millisecond timestamps are used for
+ * validity windows.
+ */
+export interface ApplicationTlsSettings {
+  client_certificates?: ApplicationClientCertificateView[];
+  certificate_count?: number;
+}
+
+export interface ApplicationClientCertificateView {
+  name?: string;
+  startsAt?: number;
+  endsAt?: number;
+  certificate?: string;
 }
 
 export interface ApplicationSimpleSettings {


### PR DESCRIPTION
This PR updates several e2e tests, focusing on improving test accuracy, documentation, and robustness. 

The changes include updating test fixtures and descriptions to match current APIM behavior, refining test assertions to avoid false positives, skipping or deferring tests blocked by current system limitations, and improving test helper robustness.
