### PR TITLE
test: skip GKO-1472 V4 export/import round-trip pending GKO-2919

### DIFF
--- a/test/platform-test/e2e/tests/gko/import-export/v4-import-export-extended.test.ts
+++ b/test/platform-test/e2e/tests/gko/import-export/v4-import-export-extended.test.ts
@@ -92,7 +92,13 @@ test.describe("V4 Import/Export — Extended", () => {
   // or produces an unimportable CRD, the apply will fail or the reconciliation
   // will move off Accepted.
 
-  test(`V4 CRD export/import round-trip preserves identity ${XRAY.IMPORT_EXPORT.V4_EXPORT_IMPORT_ROUND_TRIP} ${TAGS.REGRESSION}`, async ({
+  // Skipped pending GKO-2919: the GKO ApiV4Definition CRD does not declare
+  // `spec.allowedInApiProducts` or `spec.allowMultiJwtOauth2Subscriptions`,
+  // but APIM PR #17029 (commit d3c94cd7) added both to the v2 CRD export spec,
+  // so re-applying the exported YAML fails strict field validation on
+  // CircleCI. Re-enable once GKO adds the two fields to ApiV4Definition and
+  // regenerates the CRD.
+  test.skip(`V4 CRD export/import round-trip preserves identity ${XRAY.IMPORT_EXPORT.V4_EXPORT_IMPORT_ROUND_TRIP} ${TAGS.REGRESSION}`, async ({
     kubectl,
     mapi,
   }) => {


### PR DESCRIPTION
### Issue
APIM emits `spec.allowMultiJwtOauth2Subscriptions` and `spec.allowedInApiProducts` on V4 HTTP proxy CRD exports; neither field is declared on the GKO ApiV4Definition CRD, so the round-trip re-apply fails strict field validation on CircleCI. 

### Action taken
Skipping until problem is fixed.