### PR TITLE
fix(GKO-2857): make v4 endpoint secondary field optional

### DIFF
--- a/api/model/api/v4/endpoints.go
+++ b/api/model/api/v4/endpoints.go
@@ -55,6 +55,7 @@ type Endpoint struct {
 	Services *EndpointServices `json:"services,omitempty"`
 
 	// Endpoint is secondary or not?
+	// +kubebuilder:validation:Optional
 	Secondary bool `json:"secondary"`
 
 	// List of endpoint tenants

--- a/crds/gravitee.io/gravitee.io_apiv4definitions.yaml
+++ b/crds/gravitee.io/gravitee.io_apiv4definitions.yaml
@@ -307,7 +307,6 @@ spec:
                               type: integer
                           required:
                             - inheritConfiguration
-                            - secondary
                             - type
                           type: object
                         type: array

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -3805,7 +3805,7 @@ _Appears in:_
 | `configuration` _[GenericStringMap](#genericstringmap)_ | Endpoint Configuration, arbitrary map of key-values |  | Optional: \{\} <br /> |
 | `sharedConfigurationOverride` _[GenericStringMap](#genericstringmap)_ | Endpoint Configuration Override, arbitrary map of key-values |  | Optional: \{\} <br /> |
 | `services` _[EndpointServices](#endpointservices)_ | Endpoint Services |  |  |
-| `secondary` _boolean_ | Endpoint is secondary or not? |  |  |
+| `secondary` _boolean_ | Endpoint is secondary or not? |  | Optional: \{\} <br /> |
 | `tenants` _string array_ | List of endpoint tenants | \{  \} | Optional: \{\} <br /> |
 
 

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -1398,7 +1398,6 @@ components:
                 type: integer
             required:
               - inheritConfiguration
-              - secondary
             type: object
           type: array
         headers:

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-api-jwt-plan-removed.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-api-jwt-plan-removed.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-api-jwt-plan.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-api-jwt-plan.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-api-manual-approval-plan.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-api-manual-approval-plan.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-api-min.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-api-min.yaml
@@ -42,7 +42,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-api-mtls-plan.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-api-mtls-plan.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-api-oauth2-plan-removed.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-api-oauth2-plan-removed.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-api-oauth2-plan.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-api-oauth2-plan.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-api-private-published.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-api-private-published.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-api-public-published.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-api-public-published.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-api-public-unpublished.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-api-public-unpublished.yaml
@@ -46,7 +46,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-api-two-plans-sub.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-api-two-plans-sub.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-api-with-spg.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-api-with-spg.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-api-without-spg.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-api-without-spg.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-message-api-mock-updated.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-message-api-mock-updated.yaml
@@ -50,7 +50,6 @@ spec:
             messageInterval: 1000
             messageContent: '{"message": "updated mock message"}'
             messagesCount: 1
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-message-api-mock.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-message-api-mock.yaml
@@ -50,7 +50,6 @@ spec:
             messageInterval: 1000
             messageContent: '{"message": "hello from mock"}'
             messagesCount: 1
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-apikey-plan.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-apikey-plan.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-bad-endpoint-type.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-bad-endpoint-type.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-conflict-path.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-conflict-path.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-general-conditions.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-general-conditions.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-invalid.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-invalid.yaml
@@ -38,4 +38,3 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-jwt-oauth2-plans.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-jwt-oauth2-plans.yaml
@@ -46,7 +46,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-jwt-plan.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-jwt-plan.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-keyless-plan.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-keyless-plan.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-no-plans-started.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-no-plans-started.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-no-plans-stopped.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-no-plans-stopped.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-oauth2-plan.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-oauth2-plan.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-one-plan-remaining.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-one-plan-remaining.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-policy-removed.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-policy-removed.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-policy-updated.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-policy-updated.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-reconcile-updated.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-reconcile-updated.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-reconcile.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-reconcile.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-restart.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-restart.yaml
@@ -47,7 +47,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-staging-plan.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-staging-plan.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-started.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-started.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-stopped.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-stopped.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-sync-from-mgmt.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-sync-from-mgmt.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-two-plans.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-two-plans.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-with-failover.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-with-failover.yaml
@@ -51,7 +51,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-with-labels-categories.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-with-labels-categories.yaml
@@ -47,7 +47,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-with-policy.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-with-policy.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-without-labels.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-proxy-api-without-labels.yaml
@@ -46,7 +46,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/defaults/v4-api-no-namespace-ctx.yaml
+++ b/test/platform-test/e2e/fixtures/crds/defaults/v4-api-no-namespace-ctx.yaml
@@ -43,7 +43,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/defaults/v4-api-no-sync-from.yaml
+++ b/test/platform-test/e2e/fixtures/crds/defaults/v4-api-no-sync-from.yaml
@@ -41,7 +41,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/defaults/v4-api-valid-ctx.yaml
+++ b/test/platform-test/e2e/fixtures/crds/defaults/v4-api-valid-ctx.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/dictionaries/api-with-dictionary.yaml
+++ b/test/platform-test/e2e/fixtures/crds/dictionaries/api-with-dictionary.yaml
@@ -38,7 +38,6 @@ spec:
         - name: echo
           type: http-proxy
           inheritConfiguration: false
-          secondary: false
           configuration:
             target: https://api.gravitee.io/echo
   flowExecution:

--- a/test/platform-test/e2e/fixtures/crds/dictionaries/api-with-dyn-dict-deployed.yaml
+++ b/test/platform-test/e2e/fixtures/crds/dictionaries/api-with-dyn-dict-deployed.yaml
@@ -40,7 +40,6 @@ spec:
         - name: Default HTTP proxy
           type: http-proxy
           inheritConfiguration: false
-          secondary: false
           configuration:
             target: https://api.gravitee.io/echo
   flowExecution:

--- a/test/platform-test/e2e/fixtures/crds/dictionaries/api-with-dyn-dict-update.yaml
+++ b/test/platform-test/e2e/fixtures/crds/dictionaries/api-with-dyn-dict-update.yaml
@@ -40,7 +40,6 @@ spec:
         - name: Default HTTP proxy
           type: http-proxy
           inheritConfiguration: false
-          secondary: false
           configuration:
             target: https://api.gravitee.io/echo
   flowExecution:

--- a/test/platform-test/e2e/fixtures/crds/dictionaries/api-with-dynamic-dictionary-tpl.yaml
+++ b/test/platform-test/e2e/fixtures/crds/dictionaries/api-with-dynamic-dictionary-tpl.yaml
@@ -38,7 +38,6 @@ spec:
         - name: Default HTTP proxy
           type: http-proxy
           inheritConfiguration: false
-          secondary: false
           configuration:
             target: https://api.gravitee.io/echo
   flowExecution:

--- a/test/platform-test/e2e/fixtures/crds/dictionaries/api-with-dynamic-dictionary.yaml
+++ b/test/platform-test/e2e/fixtures/crds/dictionaries/api-with-dynamic-dictionary.yaml
@@ -38,7 +38,6 @@ spec:
         - name: Default HTTP proxy
           type: http-proxy
           inheritConfiguration: false
-          secondary: false
           configuration:
             target: https://api.gravitee.io/echo
   flowExecution:

--- a/test/platform-test/e2e/fixtures/crds/import-export/v4-proxy-api-export.yaml
+++ b/test/platform-test/e2e/fixtures/crds/import-export/v4-proxy-api-export.yaml
@@ -48,7 +48,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/import-export/v4-proxy-api-with-special-name.yaml
+++ b/test/platform-test/e2e/fixtures/crds/import-export/v4-proxy-api-with-special-name.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/invalid/v4-api-invalid-cron.yaml
+++ b/test/platform-test/e2e/fixtures/crds/invalid/v4-api-invalid-cron.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/invalid/v4-api-invalid-parent-path.yaml
+++ b/test/platform-test/e2e/fixtures/crds/invalid/v4-api-invalid-parent-path.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/invalid/v4-api-non-existing-context.yaml
+++ b/test/platform-test/e2e/fixtures/crds/invalid/v4-api-non-existing-context.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/invalid/v4-api-non-oas-errors.yaml
+++ b/test/platform-test/e2e/fixtures/crds/invalid/v4-api-non-oas-errors.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: not-a-url
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/local-configmap/v4-api-delete-when-missing.yaml
+++ b/test/platform-test/e2e/fixtures/crds/local-configmap/v4-api-delete-when-missing.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/local-configmap/v4-api-local-false.yaml
+++ b/test/platform-test/e2e/fixtures/crds/local-configmap/v4-api-local-false.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/members/v4-api-extra-po.yaml
+++ b/test/platform-test/e2e/fixtures/crds/members/v4-api-extra-po.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/members/v4-api-member-changed-role.yaml
+++ b/test/platform-test/e2e/fixtures/crds/members/v4-api-member-changed-role.yaml
@@ -48,7 +48,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/members/v4-api-member-no-role.yaml
+++ b/test/platform-test/e2e/fixtures/crds/members/v4-api-member-no-role.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/members/v4-api-member-no-source.yaml
+++ b/test/platform-test/e2e/fixtures/crds/members/v4-api-member-no-source.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/members/v4-api-member-removed.yaml
+++ b/test/platform-test/e2e/fixtures/crds/members/v4-api-member-removed.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/members/v4-api-non-existing-group.yaml
+++ b/test/platform-test/e2e/fixtures/crds/members/v4-api-non-existing-group.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/members/v4-api-non-existing-member.yaml
+++ b/test/platform-test/e2e/fixtures/crds/members/v4-api-non-existing-member.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/members/v4-api-notify-members.yaml
+++ b/test/platform-test/e2e/fixtures/crds/members/v4-api-notify-members.yaml
@@ -46,7 +46,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/members/v4-api-po-user-private.yaml
+++ b/test/platform-test/e2e/fixtures/crds/members/v4-api-po-user-private.yaml
@@ -46,7 +46,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/members/v4-api-with-groups.yaml
+++ b/test/platform-test/e2e/fixtures/crds/members/v4-api-with-groups.yaml
@@ -47,7 +47,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/members/v4-api-with-members.yaml
+++ b/test/platform-test/e2e/fixtures/crds/members/v4-api-with-members.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/message-apis/v4-message-api-http-get.yaml
+++ b/test/platform-test/e2e/fixtures/crds/message-apis/v4-message-api-http-get.yaml
@@ -50,7 +50,6 @@ spec:
             messageInterval: 1000
             messageContent: '{"message": "hello from mock"}'
             messagesCount: 1
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/message-apis/v4-message-api-http-post.yaml
+++ b/test/platform-test/e2e/fixtures/crds/message-apis/v4-message-api-http-post.yaml
@@ -50,7 +50,6 @@ spec:
             messageInterval: 1000
             messageContent: '{"message": "hello from mock"}'
             messagesCount: 1
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/message-apis/v4-message-api-mqtt.yaml
+++ b/test/platform-test/e2e/fixtures/crds/message-apis/v4-message-api-mqtt.yaml
@@ -49,7 +49,6 @@ spec:
             consumer:
               enabled: true
               topic: "e2e-mqtt-topic"
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/message-apis/v4-message-api-sse.yaml
+++ b/test/platform-test/e2e/fixtures/crds/message-apis/v4-message-api-sse.yaml
@@ -50,7 +50,6 @@ spec:
             messageInterval: 1000
             messageContent: '{"message": "hello from mock"}'
             messagesCount: 1
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/message-apis/v4-message-api-sync-k8s.yaml
+++ b/test/platform-test/e2e/fixtures/crds/message-apis/v4-message-api-sync-k8s.yaml
@@ -50,7 +50,6 @@ spec:
             messageInterval: 1000
             messageContent: '{"message": "hello from mock"}'
             messagesCount: 1
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/message-apis/v4-message-api-sync-mgmt.yaml
+++ b/test/platform-test/e2e/fixtures/crds/message-apis/v4-message-api-sync-mgmt.yaml
@@ -50,7 +50,6 @@ spec:
             messageInterval: 1000
             messageContent: '{"message": "hello from mock"}'
             messagesCount: 1
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/message-apis/v4-message-api-webhook.yaml
+++ b/test/platform-test/e2e/fixtures/crds/message-apis/v4-message-api-webhook.yaml
@@ -50,7 +50,6 @@ spec:
             messageInterval: 1000
             messageContent: '{"message": "hello from mock"}'
             messagesCount: 1
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/message-apis/v4-message-api-websocket.yaml
+++ b/test/platform-test/e2e/fixtures/crds/message-apis/v4-message-api-websocket.yaml
@@ -50,7 +50,6 @@ spec:
             messageInterval: 1000
             messageContent: '{"message": "hello from mock"}'
             messagesCount: 1
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/message-apis/v4-message-api-with-policy.yaml
+++ b/test/platform-test/e2e/fixtures/crds/message-apis/v4-message-api-with-policy.yaml
@@ -50,7 +50,6 @@ spec:
             messageInterval: 1000
             messageContent: '{"message": "hello from mock"}'
             messagesCount: 1
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/mtls-certificates/api-mtls-backward-compat.yaml
+++ b/test/platform-test/e2e/fixtures/crds/mtls-certificates/api-mtls-backward-compat.yaml
@@ -43,7 +43,6 @@ spec:
           configuration:
             target: https://api.gravitee.io/echo
           inheritConfiguration: false
-          secondary: false
   analytics:
     enabled: true
   plans:

--- a/test/platform-test/e2e/fixtures/crds/mtls-certificates/api-mtls-dates.yaml
+++ b/test/platform-test/e2e/fixtures/crds/mtls-certificates/api-mtls-dates.yaml
@@ -44,7 +44,6 @@ spec:
           configuration:
             target: "https://api.gravitee.io/echo"
           inheritConfiguration: false
-          secondary: false
   analytics:
     enabled: true
   plans:

--- a/test/platform-test/e2e/fixtures/crds/mtls-certificates/api-mtls-encoded.yaml
+++ b/test/platform-test/e2e/fixtures/crds/mtls-certificates/api-mtls-encoded.yaml
@@ -43,7 +43,6 @@ spec:
           configuration:
             target: https://api.gravitee.io/echo
           inheritConfiguration: false
-          secondary: false
   analytics:
     enabled: true
   plans:

--- a/test/platform-test/e2e/fixtures/crds/mtls-certificates/api-mtls-inline.yaml
+++ b/test/platform-test/e2e/fixtures/crds/mtls-certificates/api-mtls-inline.yaml
@@ -43,7 +43,6 @@ spec:
           configuration:
             target: https://api.gravitee.io/echo
           inheritConfiguration: false
-          secondary: false
   analytics:
     enabled: true
   plans:

--- a/test/platform-test/e2e/fixtures/crds/mtls-certificates/api-mtls-refs.yaml
+++ b/test/platform-test/e2e/fixtures/crds/mtls-certificates/api-mtls-refs.yaml
@@ -44,7 +44,6 @@ spec:
           configuration:
             target: "https://api.gravitee.io/echo"
           inheritConfiguration: false
-          secondary: false
   analytics:
     enabled: true
   plans:

--- a/test/platform-test/e2e/fixtures/crds/mtls-certificates/api-mtls-rotation.yaml
+++ b/test/platform-test/e2e/fixtures/crds/mtls-certificates/api-mtls-rotation.yaml
@@ -44,7 +44,6 @@ spec:
           configuration:
             target: "https://api.gravitee.io/echo"
           inheritConfiguration: false
-          secondary: false
   analytics:
     enabled: true
   plans:

--- a/test/platform-test/e2e/fixtures/crds/mtls-certificates/api-mtls-templates.yaml
+++ b/test/platform-test/e2e/fixtures/crds/mtls-certificates/api-mtls-templates.yaml
@@ -44,7 +44,6 @@ spec:
           configuration:
             target: "https://api.gravitee.io/echo"
           inheritConfiguration: false
-          secondary: false
   analytics:
     enabled: true
   plans:

--- a/test/platform-test/e2e/fixtures/crds/notifications/v4-api-1219-with-portal-target.yaml
+++ b/test/platform-test/e2e/fixtures/crds/notifications/v4-api-1219-with-portal-target.yaml
@@ -42,7 +42,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/notifications/v4-api-1239-with-group-members.yaml
+++ b/test/platform-test/e2e/fixtures/crds/notifications/v4-api-1239-with-group-members.yaml
@@ -42,7 +42,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/notifications/v4-api-duplicate-console-notifications.yaml
+++ b/test/platform-test/e2e/fixtures/crds/notifications/v4-api-duplicate-console-notifications.yaml
@@ -43,7 +43,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/notifications/v4-api-notif-base.yaml
+++ b/test/platform-test/e2e/fixtures/crds/notifications/v4-api-notif-base.yaml
@@ -43,7 +43,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/notifications/v4-api-using-shared-notification.yaml
+++ b/test/platform-test/e2e/fixtures/crds/notifications/v4-api-using-shared-notification.yaml
@@ -42,7 +42,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/notifications/v4-api-with-notification-remove.yaml
+++ b/test/platform-test/e2e/fixtures/crds/notifications/v4-api-with-notification-remove.yaml
@@ -40,7 +40,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/notifications/v4-api-with-notification-update-events.yaml
+++ b/test/platform-test/e2e/fixtures/crds/notifications/v4-api-with-notification-update-events.yaml
@@ -40,7 +40,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/notifications/v4-api-with-notification-update-grouprefs.yaml
+++ b/test/platform-test/e2e/fixtures/crds/notifications/v4-api-with-notification-update-grouprefs.yaml
@@ -40,7 +40,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/notifications/v4-api-with-removed-notification.yaml
+++ b/test/platform-test/e2e/fixtures/crds/notifications/v4-api-with-removed-notification.yaml
@@ -40,7 +40,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/pages/v4-api-github-fetcher-invalid-param.yaml
+++ b/test/platform-test/e2e/fixtures/crds/pages/v4-api-github-fetcher-invalid-param.yaml
@@ -42,7 +42,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/pages/v4-api-github-fetcher-missing-fields.yaml
+++ b/test/platform-test/e2e/fixtures/crds/pages/v4-api-github-fetcher-missing-fields.yaml
@@ -43,7 +43,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/pages/v4-api-public-page.yaml
+++ b/test/platform-test/e2e/fixtures/crds/pages/v4-api-public-page.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/pages/v4-api-renamed-page.yaml
+++ b/test/platform-test/e2e/fixtures/crds/pages/v4-api-renamed-page.yaml
@@ -42,7 +42,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/pages/v4-api-web-fetcher-invalid-param.yaml
+++ b/test/platform-test/e2e/fixtures/crds/pages/v4-api-web-fetcher-invalid-param.yaml
@@ -42,7 +42,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/pages/v4-api-web-fetcher-no-url.yaml
+++ b/test/platform-test/e2e/fixtures/crds/pages/v4-api-web-fetcher-no-url.yaml
@@ -42,7 +42,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/pages/v4-api-with-page-markdown.yaml
+++ b/test/platform-test/e2e/fixtures/crds/pages/v4-api-with-page-markdown.yaml
@@ -41,7 +41,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/pages/v4-api-with-swagger-http-fetcher.yaml
+++ b/test/platform-test/e2e/fixtures/crds/pages/v4-api-with-swagger-http-fetcher.yaml
@@ -41,7 +41,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/pages/v4-api-with-updated-page-markdown.yaml
+++ b/test/platform-test/e2e/fixtures/crds/pages/v4-api-with-updated-page-markdown.yaml
@@ -41,7 +41,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/pages/v4-api-without-page-markdown.yaml
+++ b/test/platform-test/e2e/fixtures/crds/pages/v4-api-without-page-markdown.yaml
@@ -41,7 +41,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/templating/v4-api-missing-configmap.yaml
+++ b/test/platform-test/e2e/fixtures/crds/templating/v4-api-missing-configmap.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/templating/v4-api-missing-key.yaml
+++ b/test/platform-test/e2e/fixtures/crds/templating/v4-api-missing-key.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/templating/v4-api-with-configmap-value.yaml
+++ b/test/platform-test/e2e/fixtures/crds/templating/v4-api-with-configmap-value.yaml
@@ -44,7 +44,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/v4-lifecycle-extended/v4-message-api-entrypoint-policy.yaml
+++ b/test/platform-test/e2e/fixtures/crds/v4-lifecycle-extended/v4-message-api-entrypoint-policy.yaml
@@ -53,7 +53,6 @@ spec:
             messageInterval: 1000
             messageContent: '{"matrix":"test"}'
             messagesCount: 1
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/v4-lifecycle-extended/v4-proxy-api-db-less.yaml
+++ b/test/platform-test/e2e/fixtures/crds/v4-lifecycle-extended/v4-proxy-api-db-less.yaml
@@ -43,7 +43,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/v4-lifecycle-extended/v4-proxy-api-many-categories-renamed.yaml
+++ b/test/platform-test/e2e/fixtures/crds/v4-lifecycle-extended/v4-proxy-api-many-categories-renamed.yaml
@@ -50,7 +50,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/v4-lifecycle-extended/v4-proxy-api-many-categories.yaml
+++ b/test/platform-test/e2e/fixtures/crds/v4-lifecycle-extended/v4-proxy-api-many-categories.yaml
@@ -50,7 +50,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/v4-lifecycle-extended/v4-proxy-api-non-existing-category.yaml
+++ b/test/platform-test/e2e/fixtures/crds/v4-lifecycle-extended/v4-proxy-api-non-existing-category.yaml
@@ -48,7 +48,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/v4-lifecycle-extended/v4-proxy-api-non-existing-group.yaml
+++ b/test/platform-test/e2e/fixtures/crds/v4-lifecycle-extended/v4-proxy-api-non-existing-group.yaml
@@ -48,7 +48,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/v4-lifecycle-extended/v4-proxy-api-policy-no-plans.yaml
+++ b/test/platform-test/e2e/fixtures/crds/v4-lifecycle-extended/v4-proxy-api-policy-no-plans.yaml
@@ -47,7 +47,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false

--- a/test/platform-test/e2e/fixtures/crds/v4-lifecycle-extended/v4-proxy-api-started-conflict.yaml
+++ b/test/platform-test/e2e/fixtures/crds/v4-lifecycle-extended/v4-proxy-api-started-conflict.yaml
@@ -48,7 +48,6 @@ spec:
           inheritConfiguration: false
           configuration:
             target: https://api.gravitee.io/echo
-          secondary: false
   flowExecution:
     mode: DEFAULT
     matchRequired: false


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-2857

## Summary

- Mark `secondary` as optional on v4 `Endpoint` in the API model and regenerate the `ApiV4Definition` CRD (defaults to `false` in APIM).
- Remove redundant `secondary: false` from 114 platform e2e fixtures that define a single endpoint.
- Align OpenAPI schema and API reference docs with the CRD change.

## Test plan

- [x] `make unit`
- [ ] CI green on this PR