### PR TITLE
docs(platform-test): improve documentation about getting started with E2E

### DIFF
--- a/test/platform-test/README.md
+++ b/test/platform-test/README.md
@@ -2,6 +2,20 @@
 
 Assertion library for Gravitee platform e2e testing. TypeScript, minimal dependencies, test-runner agnostic.
 
+## Running the E2E test suite
+
+The Playwright suite under [`e2e/`](e2e/) drives end-to-end tests for both the
+**Gravitee Kubernetes Operator** and the **Terraform APIM provider** against a
+live APIM + Gateway stack. See **[e2e/README.md](e2e/README.md)** for
+prerequisites, cluster bootstrap, and how to run the suite.
+
+Quick start (assumes a local cluster with APIM + GKO is already running):
+
+```bash
+npm install && npm run build
+npm run e2e
+```
+
 ## Install
 
 ```bash

--- a/test/platform-test/e2e/README.md
+++ b/test/platform-test/e2e/README.md
@@ -1,34 +1,177 @@
 # E2E Tests
 
-End-to-end tests for GKO and the Terraform APIM provider, built on Playwright Test.
+End-to-end tests for the **Gravitee Kubernetes Operator** and the **Terraform
+APIM provider**, built on Playwright Test. The suite drives a real local
+Kubernetes cluster running APIM, Gateway, and the GKO operator — there are no
+mocks.
+
+This doc takes you from a fresh checkout to a green `npm run e2e`.
+
+> Looking to run the GKO operator locally for development (not E2E)? See
+> [CONTRIBUTING.adoc](../../../CONTRIBUTING.adoc) — that path runs the operator
+> on your host and does **not** satisfy the in-cluster operator probe used by
+> this suite.
 
 ## Prerequisites
 
-- APIM, Gateway, and GKO operator running (e.g. via Kind)
-- `kubectl` configured and pointing at the cluster
-- `terraform` CLI installed (for Terraform tests)
-- `config.yaml` in `test/platform-test/` with APIM/Gateway endpoints and credentials (see sample in repo)
+Host tools (install before bootstrapping the cluster):
 
-## Running
+| Tool | Version | Notes |
+|------|---------|-------|
+| Node.js | ≥ 18 | per `package.json#engines` |
+| `kubectl` | recent | tests shell out to it (`helpers/kubectl.ts`) |
+| `kind` | recent | local Kubernetes cluster |
+| `helm` | recent | installs the GKO chart |
+| `terraform` | 1.12.1 | matches CI; Terraform tests assume it on `PATH` |
+| Docker | recent | required by Kind and by `sew` |
+
+The suite also expects:
+
+- An APIM + Gateway stack reachable from the host (default URLs
+  `http://localhost:30083` / `http://localhost:30082`).
+- The GKO operator running **as a Deployment** in the cluster (any namespace).
+- The GKO CRDs installed (notably `apiv4definitions.gravitee.io`).
+
+These three are validated by [`global-setup.ts`](global-setup.ts) before any
+test runs — see [Pre-flight checks](#pre-flight-checks).
+
+## Bring up the cluster + APIM + GKO
+
+Two supported paths. Pick one.
+
+### Option A — CI-blessed path (recommended)
+
+Mirrors what CI runs in `.circleci/config.yml` (`job-e2e-tests`):
+
+```bash
+# From the repo root
+make start-cluster                       # Kind + APIM CE via hack/scripts/run-kind.mjs
+
+# Build the operator image, load it into Kind, install via Helm
+IMG=gko TAG=latest make docker-build \
+  && kind load docker-image gko:latest --name gravitee \
+  && helm upgrade --install gko helm/gko -n default \
+    --set manager.image.repository=gko \
+    --set manager.image.tag=latest
+
+kubectl rollout status deployment/gko-controller-manager -n default --timeout=120s
+```
+
+### Option B — `sew` (one-shot stack composer)
+
+[`sew`](https://a-cordier.github.io/sew/) is a third-party Kubernetes stack
+composer that brings up APIM + GKO in a single command from its registry.
+It is **not** part of this repo — you author your own `sew.yaml` and run
+`sew create`.
+
+Install (macOS):
+
+```bash
+brew install sew
+```
+
+Pick a starter composition for E2E:
+
+```yaml
+# sew.yaml — minimal: APIM (DB-less) + GKO
+from:
+  - gravitee-io/oss/apim/dbless
+```
+
+```yaml
+# sew.yaml — full stack: APIM + MongoDB + Elasticsearch + GKO (closer to CI)
+from:
+  - gravitee-io/oss/apim/mongodb
+```
+
+Then:
+
+```bash
+sew info --from gravitee-io/oss/apim/mongodb   # preview the composition
+sew create                                     # bring up the stack
+sew delete                                     # tear it down
+```
+
+`sew` installs GKO into the `gravitee` namespace, while Option A uses
+`default`. The suite probes all namespaces (`kubectl get deploy -A`), so both
+work. EE registry variants (`gravitee-io/ee/apim/*`) exist but require a
+licence file and are out of scope here — see the
+[sew registry](https://a-cordier.github.io/sew/registry/).
+
+## Build platform-test
+
+```bash
+cd test/platform-test
+npm install
+npm run build
+```
+
+## Configuration
+
+The suite reads [`config.yaml`](../config.yaml) from `test/platform-test/`. It
+is committed and defaults match the local cluster brought up by Option A or B,
+so no edits are needed for the common case.
+
+Environment variables override fields in `config.yaml`:
+
+| Variable | Overrides |
+|----------|-----------|
+| `GRAVITEE_BASE_URL` | `apim.baseUrl` |
+| `GRAVITEE_ENV_ID` | `apim.envId` |
+| `GRAVITEE_USERNAME` | `apim.auth.username` |
+| `GRAVITEE_PASSWORD` | `apim.auth.password` |
+| `GRAVITEE_GATEWAY_URL` | `gateway.baseUrl` |
+| `GRAVITEE_GATEWAY_MTLS_URL` | `gateway.mtlsBaseUrl` |
+
+## Terraform provider
+
+Terraform tests under [`tests/terraform/`](tests/terraform/) use the
+registry-published `gravitee-io/apim` provider by default - no extra setup.
+
+To exercise unreleased provider code, build the provider from source into a
+local mirror that `helpers/terraform.ts` auto-detects:
+
+```bash
+bash test/platform-test/scripts/build-tf-provider.sh main
+```
+
+
+## Run the suite
 
 ```bash
 cd test/platform-test
 
-# Run all E2E tests
+# All E2E tests
 npm run e2e
 
-# Run a single Xray test
-npm run e2e -- --grep @GKO-110
-
-# Run regression suite
+# Regression suite only
 npm run e2e:regression
+
+# Single test by Xray tag
+npm run e2e -- --grep @GKO-110
 ```
+
+Reports land in `test/platform-test/playwright-results/` (JUnit XML) and
+`test/platform-test/playwright-report/` (HTML).
+
+## Pre-flight checks
+
+[`global-setup.ts`](global-setup.ts) runs five checks before any test. If any
+fail, the suite aborts with a clear message. Mapping of symptom → fix:
+
+| Failure | What it means | Fix |
+|---------|---------------|-----|
+| Management API unreachable | `GRAVITEE_BASE_URL` doesn't respond | Verify APIM is running; check `kubectl get pods -A` and port-forward / NodePort mapping |
+| Gateway unreachable | `GRAVITEE_GATEWAY_URL` doesn't respond | Verify the gateway pod is `Ready`; check the gateway service NodePort |
+| `kubectl cluster-info` fails | No reachable cluster context | `kubectl config use-context kind-gravitee` (or your cluster's context) |
+| `apiv4definitions.gravitee.io` CRD missing | GKO CRDs not installed | Re-run `helm upgrade --install gko helm/gko ...` (Option A) or `sew create` (Option B) |
+| No `app.kubernetes.io/name=gko` deployment | Operator not running in-cluster | Same as above — the operator must be a Deployment, not `go run` on the host |
 
 ## Folder structure
 
 ```
 e2e/
-  playwright.config.ts   # Test runner config (serial, 1 worker)
+  playwright.config.ts   # Test runner config (serial, 1 worker, 30s timeout)
   global-setup.ts        # Pre-flight infra checks (APIM, Gateway, K8s, GKO)
   setup.ts               # Playwright fixtures (mapi, gateway, kubectl)
   helpers/


### PR DESCRIPTION
- Adds a "Running the E2E test suite" section to `test/platform-test/README.md` so the library README points readers at the Playwright suite under `e2e/`
- Rewrites `test/platform-test/e2e/README.md` as a complete bootstrap recipe: prerequisites, two cluster-bootstrap options (the CI-blessed `make start-cluster` + `helm install gko` path, and a `sew` one-shot alternative with two starter compositions), configuration, run commands, and a troubleshooting table mapped to the five pre-flight checks in `global-setup.ts`

See: https://gravitee.atlassian.net/browse/GKO-2933