### PR TITLE
test: push Playwright e2e results from CircleCI to Xray Cloud (GKO-2906)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -495,6 +495,16 @@ jobs:
           name: Wait for operator to be ready
           command: |
             kubectl rollout status deployment/gko-controller-manager -n default --timeout=120s
+      # Export the Xray Cloud API credentials BEFORE the e2e run. keeper/env-export
+      # runs on_success, so placing it here (while the pipeline is still green)
+      # guarantees the creds are in BASH_ENV for the `when: always` push step below
+      # even when the e2e run itself fails.
+      - keeper/env-export:
+          secret-url: keeper://so8_Jh2tP-AZSbtIYcbBvg/custom_field/CLIENT ID
+          var-name: XRAY_CLIENT_ID
+      - keeper/env-export:
+          secret-url: keeper://so8_Jh2tP-AZSbtIYcbBvg/custom_field/CLIENT SECRET
+          var-name: XRAY_CLIENT_SECRET
       - run:
           name: Run Playwright E2E tests
           command: npm --prefix test/platform-test run e2e
@@ -523,6 +533,22 @@ jobs:
       - store_artifacts:
           path: /tmp/junit/reports/cover-e2e.out
           destination: cover-e2e.out
+      # Best-effort push of the Playwright JUnit results to Xray Cloud so the
+      # "Test Coverage" panel on each linked Jira Test reflects the latest run.
+      # See test/platform-test/scripts/xray/README.md for env-var setup. Runs
+      # `when: always` so failed test runs still surface their failures in Jira
+      # instead of leaving the panel stuck at TO DO. The XRAY_CLIENT_* creds are
+      # exported earlier (before the e2e run) by keeper/env-export.
+      - run:
+          name: Push results to Xray Cloud
+          when: always
+          command: ./test/platform-test/scripts/xray/push-results.sh
+      # Note: store_artifacts can't take `when: always`; if e2e fails this
+      # step is skipped — the Test Execution key is still in the build log
+      # of the "Push results to Xray Cloud" step above.
+      - store_artifacts:
+          path: /tmp/xray-test-execution.txt
+          destination: xray-test-execution.txt
 
   job-stage-helm-chart:
     docker:

