### PR TITLE
test: improve e2e Test Execution reporting

### DIFF
--- a/test/platform-test/scripts/xray/README.md
+++ b/test/platform-test/scripts/xray/README.md
@@ -48,7 +48,48 @@ exit 0. The pipeline's pass/fail gate is unaffected (CircleCI parses
 | `XRAY_CLIENT_ID` | yes | — | Xray Cloud API key client id |
 | `XRAY_CLIENT_SECRET` | yes | — | Xray Cloud API key client secret |
 | `XRAY_TEST_PLAN_KEY` | no | — | Existing Test Plan issue (e.g. `GKO-NNNN`) to roll runs up to |
-| `CIRCLE_BUILD_URL` / `CIRCLE_BUILD_NUM` / `CIRCLE_BRANCH` | no | autodetected | Used to build the Test Execution summary + description; CircleCI sets them automatically |
+| `CIRCLE_BUILD_URL` / `CIRCLE_BUILD_NUM` / `CIRCLE_BRANCH` | no | autodetected | Used to template the Test Execution summary + description; CircleCI sets them automatically |
+
+### Test Execution title
+
+The script defers the title to [`junit-to-xray.mjs`](./junit-to-xray.mjs) — it
+has the per-test totals naturally. The default template is:
+
+```
+GKO Playwright e2e on <branch> — <n> passed, <n> failed[, <n> skipped] (CircleCI #<num>)
+```
+
+Examples:
+
+- `GKO Playwright e2e on master — 355 passed, 0 failed (CircleCI #85230)`
+- `GKO Playwright e2e on master — 354 passed, 1 failed, 12 skipped (CircleCI #85231)`
+- `GKO Playwright e2e on master — 1 passed, 0 failed (local)` *(local dry-run)*
+
+Pass an explicit `XRAY_SUMMARY` env var to override.
+
+### Test Execution description
+
+Deliberately small — the Xray-generated "Tests" panel inside the issue body
+already shows totals and the per-test rundown, so duplicating that here is
+noise. The default is:
+
+```
+Commit: <git log -1 --pretty=%s>
+Automated import from CircleCI: <build URL>
+```
+
+The `Commit:` line is omitted when `XRAY_COMMIT_SUBJECT` isn't set
+(e.g. local dry-runs in a worktree without a HEAD), and the second line
+falls back to a generic "Automated import of Playwright e2e results."
+when no `XRAY_BUILD_URL` is available. Pass an explicit `XRAY_DESCRIPTION`
+to override entirely.
+
+> **Test Execution workflow state.** The created issue stays in its default
+> "To Do" state — that's intentional. The per-test results (PASSED / FAILED
+> rows on each linked Test's "Test Coverage" panel) are what consumers
+> actually look at; the Test Execution issue is a per-run log entry whose
+> workflow column nobody reads. Don't add a Jira API token just to flip the
+> badge.
 
 The Test Execution is created in the project of the referenced Tests (GKO),
 so no project key is needed.
