### PR TITLE
docs: use a separate Mongo deployment in runbook to facilitate upgrade

### DIFF
--- a/runbooks/upgrade-lifecycle/mongo-standalone.yaml
+++ b/runbooks/upgrade-lifecycle/mongo-standalone.yaml
@@ -1,0 +1,83 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb
+  labels:
+    app: mongodb
+    version: "7.0.31"
+spec:
+  selector:
+    app: mongodb
+  ports:
+    - name: mongo
+      port: 27017
+      targetPort: 27017
+      protocol: TCP
+  type: ClusterIP
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mongodb
+  labels:
+    app: mongodb
+    version: "7.0.31"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mongodb
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: mongodb
+        version: "7.0.31"
+    spec:
+      containers:
+        - name: mongodb
+          image: mongo:7.0.31-jammy
+          ports:
+            - containerPort: 27017
+              name: mongo
+              protocol: TCP
+          args:
+            - "--noauth"
+            - "--wiredTigerCacheSizeGB=0.5"
+            - "--bind_ip_all"
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+            limits:
+              cpu: "2000m"
+              memory: "2Gi"
+          volumeMounts:
+            - name: datadir
+              mountPath: /data/db
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 999
+            allowPrivilegeEscalation: false
+      volumes:
+        - name: datadir
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Gi

--- a/runbooks/upgrade-lifecycle/runbook.md
+++ b/runbooks/upgrade-lifecycle/runbook.md
@@ -19,7 +19,7 @@ export APIM_IMAGE_REGISTRY=graviteeio.azurecr.io
 export APIM_410_TAG=4.10.x-latest            # initial APIM image tag
 export APIM_410_CHART=4.10.*          # initial Helm chart version
 export APIM_LATEST_TAG=master-latest  # upgrade target image tag
-export APIM_LATEST_CHART=4.11.*       # upgrade target chart version
+export APIM_LATEST_CHART=4.12.*       # upgrade target chart version
 
 # GKO
 export GKO_410_IMAGE=graviteeio/kubernetes-operator:4.10.9
@@ -33,9 +33,6 @@ export PKI_JWT=examples/usecase/subscribe-to-jwt-plan/pki
 export PKI_MTLS=examples/usecase/subscribe-to-mtls-plan/pki
 export RUNBOOK=runbooks/upgrade-lifecycle
 
-# Branch
-export GIT_CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-export GIT_410_BRANCH=4.10.x
 ```
 
 ---
@@ -58,8 +55,8 @@ for component in apim-gateway apim-management-api apim-management-ui; do
 done
 
 # MongoDB
-docker pull mongo:7.0.30-jammy
-kind load docker-image mongo:7.0.30-jammy --name gravitee
+docker pull mongo:7.0.31-jammy
+kind load docker-image mongo:7.0.31-jammy --name gravitee
 
 ```
 
@@ -70,14 +67,19 @@ kind load docker-image mongo:7.0.30-jammy --name gravitee
 kubectl create secret tls tls-server \
   --cert=${PKI_MTLS}/server.crt --key=${PKI_MTLS}/server.key \
   --dry-run=client -o yaml | kubectl apply -f -
-
+  
 # Install APIM 4.10 with explicit image tags
 helm repo add graviteeio https://helm.gravitee.io
 helm repo update graviteeio
 
+kubectl apply -f $RUNBOOK/mongo-standalone.yaml
+kubectl wait --for=condition=ready pod -l app=mongodb --timeout=360s
+
 helm upgrade --install apim oci://graviteeio.azurecr.io/helm/apim3 \
   -f $APIM_VALUES \
   --version "$APIM_410_CHART" \
+  --set mongodb.enabled=false \
+  --set mongo.uri=mongodb://mongodb:27017/gravitee \
   --set gateway.image.repository=gravitee-apim-gateway \
   --set gateway.image.tag=dev \
   --set api.image.repository=gravitee-apim-management-api \
@@ -153,12 +155,8 @@ curl -s -o /dev/null -w "---\nstatus %{http_code}\n---\n" http://localhost:30082
 ### 3.1 Load new APIM images
 
 ```bash
-# TODO remove this once APIM images are published to the public registry
-export APIM_LATEST_TAG=local 
-export APIM_IMAGE_REGISTRY=graviteeio
 for component in apim-gateway apim-management-api apim-management-ui; do
-  # TODO uncomment when APIM images are published to the public registry
-  # docker pull ${APIM_IMAGE_REGISTRY}/${component}:${APIM_LATEST_TAG}
+  docker pull ${APIM_IMAGE_REGISTRY}/${component}:${APIM_LATEST_TAG}
   docker tag  ${APIM_IMAGE_REGISTRY}/${component}:${APIM_LATEST_TAG} gravitee-${component}:dev
   kind load docker-image gravitee-${component}:dev --name gravitee
 done
@@ -173,16 +171,14 @@ by pinning the MongoDB subchart values so Helm sees no diff on that resource.
 helm upgrade apim oci://graviteeio.azurecr.io/helm/apim3 \
   -f $APIM_VALUES \
   --version "$APIM_LATEST_CHART" \
+  --set mongodb.enabled=false \
+  --set mongo.uri=mongodb://mongodb:27017/gravitee \
   --set gateway.image.repository=gravitee-apim-gateway \
   --set gateway.image.tag=dev \
   --set api.image.repository=gravitee-apim-management-api \
   --set api.image.tag=dev \
   --set ui.image.repository=gravitee-apim-management-ui \
-  --set ui.image.tag=dev \
-  --set mongodb.enabled=true \
-  --set mongodb.architecture=standalone \
-  --set mongodb.auth.enabled=false \
-  --reuse-values
+  --set ui.image.tag=dev
 ```
 
 > `--reuse-values` prevents Helm from recomputing the MongoDB subchart template,
@@ -198,7 +194,7 @@ kubectl rollout status deployment/apim-apim3-api --timeout=120s
 Verify MongoDB pod did **not** restart:
 
 ```bash
-kubectl get pod -l app.kubernetes.io/component=mongodb -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}'
+kubectl get pod -l app=mongodb -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}'
 # Expected: 0
 ```
 
@@ -215,10 +211,7 @@ curl -s -o /dev/null -w "---\nstatus %{http_code}\n---\n" \
 ### 3.4 Upgrade GKO
 
 ```bash
-#TODO remove this once GKO is published to the public registry
-export GKO_LATEST_IMAGE=gko:dev
-# TODO uncomment when GKO is published to the public registry
-# docker pull $GKO_LATEST_IMAGE
+docker pull $GKO_LATEST_IMAGE
 kind load docker-image $GKO_LATEST_IMAGE --name gravitee
 
 helm upgrade gko helm/gko \


### PR DESCRIPTION
Use a separate Mongo deployment to upgrade easily without killing the DB