### PR TITLE
test: re-enable notification e2e tests after Automation API support

### DIFF
--- a/test/platform-test/e2e/tests/gko/deployment-reconciliation/cr-managed-readonly.test.ts
+++ b/test/platform-test/e2e/tests/gko/deployment-reconciliation/cr-managed-readonly.test.ts
@@ -83,14 +83,8 @@ test.describe("CR-managed resources are read-only in APIM", () => {
   });
 
   // ── GKO-1234: Notification settings tagged origin=KUBERNETES
-  //
-  // Skipped: master-GKO ↔ APIM 4.11 payload mismatch. Master GKO sends embedded
-  // `consoleNotificationConfiguration` via the Automation API v4 import; APIM
-  // 4.11 silently drops it, so the default PORTAL setting comes back with
-  // origin=MANAGEMENT. Verified passing with GKO 4.11.4 against APIM 4.11.
-  // Re-enable when the test setup pins APIM ≥ 4.12.
 
-  test.skip(`Notification settings created via CR are origin=KUBERNETES ${XRAY.NOTIFICATIONS.CR_READONLY_VIA_MAPI} ${TAGS.REGRESSION}`, async ({
+  test(`Notification settings created via CR are origin=KUBERNETES ${XRAY.NOTIFICATIONS.CR_READONLY_VIA_MAPI} ${TAGS.REGRESSION}`, async ({
     kubectl,
     mapi,
   }) => {

--- a/test/platform-test/e2e/tests/gko/notifications/notification-cross-version.test.ts
+++ b/test/platform-test/e2e/tests/gko/notifications/notification-cross-version.test.ts
@@ -34,12 +34,7 @@ const NOTIFICATION = "crds/notifications/notification-shared.yaml";
 const V4_API = "crds/notifications/v4-api-using-shared-notification.yaml";
 const V2_API = "crds/notifications/v2-api-using-shared-notification.yaml";
 
-// Skipped: master-GKO ↔ APIM 4.11 payload mismatch. Master GKO sends embedded
-// `consoleNotificationConfiguration` via the Automation API v4 import; APIM
-// 4.11 silently drops it (PORTAL setting comes back with hooks/groups empty
-// and origin=MANAGEMENT). Verified passing with GKO 4.11.4 against APIM 4.11.
-// Re-enable when the test setup pins APIM ≥ 4.12.
-test.describe.skip("Notification CR — Cross Version", () => {
+test.describe("Notification CR — Cross Version", () => {
   test.afterEach(async () => {
     await kubectlSafe.del(fixture(V2_API)).catch(() => {});
     await kubectlSafe.del(fixture(V4_API)).catch(() => {});

--- a/test/platform-test/e2e/tests/gko/notifications/notification-recipients.test.ts
+++ b/test/platform-test/e2e/tests/gko/notifications/notification-recipients.test.ts
@@ -54,12 +54,7 @@ const NOTIF_1239 = "crds/notifications/notification-1239-group-members.yaml";
 const GROUP_1239 = "crds/notifications/group-1239-group-members.yaml";
 const API_1239 = "crds/notifications/v4-api-1239-with-group-members.yaml";
 
-// Skipped: master-GKO ↔ APIM 4.11 payload mismatch. Master GKO sends embedded
-// `consoleNotificationConfiguration` via the Automation API v4 import; APIM
-// 4.11 silently drops it (PORTAL setting comes back with hooks/groups empty
-// and origin=MANAGEMENT). Verified passing with GKO 4.11.4 against APIM 4.11.
-// Re-enable when the test setup pins APIM ≥ 4.12.
-test.describe.skip("Notifications — recipients & visibility", () => {
+test.describe("Notifications — recipients & visibility", () => {
   test.afterEach(async () => {
     // Reverse dependency order: API → Notification → Group
     await kubectlSafe.del(fixture(API_1239)).catch(() => {});

--- a/test/platform-test/e2e/tests/gko/notifications/notifications-export.test.ts
+++ b/test/platform-test/e2e/tests/gko/notifications/notifications-export.test.ts
@@ -44,12 +44,7 @@ interface ExportedCrd {
   };
 }
 
-// Skipped: master-GKO ↔ APIM 4.11 payload mismatch. Master GKO sends embedded
-// `consoleNotificationConfiguration` via the Automation API v4 import; APIM
-// 4.11 silently drops it (PORTAL setting comes back with hooks/groups empty
-// and origin=MANAGEMENT). Verified passing with GKO 4.11.4 against APIM 4.11.
-// Re-enable when the test setup pins APIM ≥ 4.12.
-test.describe.skip("Notifications — export & validation", () => {
+test.describe("Notifications — export & validation", () => {
   test.afterEach(async () => {
     await kubectlSafe.del(fixture(V4_API_WITH_NOTIF)).catch(() => {});
     await kubectlSafe.del(fixture(DUPLICATE_API)).catch(() => {});


### PR DESCRIPTION
Notification E2E tests were previously skipped because the Automation-API lacked notification management. GKO-2835 adds that support, so the tests can now run.

Changes:
- Un-skip the 4 notification test groups
- Remove the stale skip-reason comments

See: https://gravitee.atlassian.net/browse/GKO-2856