@@ -60,6 +101,7 @@ orb from the Keeper record `so8_Jh2tP-AZSbtIYcbBvg` (custom fields
 pipeline is green (the orb command runs `on_success`). Generate a fresh
 key pair from Jira if needed: *Apps → Xray → Global Settings → API Keys →
 Create*.
+
 
 ## Local run
 

--- a/test/platform-test/scripts/xray/junit-to-xray.mjs
+++ b/test/platform-test/scripts/xray/junit-to-xray.mjs
@@ -27,7 +27,14 @@
 // test.fixme'd cases are omitted entirely so a temporarily-disabled test does
 // not overwrite a Test's previously recorded result with TODO.
 //
-// Env (all optional): XRAY_SUMMARY, XRAY_DESCRIPTION, XRAY_TEST_PLAN_KEY.
+// Env (all optional):
+//   XRAY_SUMMARY         explicit Test Execution summary; overrides the auto-templated one
+//   XRAY_DESCRIPTION     explicit description; overrides the auto-templated one
+//   XRAY_TEST_PLAN_KEY   existing Test Plan key to link the Execution to
+//   XRAY_BRANCH          branch name woven into the default summary (e.g. "master")
+//   XRAY_BUILD_NUM       CircleCI build number woven into the default summary
+//   XRAY_BUILD_URL       CircleCI build URL woven into the default description
+//   XRAY_COMMIT_SUBJECT  git commit subject; prepended to the default description as "Commit: <subject>"
 
 import { readFileSync, realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -74,11 +81,54 @@ export function toTests(cases) {
   return [...byKey].map(([testKey, status]) => ({ testKey, status }));
 }
 
-export function buildPayload(xml, { summary, description, testPlanKey } = {}) {
-  const tests = toTests(parseTestcases(xml));
+export function tally(cases) {
+  // Count cases from the raw parsed list so the summary reflects what
+  // *actually ran* (including untagged ones), independent of testKey dedup.
+  let passed = 0,
+    failed = 0,
+    skipped = 0;
+  for (const c of cases) {
+    if (c.skipped) skipped++;
+    else if (c.failed) failed++;
+    else passed++;
+  }
+  return { passed, failed, skipped };
+}
+
+export function defaultSummary({ passed, failed, skipped }, { branch, buildNum } = {}) {
+  // Format the Test Execution title so it's readable at a glance in the
+  // Jira/Xray list view — branch and outcome up front, build number as a
+  // parenthetical for click-through traceability.
+  const where = branch ? ` on ${branch}` : "";
+  const skippedPart = skipped > 0 ? `, ${skipped} skipped` : "";
+  const buildPart = buildNum ? ` (CircleCI #${buildNum})` : " (local)";
+  return `GKO Playwright e2e${where} — ${passed} passed, ${failed} failed${skippedPart}${buildPart}`;
+}
+
+export function defaultDescription({ buildUrl, commitSubject } = {}) {
+  // Keep the description deliberately small — the Xray-generated "Tests" panel
+  // already shows totals + per-test rundown inside the issue body, so anything
+  // we add here that duplicates it is noise. Two pieces of context that aren't
+  // visible anywhere else on the page:
+  //   1. The CircleCI build URL (one click to logs / artifacts).
+  //   2. The commit subject (what change was being tested, in plain English).
+  // Falls back to the original merged-master one-liner when either is missing.
+  const base = buildUrl
+    ? `Automated import from CircleCI: ${buildUrl}`
+    : "Automated import of Playwright e2e results.";
+  return commitSubject ? `Commit: ${commitSubject}\n${base}` : base;
+}
+
+export function buildPayload(
+  xml,
+  { summary, description, testPlanKey, branch, buildNum, buildUrl, commitSubject } = {},
+) {
+  const cases = parseTestcases(xml);
+  const tests = toTests(cases);
+  const totals = tally(cases);
   const info = {
-    summary: summary || "GKO e2e — automated import",
-    description: description || "Automated import of Playwright e2e results",
+    summary: summary || defaultSummary(totals, { branch, buildNum }),
+    description: description || defaultDescription({ buildUrl, commitSubject }),
   };
   if (testPlanKey) info.testPlanKey = testPlanKey;
   return { info, tests };
@@ -91,6 +141,10 @@ function main() {
     summary: process.env.XRAY_SUMMARY,
     description: process.env.XRAY_DESCRIPTION,
     testPlanKey: process.env.XRAY_TEST_PLAN_KEY,
+    branch: process.env.XRAY_BRANCH,
+    buildNum: process.env.XRAY_BUILD_NUM,
+    buildUrl: process.env.XRAY_BUILD_URL,
+    commitSubject: process.env.XRAY_COMMIT_SUBJECT,
   });
   process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
 }

--- a/test/platform-test/scripts/xray/push-results.sh
+++ b/test/platform-test/scripts/xray/push-results.sh
@@ -40,7 +40,7 @@
 #   CIRCLE_BUILD_URL,
 #   CIRCLE_BUILD_NUM,
 #   CIRCLE_BRANCH          (optional) populated automatically in CircleCI; used
-#                          in the resulting Test Execution summary/description
+#                          to template the Test Execution summary/description
 
 set -uo pipefail
 
@@ -98,12 +98,21 @@ TOKEN=$(curl -fsS -X POST \
 # classname+name and would create duplicate Test issues). Skipped / fixme'd
 # cases are dropped so they don't overwrite a Test's prior result with TODO.
 
-BRANCH="${CIRCLE_BRANCH:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo local)}"
-BUILD_NUM="${CIRCLE_BUILD_NUM:-local}"
-BUILD_URL="${CIRCLE_BUILD_URL:-(local run)}"
+BRANCH="${CIRCLE_BRANCH:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")}"
+BUILD_NUM="${CIRCLE_BUILD_NUM:-}"
+BUILD_URL="${CIRCLE_BUILD_URL:-}"
+# The CircleCI workspace is checked out at the commit being tested, so
+# git log -1 returns its subject directly. Empty fallback is fine — the
+# transform's defaultDescription skips the "Commit:" line when it's unset.
+COMMIT_SUBJECT="$(git log -1 --pretty=%s 2>/dev/null || echo "")"
 
-XRAY_SUMMARY="GKO e2e - ${BUILD_NUM} (${BRANCH})" \
-XRAY_DESCRIPTION="Automated import from CircleCI: ${BUILD_URL}" \
+# Title / description templating now lives in junit-to-xray.mjs (it has the
+# totals naturally). The script only forwards context; the transform falls
+# back to sensible defaults when XRAY_SUMMARY / XRAY_DESCRIPTION are unset.
+XRAY_BRANCH="${BRANCH}" \
+XRAY_BUILD_NUM="${BUILD_NUM}" \
+XRAY_BUILD_URL="${BUILD_URL}" \
+XRAY_COMMIT_SUBJECT="${COMMIT_SUBJECT}" \
 XRAY_TEST_PLAN_KEY="${XRAY_TEST_PLAN_KEY:-}" \
   node "${TRANSFORM}" "${RESULTS_PATH}" > "${PAYLOAD_FILE}" \
   || warn_and_exit "failed to build Xray payload from ${RESULTS_PATH}"

--- a/test/platform-test/test/scripts/junit-to-xray.test.ts
+++ b/test/platform-test/test/scripts/junit-to-xray.test.ts
@@ -15,7 +15,14 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { parseTestcases, toTests, buildPayload } from "../../scripts/xray/junit-to-xray.mjs";
+import {
+  parseTestcases,
+  toTests,
+  buildPayload,
+  tally,
+  defaultSummary,
+  defaultDescription,
+} from "../../scripts/xray/junit-to-xray.mjs";
 
 const tc = (name: string, body = "") =>
   `<testcase name="${name}" classname="suite.test.ts" time="1.0">${body}</testcase>`;
@@ -66,12 +73,91 @@ describe("junit-to-xray transform", () => {
   });
 });
 
