### PR TITLE
Test/fix dictionary fixture secondary

### DIFF
--- a/test/platform-test/e2e/fixtures/crds/dictionaries/api-with-dictionary.yaml
+++ b/test/platform-test/e2e/fixtures/crds/dictionaries/api-with-dictionary.yaml
@@ -38,6 +38,7 @@ spec:
         - name: echo
           type: http-proxy
           inheritConfiguration: false
+          secondary: false
           configuration:
             target: https://api.gravitee.io/echo
   flowExecution:

--- a/test/platform-test/e2e/fixtures/crds/dictionaries/api-with-dynamic-dictionary-tpl.yaml
+++ b/test/platform-test/e2e/fixtures/crds/dictionaries/api-with-dynamic-dictionary-tpl.yaml
@@ -38,6 +38,7 @@ spec:
         - name: Default HTTP proxy
           type: http-proxy
           inheritConfiguration: false
+          secondary: false
           configuration:
             target: https://api.gravitee.io/echo
   flowExecution:

--- a/test/platform-test/e2e/fixtures/crds/dictionaries/api-with-dynamic-dictionary.yaml
+++ b/test/platform-test/e2e/fixtures/crds/dictionaries/api-with-dynamic-dictionary.yaml
@@ -38,6 +38,7 @@ spec:
         - name: Default HTTP proxy
           type: http-proxy
           inheritConfiguration: false
+          secondary: false
           configuration:
             target: https://api.gravitee.io/echo
   flowExecution:

--- a/test/platform-test/e2e/tests/gko/dictionaries/dictionary-templating.test.ts
+++ b/test/platform-test/e2e/tests/gko/dictionaries/dictionary-templating.test.ts
@@ -46,7 +46,11 @@ async function gatewayBaseUrl(): Promise<string> {
 }
 
 test.describe("Dictionaries — Templating", () => {
-  test(`Dynamic dictionary with secret templates resolves in API header ${XRAY.DICTIONARIES.DYNAMIC_TEMPLATE_RESOLVE} ${TAGS.REGRESSION}`, async ({
+  // FIXME(GKO-2858): a secret-templated Dictionary cannot be deleted — the Dictionary
+  // controller runs template.Compile before the IsBeingDeleted() check, so the finalizer
+  // is never removed and cleanup hangs in Terminating. Un-fixme once GKO-2858 is fixed.
+  // https://gravitee.atlassian.net/browse/GKO-2858
+  test.fixme(`Dynamic dictionary with secret templates resolves in API header ${XRAY.DICTIONARIES.DYNAMIC_TEMPLATE_RESOLVE} ${TAGS.REGRESSION}`, async ({
     kubectl,
   }) => {
     const secretFixture = fixture("crds/dictionaries/dictionary-dynamic-tpl-secret.yaml");


### PR DESCRIPTION
## What

The 3 Dictionary CRD e2e fixtures added in #1671 omitted the required `secondary`
field on their endpoint, causing all dictionary e2e tests to fail in CI with:
```
ApiV4Definition "e2e-api-with-dict" is invalid:
spec.endpointGroups[0].endpoints[0].secondary: Required value
```


## Changes

- Add `secondary: false` to the endpoint in `api-with-dictionary.yaml`,
  `api-with-dynamic-dictionary.yaml`, and `api-with-dynamic-dictionary-tpl.yaml`
  (matching every other `ApiV4Definition` fixture).
- Mark `dictionary-templating.test.ts` as `test.fixme()` — it surfaces a separate
  operator bug ([GKO-2858](https://gravitee.atlassian.net/browse/GKO-2858)): a
  secret-templated Dictionary cannot be deleted because the controller runs
  `template.Compile` before the `IsBeingDeleted()` check, so the finalizer is
  never removed. Un-fixme once GKO-2858 is fixed.

[GKO-2858]: https://gravitee.atlassian.net/browse/GKO-2858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