### PR TITLE
chore: set values for console and portal urls in kind APIM values

### DIFF
--- a/examples/apim/api_definition/v4/api-v4-llm-proxy.yml
+++ b/examples/apim/api_definition/v4/api-v4-llm-proxy.yml
@@ -40,7 +40,12 @@ spec:
           type: llm-proxy
           inheritConfiguration: false
           configuration:
+            provider: OPEN_AI
             target: https://api.openai.com
+            models:
+              - name: gpt-4o
+            authentication:
+              type: NONE
           secondary: false
   flowExecution:
     mode: DEFAULT

--- a/hack/kind/apim/values.yaml
+++ b/hack/kind/apim/values.yaml
@@ -135,6 +135,13 @@ installation:
     proxyPath:
       management: /management
       portal: /portal
+  standalone:
+    console:
+      urls:
+        - http://localhost:30080
+    portal:
+      urls:
+        - http://localhost:30080
 
 extraObjects:
   - apiVersion: v1


### PR DESCRIPTION
The APIM master-latest image now strictly validates `installation.standalone.console.url` at startup; the chart's default leaves it empty when `ui.ingress.enabled=false`, causing the management API to crash with `InvalidInstallationUrlException`.

Set `installation.standalone.console.urls` and `installation.standalone.portal.urls` so the rendered `gravitee.yml` has valid URLs and the management API boots cleanly.