+describe("tally", () => {
+  it("counts passed / failed / skipped from parsed cases", () => {
+    const xml =
+      tc("a @GKO-1") +
+      tc("b @GKO-2", "<failure>x</failure>") +
+      tc("c @GKO-3", "<skipped/>") +
+      tc("untagged");
+    expect(tally(parseTestcases(xml))).toEqual({ passed: 2, failed: 1, skipped: 1 });
+  });
+});
+
+describe("defaultSummary", () => {
+  it("includes branch, totals, and CircleCI build number", () => {
+    expect(
+      defaultSummary({ passed: 355, failed: 0, skipped: 0 }, { branch: "master", buildNum: "85230" }),
+    ).toBe("GKO Playwright e2e on master — 355 passed, 0 failed (CircleCI #85230)");
+  });
+
+  it("surfaces skipped count when non-zero", () => {
+    expect(
+      defaultSummary({ passed: 12, failed: 2, skipped: 3 }, { branch: "feature/x", buildNum: "1" }),
+    ).toBe("GKO Playwright e2e on feature/x — 12 passed, 2 failed, 3 skipped (CircleCI #1)");
+  });
+
+  it("falls back to '(local)' when no build number is supplied", () => {
+    expect(defaultSummary({ passed: 1, failed: 0, skipped: 0 }, { branch: "master" })).toBe(
+      "GKO Playwright e2e on master — 1 passed, 0 failed (local)",
+    );
+  });
+
+  it("omits the branch segment when no branch is supplied", () => {
+    expect(defaultSummary({ passed: 1, failed: 0, skipped: 0 }, { buildNum: "1" })).toBe(
+      "GKO Playwright e2e — 1 passed, 0 failed (CircleCI #1)",
+    );
+  });
+});
+
+describe("defaultDescription", () => {
+  it("returns just the CircleCI import line when only buildUrl is supplied", () => {
+    expect(defaultDescription({ buildUrl: "https://x.test/1" })).toBe(
+      "Automated import from CircleCI: https://x.test/1",
+    );
+  });
+
+  it("prepends 'Commit: ...' when a commitSubject is supplied", () => {
+    expect(
+      defaultDescription({
+        buildUrl: "https://x.test/1",
+        commitSubject: "test: readable Test Execution title (GKO-2906)",
+      }),
+    ).toBe(
+      "Commit: test: readable Test Execution title (GKO-2906)\nAutomated import from CircleCI: https://x.test/1",
+    );
+  });
+
+  it("falls back to a generic line when no buildUrl is supplied", () => {
+    expect(defaultDescription({})).toBe("Automated import of Playwright e2e results.");
+  });
+});
+
 describe("buildPayload", () => {
-  it("wraps tests with default info when none supplied", () => {
-    const payload = buildPayload(tc("t @GKO-1"));
+  it("wraps tests with auto-templated summary/description when none supplied", () => {
+    const payload = buildPayload(tc("t @GKO-1"), {
+      branch: "master",
+      buildNum: "42",
+      buildUrl: "https://x.test/42",
+    });
     expect(payload.tests).toEqual([{ testKey: "GKO-1", status: "PASSED" }]);
-    expect(payload.info.summary).toBeTruthy();
+    expect(payload.info.summary).toBe(
+      "GKO Playwright e2e on master — 1 passed, 0 failed (CircleCI #42)",
+    );
+    expect(payload.info.description).toBe("Automated import from CircleCI: https://x.test/42");
     expect(payload.info).not.toHaveProperty("testPlanKey");
+  });
+
+  it("includes the commit subject in the auto-templated description when supplied", () => {
+    const payload = buildPayload(tc("t @GKO-1"), {
+      branch: "master",
+      buildNum: "42",
+      buildUrl: "https://x.test/42",
+      commitSubject: "fix: handle empty result file (GKO-2999)",
+    });
+    expect(payload.info.description).toBe(
+      "Commit: fix: handle empty result file (GKO-2999)\nAutomated import from CircleCI: https://x.test/42",
+    );
   });
 
   it("uses provided summary/description and adds testPlanKey only when set", () => {


### PR DESCRIPTION

Minor adjustment to the auto-created Test Execution ticket in Jira/Xray (after each e2e run, e.g. [GKO-2937](https://gravitee.atlassian.net/browse/GKO-2937)). All changes are in \`test/platform-test/scripts/xray/\`, no CI config change, no new secrets.

**Title** is now templated so the outcome is visible in list views (Test Plan tab, search results, parent Story's "Linked work items" panel) without clicking through. The opaque \`CIRCLE_BUILD_NUM\` keeps its place as a parenthetical for click-through. Examples:

- \`GKO Playwright e2e on master — 355 passed, 0 failed (CircleCI #85230)\`
- \`GKO Playwright e2e on master — 354 passed, 1 failed, 12 skipped (CircleCI #85231)\`
- \`GKO Playwright e2e on master — 1 passed, 0 failed (local)\` (local dry-run)

**Description** gets one extra line - `Commit: <subject>`, sourced from `git log -1 --pretty=%s` in the workspace - above the existing CircleCI URL line. 


See: https://gravitee.atlassian.net/browse/GKO-2946

[GKO-2937]: https://gravitee.atlassian.net/browse/GKO-2937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
