### PR TITLE
test: correct stale Xray tags for Dictionary tests

### DIFF
--- a/test/platform-test/e2e/helpers/tags.ts
+++ b/test/platform-test/e2e/helpers/tags.ts
@@ -236,10 +236,14 @@ export const XRAY = {
     PREVENT_PO_GROUP_AS_MEMBER: "@GKO-974",
   },
   DICTIONARIES: {
-    CREATE_AND_RESOLVE: "@GKO-2562",
-    DELETE_DICTIONARY: "@GKO-2563",
-    DYNAMIC_RESOLVE: "@GKO-2564",
-    DYNAMIC_TEMPLATE_RESOLVE: "@GKO-TBD-DICT-DYNAMIC-TPL",
+    // @parent: GKO-2562
+    CREATE_AND_RESOLVE: "@GKO-2903",
+    DELETE_DICTIONARY: "@GKO-2905",
+    DYNAMIC_RESOLVE: "@GKO-2904",
+    // DYNAMIC_TEMPLATE_RESOLVE is currently skipped pending GKO-2858 — templated
+    // Dictionary cannot be deleted because secret-resolve runs during the delete
+    // reconcile.
+    DYNAMIC_TEMPLATE_RESOLVE: "@GKO-2902",
   },
   SHARED_POLICY_GROUPS: {
     ADD_SPG_TO_API: "@GKO-976",


### PR DESCRIPTION
## Summary

Aligns `XRAY.DICTIONARIES.*` entries in [test/platform-test/e2e/helpers/tags.ts](test/platform-test/e2e/helpers/tags.ts) with the actual Jira Test tickets:

| Const | Before | After | Test ticket |
|---|---|---|---|
| `CREATE_AND_RESOLVE` | `@GKO-2562` (parent Story) | `@GKO-2903` | [MANUAL Dictionary CRD resolves in API response header](https://gravitee.atlassian.net/browse/GKO-2903) |
| `DELETE_DICTIONARY` | `@GKO-2563` (parent Story) | `@GKO-2905` | [Dictionary CRD can be deleted](https://gravitee.atlassian.net/browse/GKO-2905) |
| `DYNAMIC_RESOLVE` | `@GKO-2564` (**unrelated** TF-groups Story) | `@GKO-2904` | [DYNAMIC Dictionary CRD resolves in API response header](https://gravitee.atlassian.net/browse/GKO-2904) |
| `DYNAMIC_TEMPLATE_RESOLVE` | `@GKO-TBD-DICT-DYNAMIC-TPL` | `@GKO-2902` | [Dynamic Dictionary with secret templates resolves in API header](https://gravitee.atlassian.net/browse/GKO-2902) |

All four Test tickets already exist in Jira with the `automated` label and Gherkin scenarios in the description.

## Why a separate PR

These corrections were originally bundled inside #1675 (commit `84235aa8`) alongside unrelated TF-groups feature work and other tag remappings. Extracted here so the dictionary cleanup can land independently and unblock the GKO-2565 DYNAMIC dictionary e2e extension work without waiting on the TF-groups review cycle.

After this lands, #1675 will be rebased to drop these four lines from its cleanup commit.

## Test plan

- [x] No production code changed — pure tag rename.
- [x] `npm --prefix test/platform-test run typecheck` — clean (no type changes).
- [ ] CI passes.