--- a/test/platform-test/scripts/xray/README.md
+++ b/test/platform-test/scripts/xray/README.md
@@ -1,0 +1,111 @@
+# test/platform-test/scripts/xray/
+
+Wiring for **pushing CircleCI e2e results into Xray Cloud** so the
+"Test Coverage" panel on each linked Jira Test (and on the parent Story it
+`is tested by`) reflects the latest run instead of staying at `TO DO`.
+
+This is the **write** counterpart to the read-side `xray-export` Claude Code
+skill — they don't overlap.
+
+## How it fits together
+
+1. The Playwright e2e suite (`test/platform-test/`) is already configured to
+   emit a JUnit XML report at `test/platform-test/playwright-results/results.xml`
+   (see `playwright.config.ts`, `["junit", { outputFile: ... }]`).
+2. Each test title already carries its Xray Test issue key as a tag, e.g.
+   `terraform apply creates the group in APIM @GKO-2865 @regression`, via
+   the `XRAY` constants in [`e2e/helpers/tags.ts`](../../e2e/helpers/tags.ts).
+3. After the e2e job runs, the CircleCI step `Push results to Xray Cloud`
+   invokes [`push-results.sh`](./push-results.sh). It authenticates to Xray
+   Cloud, runs [`junit-to-xray.mjs`](./junit-to-xray.mjs) to convert the JUnit
+   report into Xray's **JSON results format** keyed by the `@GKO-NNNN` id in
+   each title, and POSTs it to `/api/v2/import/execution`.
+4. Xray Cloud creates a new **Test Execution** in Jira and, because each result
+   carries a `testKey`, attaches it to the *existing* Test issue — updating that
+   Test's "Test Coverage" panel with `PASSED` / `FAILED`.
+5. If a `XRAY_TEST_PLAN_KEY` is set, the Test Execution is also linked to
+   that Test Plan, so the Plan view shows trend over time.
+
+> **Why JSON, not raw JUnit?** Xray's JUnit importer matches Tests by
+> `classname`+`name` (its "Generic Test Definition"), **not** by a Jira key in
+> the title — so a raw JUnit import creates a *duplicate* Test issue per
+> testcase instead of updating the existing one. The JSON format's `testKey`
+> is the only thing that binds a result to a pre-existing Test.
+
+Skipped / `test.fixme`'d cases are **omitted** from the payload so a
+temporarily-disabled test doesn't overwrite a Test's last real result with
+`TODO`.
+
+The script is **best-effort** — auth failures, credential gaps, missing
+`jq` / `node`, missing results file, network errors all log a warning and
+exit 0. The pipeline's pass/fail gate is unaffected (CircleCI parses
+`store_test_results` independently).
+
+## Environment variables
+
+| Variable | Required? | Default | Purpose |
+|----------|-----------|---------|---------|
+| `XRAY_CLIENT_ID` | yes | — | Xray Cloud API key client id |
+| `XRAY_CLIENT_SECRET` | yes | — | Xray Cloud API key client secret |
+| `XRAY_TEST_PLAN_KEY` | no | — | Existing Test Plan issue (e.g. `GKO-NNNN`) to roll runs up to |
+| `CIRCLE_BUILD_URL` / `CIRCLE_BUILD_NUM` / `CIRCLE_BRANCH` | no | autodetected | Used to build the Test Execution summary + description; CircleCI sets them automatically |
+
+The Test Execution is created in the project of the referenced Tests (GKO),
+so no project key is needed.
+
+In CI the two `XRAY_CLIENT_*` vars are injected by the `keeper/env-export`
+orb from the Keeper record `so8_Jh2tP-AZSbtIYcbBvg` (custom fields
+`CLIENT ID` / `CLIENT SECRET`) — see the two `keeper/env-export` steps in
+`job-e2e-tests`, placed *before* the e2e run so they still run while the
+pipeline is green (the orb command runs `on_success`). Generate a fresh
+key pair from Jira if needed: *Apps → Xray → Global Settings → API Keys →
+Create*.
+
+## Local run
+
+After a local e2e run:
+
+```sh
+export XRAY_CLIENT_ID=...
+export XRAY_CLIENT_SECRET=...
+# optional: export XRAY_TEST_PLAN_KEY=GKO-NNNN
+
+./test/platform-test/scripts/xray/push-results.sh
+# → [xray-push] reporting 6 test result(s) to Xray Cloud
+# → [xray-push] created Test Execution GKO-NNNN
+```
+
+Spot-check by opening the created Test Execution in Jira, and any of the
+linked Tests (e.g. [GKO-2865](https://gravitee.atlassian.net/browse/GKO-2865))
+— the "Test Coverage" panel should now show the run with the right status.
+
+You can pass a custom results path as the first argument if you've moved
+the JUnit file:
+
+```sh
+./test/platform-test/scripts/xray/push-results.sh /path/to/results.xml
+```
+
+## CI invocation
+
+The script is invoked from `.circleci/config.yml` inside `job-e2e-tests`,
+right after the existing `store_artifacts` steps. The CI step uses
+`when: always` so failed runs still report their failures back to Xray.
+
+The credentials are loaded earlier in the job by two `keeper/env-export`
+steps placed **before** the `Run Playwright E2E tests` step. That ordering
+matters: `keeper/env-export` runs `on_success`, so if it were placed next to
+the `when: always` push step and the e2e run failed, the export would be
+skipped and the push would run without credentials.
+
+## What this script intentionally doesn't do
+
+- **No Playwright reporter swap.** A community `playwright-xray-cloud-reporter`
+  exists but adds a runtime dep and pushes per-test rather than per-suite.
+  Keeping the push as a post-step keeps the test container clean.
+- **No Cucumber import.** The Gherkin scenarios live in the Jira Test
+  descriptions, not in `.feature` files. The JUnit report (transformed to
+  Xray JSON) is sufficient for per-Test status.
+- **No PR comment / Slack callout.** The Test Execution key is written to
+  `/tmp/xray-test-execution.txt` and stored as a CircleCI artifact —
+  follow-up automation can pick it up from there.

--- a/test/platform-test/scripts/xray/junit-to-xray.mjs
+++ b/test/platform-test/scripts/xray/junit-to-xray.mjs
@@ -1,0 +1,102 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Transform a Playwright JUnit XML report into the Xray Cloud JSON results
+// format, keyed by the @GKO-NNNN Jira Test issue id embedded in each test
+// title. Unlike the JUnit importer (which matches Tests by classname+name and
+// would create duplicate Test issues), this lets Xray attach each result to the
+// existing Test by its key, updating that Test's "Test Coverage" panel.
+//
+// Reads the JUnit XML from argv[2] (or stdin), writes Xray JSON to stdout:
+//   { info: { summary, description, [testPlanKey] }, tests: [ { testKey, status } ] }
+//
+// Status mapping: <failure>/<error> -> FAILED, otherwise PASSED. Skipped /
+// test.fixme'd cases are omitted entirely so a temporarily-disabled test does
+// not overwrite a Test's previously recorded result with TODO.
+//
+// Env (all optional): XRAY_SUMMARY, XRAY_DESCRIPTION, XRAY_TEST_PLAN_KEY.
+
+import { readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const KEY_RE = /@(GKO-\d+)/g;
+
+export function decodeEntities(s) {
+  return s
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+export function parseTestcases(xml) {
+  const cases = [];
+  const re = /<testcase\b([^>]*)>([\s\S]*?)<\/testcase>/g;
+  let m;
+  while ((m = re.exec(xml)) !== null) {
+    const attrs = m[1];
+    const inner = m[2];
+    const nameMatch = /(?:^|\s)name="([^"]*)"/.exec(attrs);
+    if (!nameMatch) continue;
+    const name = decodeEntities(nameMatch[1]);
+    const failed = /<(failure|error)\b/.test(inner);
+    const skipped = /<skipped\b/.test(inner);
+    cases.push({ name, failed, skipped });
+  }
+  return cases;
+}
+
+export function toTests(cases) {
+  // One Test issue maps to one result. If a title carries several @GKO keys,
+  // record the same status against each. Last write wins per key within a run.
+  const byKey = new Map();
+  for (const c of cases) {
+    if (c.skipped) continue; // not executed -> leave the Test's prior result intact
+    const keys = [...c.name.matchAll(KEY_RE)].map((k) => k[1]);
+    const status = c.failed ? "FAILED" : "PASSED";
+    for (const key of keys) byKey.set(key, status);
+  }
+  return [...byKey].map(([testKey, status]) => ({ testKey, status }));
+}
+
+export function buildPayload(xml, { summary, description, testPlanKey } = {}) {
+  const tests = toTests(parseTestcases(xml));
+  const info = {
+    summary: summary || "GKO e2e — automated import",
+    description: description || "Automated import of Playwright e2e results",
+  };
+  if (testPlanKey) info.testPlanKey = testPlanKey;
+  return { info, tests };
+}
+
+function main() {
+  const path = process.argv[2];
+  const xml = path ? readFileSync(path, "utf8") : readFileSync(0, "utf8");
+  const payload = buildPayload(xml, {
+    summary: process.env.XRAY_SUMMARY,
+    description: process.env.XRAY_DESCRIPTION,
+    testPlanKey: process.env.XRAY_TEST_PLAN_KEY,
+  });
+  process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
+}
+
+// Run only when executed directly, not when imported (e.g. by unit tests).
+const invokedDirectly =
+  process.argv[1] &&
+  realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
+if (invokedDirectly) main();

--- a/test/platform-test/scripts/xray/push-results.sh
+++ b/test/platform-test/scripts/xray/push-results.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Push the Playwright e2e results to Xray Cloud as a Test Execution so the
+# matching Jira Test issues' "Test Coverage" panel reflects each run.
+#
+# The JUnit report is transformed (junit-to-xray.mjs) into Xray's JSON results
+# format, keyed by the Jira issue id embedded in each test title — the platform
+# test suite already includes those via the XRAY constants in
+# e2e/helpers/tags.ts (e.g. "... @GKO-2865 @regression"). Importing as Xray
+# JSON (rather than raw JUnit) is what makes results attach to the existing
+# Tests by key instead of creating duplicate Test issues.
+#
+# Best-effort: if Xray is unreachable, credentials are missing, or the upload
+# fails for any reason, the script exits 0 with a warning. The pipeline's
+# pass/fail gate is unaffected — that's CircleCI's own test-result parsing.
+#
+# Usage:
+#   XRAY_CLIENT_ID=...  XRAY_CLIENT_SECRET=... \
+#       ./test/platform-test/scripts/xray/push-results.sh [path/to/junit-results.xml]
+#
+# Env vars (consumed by the script):
+#   XRAY_CLIENT_ID         (required) Xray Cloud API client id
+#   XRAY_CLIENT_SECRET     (required) Xray Cloud API client secret
+#   XRAY_TEST_PLAN_KEY     (optional) existing Test Plan issue key; if set, the
+#                          new Test Execution is linked to it so the Plan view
+#                          shows trend over time
+#   CIRCLE_BUILD_URL,
+#   CIRCLE_BUILD_NUM,
+#   CIRCLE_BRANCH          (optional) populated automatically in CircleCI; used
+#                          in the resulting Test Execution summary/description
+
+set -uo pipefail
+
+# Resolve paths relative to this script so it works both from the repo root
+# and once test/platform-test/ is extracted into its own repository.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLATFORM_TEST_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+RESULTS_PATH="${1:-${PLATFORM_TEST_DIR}/playwright-results/results.xml}"
+TRANSFORM="${SCRIPT_DIR}/junit-to-xray.mjs"
+PAYLOAD_FILE="${TMPDIR:-/tmp}/xray-execution.json"
+KEY_FILE="${TMPDIR:-/tmp}/xray-test-execution.txt"
+
+log() { printf '[xray-push] %s\n' "$*"; }
+warn_and_exit() { log "WARN: $*"; log "skipping Xray upload — pipeline not affected"; exit 0; }
+
+# ── Preflight ────────────────────────────────────────────────────────
+
+[[ -f "${RESULTS_PATH}" ]] \
+  || warn_and_exit "no JUnit results found at ${RESULTS_PATH}"
+
+[[ -n "${XRAY_CLIENT_ID:-}" && -n "${XRAY_CLIENT_SECRET:-}" ]] \
+  || warn_and_exit "XRAY_CLIENT_ID / XRAY_CLIENT_SECRET not set"
+
+command -v jq >/dev/null \
+  || warn_and_exit "jq not on PATH"
+
+command -v node >/dev/null \
+  || warn_and_exit "node not on PATH"
+
+[[ -f "${TRANSFORM}" ]] \
+  || warn_and_exit "transform script missing at ${TRANSFORM}"
+
+# ── 1. Authenticate → JWT ────────────────────────────────────────────
+#
+# The /authenticate endpoint returns the token as a JSON string (i.e. a
+# bare quoted string). `jq -r .` strips the quotes; -f makes curl error on
+# non-2xx so we can fall through to warn_and_exit.
+
+TOKEN=$(curl -fsS -X POST \
+          -H 'Content-Type: application/json' \
+          -d "{\"client_id\":\"${XRAY_CLIENT_ID}\",\"client_secret\":\"${XRAY_CLIENT_SECRET}\"}" \
+          https://xray.cloud.getxray.app/api/v2/authenticate \
+        | jq -r '.') \
+  || warn_and_exit "auth to Xray Cloud failed"
+
+[[ -n "${TOKEN}" && "${TOKEN}" != "null" ]] \
+  || warn_and_exit "auth returned an empty token"
+
+# ── 2. Build the Xray JSON payload ───────────────────────────────────
+#
+# Convert the JUnit report into Xray's JSON results format, keyed by the
+# @GKO-NNNN Test issue id embedded in each title, so each result attaches to
+# the *existing* Test (the JUnit importer instead matches Tests by
+# classname+name and would create duplicate Test issues). Skipped / fixme'd
+# cases are dropped so they don't overwrite a Test's prior result with TODO.
+
+BRANCH="${CIRCLE_BRANCH:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo local)}"
+BUILD_NUM="${CIRCLE_BUILD_NUM:-local}"
+BUILD_URL="${CIRCLE_BUILD_URL:-(local run)}"
+
+XRAY_SUMMARY="GKO e2e - ${BUILD_NUM} (${BRANCH})" \
+XRAY_DESCRIPTION="Automated import from CircleCI: ${BUILD_URL}" \
+XRAY_TEST_PLAN_KEY="${XRAY_TEST_PLAN_KEY:-}" \
+  node "${TRANSFORM}" "${RESULTS_PATH}" > "${PAYLOAD_FILE}" \
+  || warn_and_exit "failed to build Xray payload from ${RESULTS_PATH}"
+
+TEST_COUNT=$(jq '.tests | length' "${PAYLOAD_FILE}" 2>/dev/null || echo 0)
+if [[ "${TEST_COUNT}" -eq 0 ]]; then
+  warn_and_exit "no @GKO-tagged results to report (all skipped or untagged)"
+fi
+log "reporting ${TEST_COUNT} test result(s) to Xray Cloud"
+
+# ── 3. POST the Xray JSON results ────────────────────────────────────
+#
+# Capture the body and HTTP status separately (no -f) so a non-2xx
+# response surfaces Xray's actual error message instead of an opaque
+# curl exit code — the import endpoint returns the reason in the body.
+
+BODY_FILE="${TMPDIR:-/tmp}/xray-upload-response.json"
+HTTP_CODE=$(curl -sS -o "${BODY_FILE}" -w '%{http_code}' -X POST \
+              -H "Authorization: Bearer ${TOKEN}" \
+              -H "Content-Type: application/json" \
+              --data @"${PAYLOAD_FILE}" \
+              "https://xray.cloud.getxray.app/api/v2/import/execution") \
+  || warn_and_exit "could not reach Xray Cloud import endpoint"
+
+RESP=$(cat "${BODY_FILE}" 2>/dev/null)
+
+if [[ "${HTTP_CODE}" != 2* ]]; then
+  log "WARN: import endpoint returned HTTP ${HTTP_CODE}"
+  log "raw response: ${RESP}"
+  warn_and_exit "upload to Xray Cloud failed"
+fi
+
+# ── 4. Capture the Test Execution key as a build artifact ────────────
+
+TEST_EXEC_KEY=$(echo "${RESP}" | jq -r '.testExecIssue.key // .key // empty')
+if [[ -z "${TEST_EXEC_KEY}" ]]; then
+  log "WARN: Xray accepted the upload but no Test Execution key was returned"
+  log "raw response: ${RESP}"
+  exit 0
+fi
+
+echo "${TEST_EXEC_KEY}" > "${KEY_FILE}"
+log "created Test Execution ${TEST_EXEC_KEY}"
+log "  Jira: https://gravitee.atlassian.net/browse/${TEST_EXEC_KEY}"
+log "  key written to ${KEY_FILE}"

--- a/test/platform-test/test/scripts/junit-to-xray.test.ts
+++ b/test/platform-test/test/scripts/junit-to-xray.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect } from "vitest";
+import { parseTestcases, toTests, buildPayload } from "../../scripts/xray/junit-to-xray.mjs";
+
+const tc = (name: string, body = "") =>
+  `<testcase name="${name}" classname="suite.test.ts" time="1.0">${body}</testcase>`;
+
+describe("junit-to-xray transform", () => {
+  it("maps a clean testcase to PASSED keyed by its @GKO id", () => {
+    const xml = tc("does a thing @GKO-100 @regression");
+    expect(toTests(parseTestcases(xml))).toEqual([{ testKey: "GKO-100", status: "PASSED" }]);
+  });
+
+  it("maps <failure> and <error> to FAILED", () => {
+    const xml =
+      tc("fails @GKO-1", "<failure>boom</failure>") + tc("errors @GKO-2", "<error>nope</error>");
+    expect(toTests(parseTestcases(xml))).toEqual([
+      { testKey: "GKO-1", status: "FAILED" },
+      { testKey: "GKO-2", status: "FAILED" },
+    ]);
+  });
+
+  it("omits skipped / fixme'd cases so a Test's prior result is not clobbered", () => {
+    const xml =
+      tc("ran @GKO-1") +
+      tc("skipped @GKO-2", "<properties><property name=\"fixme\" value=\"\"></property></properties><skipped></skipped>");
+    expect(toTests(parseTestcases(xml))).toEqual([{ testKey: "GKO-1", status: "PASSED" }]);
+  });
+
+  it("drops testcases without a @GKO key", () => {
+    const xml = tc("untagged test") + tc("tagged @GKO-9");
+    expect(toTests(parseTestcases(xml))).toEqual([{ testKey: "GKO-9", status: "PASSED" }]);
+  });
+
+  it("emits one entry per key when a title carries several", () => {
+    const xml = tc("covers two @GKO-1 @GKO-2");
+    expect(toTests(parseTestcases(xml))).toEqual([
+      { testKey: "GKO-1", status: "PASSED" },
+      { testKey: "GKO-2", status: "PASSED" },
+    ]);
+  });
+
+  it("does not mistake classname for the test name and survives XML entities", () => {
+    const xml = tc("A &amp; B &gt; C @GKO-42");
+    expect(toTests(parseTestcases(xml))).toEqual([{ testKey: "GKO-42", status: "PASSED" }]);
+  });
+
+  it("last status wins when the same key appears twice in a run", () => {
+    const xml = tc("first @GKO-7") + tc("retry @GKO-7", "<failure>flaky</failure>");
+    expect(toTests(parseTestcases(xml))).toEqual([{ testKey: "GKO-7", status: "FAILED" }]);
+  });
+});
+
+describe("buildPayload", () => {
+  it("wraps tests with default info when none supplied", () => {
+    const payload = buildPayload(tc("t @GKO-1"));
+    expect(payload.tests).toEqual([{ testKey: "GKO-1", status: "PASSED" }]);
+    expect(payload.info.summary).toBeTruthy();
+    expect(payload.info).not.toHaveProperty("testPlanKey");
+  });
+
+  it("uses provided summary/description and adds testPlanKey only when set", () => {
+    const payload = buildPayload(tc("t @GKO-1"), {
+      summary: "run 42",
+      description: "from CI",
+      testPlanKey: "GKO-500",
+    });
+    expect(payload.info).toEqual({
+      summary: "run 42",
+      description: "from CI",
+      testPlanKey: "GKO-500",
+    });
+  });
+});


### PR DESCRIPTION

Pushes Playwright e2e results to Xray Cloud from CircleCI so each linked Jira Test's **Test Coverage** panel reflects real pass/fail.



See: https://gravitee.atlassian.net/browse/GKO-2906