### PR TITLE
test(platform-test): provision the e2e cluster via gck

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -452,10 +452,17 @@ jobs:
           registry: graviteeio.azurecr.io
           username: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
           password: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
+      # Must run after docker-login: the gck image preload pulls the APIM
+      # master nightlies from graviteeio.azurecr.io.
+      - run:
+          name: Install gck
+          command: |
+            go install github.com/gravitee-io-labs/gck@v1.0.2
+            echo 'export PATH="$HOME/go/bin:$PATH"' >> "$BASH_ENV"
       - run:
           name: Start cluster
           command: |
-            make start-cluster
+            make start-e2e-cluster
       - run:
           name: Prepare coverage storage
           command: |

--- a/hack/make/dev.mk
+++ b/hack/make/dev.mk
@@ -8,6 +8,11 @@ start-cluster: ## Init and start a local cluster
 start-cluster-ui: ## Init and start a local cluster
 	@APIM_UI=true npx zx ./hack/scripts/run-kind.mjs
 
+.PHONY: start-e2e-cluster
+start-e2e-cluster: ## Init and start the e2e (platform-test) cluster via gck. Fails if the cluster exists: run delete-cluster first
+	@gck create --config test/platform-test/gck.yaml --disable-es --disable-portal \
+		--set imagePrefix=graviteeio.azurecr.io --set imageTag=master-latest
+
 .PHONY: start-conformance-cluster
 start-conformance-cluster: ## Init and start a local cluster for gateway-api conformance tests
 	kind create cluster --config hack/kind/kind.conformance.yaml

--- a/test/platform-test/AGENTS.md
+++ b/test/platform-test/AGENTS.md
@@ -5,8 +5,8 @@ Playwright (TypeScript) end-to-end suite that drives a **real** local Kubernetes
 cluster running APIM + Gateway + the GKO operator, plus the Terraform APIM
 provider. There are **no mocks**: every test mutates live cluster + APIM state.
 
-> Read this before editing or adding tests. For environment bootstrap (Kind,
-> Helm, `sew`, pre-flight checks) read [`e2e/README.md`](e2e/README.md) instead,
+> Read this before editing or adding tests. For environment bootstrap (`gck`,
+> Helm, pre-flight checks) read [`e2e/README.md`](e2e/README.md) instead,
 > do not duplicate that here. For the assertion library API read
 > [`README.md`](README.md).
 
@@ -117,7 +117,7 @@ backend**. Two consequences agents must respect:
   name** over reusing an existing fixture's name.
 - **APIM/MongoDB state persists across cluster restarts.** Only `kind delete
   cluster` or a full Helm uninstall + PV delete wipes it. A half-cleaned test
-  leaves rows behind that survive `make start-cluster`.
+  leaves rows behind that survive `make start-e2e-cluster`.
 
 ### Safety-net cleanup pattern
 

--- a/test/platform-test/e2e/README.md
+++ b/test/platform-test/e2e/README.md
@@ -20,10 +20,11 @@ Host tools (install before bootstrapping the cluster):
 |------|---------|-------|
 | Node.js | ≥ 18 | per `package.json#engines` |
 | `kubectl` | recent | tests shell out to it (`helpers/kubectl.ts`) |
-| `kind` | recent | local Kubernetes cluster |
+| `gck` | recent | provisions the Kind cluster + APIM stack ([docs](https://gravitee-io-labs.github.io/gck/)) |
+| `kind` | recent | `kind load` of the locally built operator image |
 | `helm` | recent | installs the GKO chart |
 | `terraform` | 1.12.1 | matches CI; Terraform tests assume it on `PATH` |
-| Docker | recent | required by Kind and by `sew` |
+| Docker | recent | required by Kind and by `gck` |
 
 The suite also expects:
 
@@ -37,15 +38,28 @@ test runs — see [Pre-flight checks](#pre-flight-checks).
 
 ## Bring up the cluster + APIM + GKO
 
-Two supported paths. Pick one.
+The cluster + APIM stack is provisioned with
+[`gck`](https://gravitee-io-labs.github.io/gck/) (Gravitee Cluster Kit) from
+the checked-in [`gck.yaml`](../gck.yaml): it composes the registry context
+`gravitee-io/oss/apim/mongodb` with suite-specific overrides (APIM master
+nightlies from azurecr, gateway sync across all namespaces, coverage mount,
+Elasticsearch and portal disabled).
 
-### Option A — CI-blessed path (recommended)
+Install gck (same version CI pins in `.circleci/config.yml`):
+
+```bash
+go install github.com/gravitee-io-labs/gck@v1.0.2
+```
 
 Mirrors what CI runs in `.circleci/config.yml` (`job-e2e-tests`):
 
 ```bash
-# From the repo root
-make start-cluster                       # Kind + APIM CE via hack/scripts/run-kind.mjs
+# From the repo root. The image preload pulls APIM master nightlies:
+docker login graviteeio.azurecr.io
+
+# Kind cluster `gravitee` + APIM + MongoDB into namespace `gravitee`.
+# Errors if the cluster already exists — `make delete-cluster` first.
+make start-e2e-cluster
 
 # Build the operator image, load it into Kind, install via Helm
 IMG=gko TAG=latest make docker-build \
@@ -57,46 +71,22 @@ IMG=gko TAG=latest make docker-build \
 kubectl rollout status deployment/gko-controller-manager -n default --timeout=120s
 ```
 
-### Option B — `sew` (one-shot stack composer)
-
-[`sew`](https://a-cordier.github.io/sew/) is a third-party Kubernetes stack
-composer that brings up APIM + GKO in a single command from its registry.
-It is **not** part of this repo — you author your own `sew.yaml` and run
-`sew create`.
-
-Install (macOS):
+Useful gck commands:
 
 ```bash
-brew install sew
+gck info --config test/platform-test/gck.yaml   # preview composition + flags
+gck list                                        # show gck-managed clusters
+make delete-cluster                             # tear the cluster down
 ```
 
-Pick a starter composition for E2E:
-
-```yaml
-# sew.yaml — minimal: APIM (DB-less) + GKO
-from:
-  - gravitee-io/oss/apim/dbless
-```
-
-```yaml
-# sew.yaml — full stack: APIM + MongoDB + Elasticsearch + GKO (closer to CI)
-from:
-  - gravitee-io/oss/apim/mongodb
-```
-
-Then:
-
-```bash
-sew info --from gravitee-io/oss/apim/mongodb   # preview the composition
-sew create                                     # bring up the stack
-sew delete                                     # tear it down
-```
-
-`sew` installs GKO into the `gravitee` namespace, while Option A uses
-`default`. The suite probes all namespaces (`kubectl get deploy -A`), so both
-work. EE registry variants (`gravitee-io/ee/apim/*`) exist but require a
-licence file and are out of scope here — see the
-[sew registry](https://a-cordier.github.io/sew/registry/).
+APIM lives in the `gravitee` namespace (in-cluster management API URL:
+`http://apim-api.gravitee.svc:83`, hardcoded in the management-context
+fixtures); the operator lives in `default`. The suite probes all namespaces
+(`kubectl get deploy -A`), so both work. The integration-test (Ginkgo) suite
+and `make start-cluster` still use the legacy
+`hack/scripts/run-kind.mjs` flow, which installs the `apim3` chart into
+`default` — the two cluster flavors share the name `gravitee`, so delete one
+before creating the other.
 
 ## Build platform-test
 

--- a/test/platform-test/e2e/fixtures/admission-webhook/v4-invalid-credentials-context/crd.yaml
+++ b/test/platform-test/e2e/fixtures/admission-webhook/v4-invalid-credentials-context/crd.yaml
@@ -17,7 +17,7 @@ kind: ManagementContext
 metadata:
   name: e2e-invalid-creds-ctx
 spec:
-  baseUrl: http://apim-apim3-api.default.svc:83
+  baseUrl: http://apim-api.gravitee.svc:83
   environmentId: DEFAULT
   organizationId: DEFAULT
   auth:

--- a/test/platform-test/e2e/fixtures/management-context/dev-ctx/crd.yaml
+++ b/test/platform-test/e2e/fixtures/management-context/dev-ctx/crd.yaml
@@ -18,7 +18,7 @@ metadata:
   name: dev-ctx
   namespace: default
 spec:
-  baseUrl: http://apim-apim3-api.default.svc:83
+  baseUrl: http://apim-api.gravitee.svc:83
   environmentId: DEFAULT
   organizationId: DEFAULT
   auth:

--- a/test/platform-test/e2e/fixtures/management-context/invalid-env/crd.yaml
+++ b/test/platform-test/e2e/fixtures/management-context/invalid-env/crd.yaml
@@ -17,7 +17,7 @@ kind: ManagementContext
 metadata:
   name: e2e-bad-env-ctx
 spec:
-  baseUrl: http://apim-apim3-api.default.svc:83
+  baseUrl: http://apim-api.gravitee.svc:83
   environmentId: NON_EXISTING_ENV
   organizationId: DEFAULT
   auth:

--- a/test/platform-test/e2e/fixtures/management-context/invalid-org/crd.yaml
+++ b/test/platform-test/e2e/fixtures/management-context/invalid-org/crd.yaml
@@ -17,7 +17,7 @@ kind: ManagementContext
 metadata:
   name: e2e-bad-org-ctx
 spec:
-  baseUrl: http://apim-apim3-api.default.svc:83
+  baseUrl: http://apim-api.gravitee.svc:83
   environmentId: DEFAULT
   organizationId: NON_EXISTING_ORG
   auth:

--- a/test/platform-test/e2e/fixtures/management-context/temporary-ctx/crd.yaml
+++ b/test/platform-test/e2e/fixtures/management-context/temporary-ctx/crd.yaml
@@ -18,7 +18,7 @@ metadata:
   name: e2e-temp-ctx
   namespace: default
 spec:
-  baseUrl: http://apim-apim3-api.default.svc:83
+  baseUrl: http://apim-api.gravitee.svc:83
   environmentId: DEFAULT
   organizationId: DEFAULT
   auth:

--- a/test/platform-test/e2e/fixtures/templating/management-context-bearer-token/crd.yaml
+++ b/test/platform-test/e2e/fixtures/templating/management-context-bearer-token/crd.yaml
@@ -18,7 +18,11 @@ metadata:
   name: e2e-ctx-bearer
   namespace: default
 spec:
-  baseUrl: http://apim-apim-rest-api.apim.svc:83
+  # Intentionally NOT the real management API service: the admission webhook
+  # fails open when the host is unreachable, but would reject this context's
+  # dummy bearer token with 401 if it could actually reach APIM. This test
+  # only verifies that the token is templated from the Secret into the CR.
+  baseUrl: http://apim-api-unreachable.gravitee.svc:83
   environmentId: DEFAULT
   organizationId: DEFAULT
   auth:

--- a/test/platform-test/gck.yaml
+++ b/test/platform-test/gck.yaml
@@ -1,0 +1,92 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# E2E cluster for the platform-test suite, provisioned with gck
+# (https://gravitee-io-labs.github.io/gck/). Replaces hack/scripts/run-kind.mjs
+# for this flow only — the integration-test job and local dev still use
+# `make start-cluster`.
+#
+# Create with:  make start-e2e-cluster
+# (requires a docker login to graviteeio.azurecr.io for the image preload)
+#
+# The APIM image source/tag (azurecr master nightlies) are passed by the make
+# target as `--set imagePrefix=... --set imageTag=...` — they are recipe vars,
+# not config. This file only carries what vars cannot express.
+#
+# Unlike run-kind.mjs, `gck create` errors if the cluster already exists —
+# run `make delete-cluster` first.
+from:
+  - gravitee-io/oss/apim/mongodb
+
+kind:
+  nodes:
+    - role: control-plane
+      # The one reason a kind section exists here: the operator coverage PV
+      # (test/e2e/coverage.yaml) is backed by this hostPath. Everything else
+      # (cluster name, NodePorts) comes from the registry recipe.
+      extraMounts:
+        - hostPath: /tmp/coverage
+          containerPath: /tmp/coverage
+
+components:
+  # Deep-merged onto the registry recipe's apim component: only the
+  # differences from the recipe are declared here.
+  - name: apim
+    helm:
+      # Pin to the 4.12 line; the "-0" prerelease bound is required to match
+      # milestone builds (currently resolves to 4.12.0-milestone.2).
+      version: ">=4.12.0-0 <4.13.0-0"
+      values:
+        gateway:
+          managedServiceAccount: false
+          deployment:
+            serviceAccount: gravitee-gateway
+          services:
+            sync:
+              kubernetes:
+                # Sync itself is enabled by the recipe. The gateway runs in
+                # ns `gravitee` while v2 local:true and v4 db-less test
+                # fixtures live in test namespaces, so it must watch the
+                # whole cluster (RBAC in extraObjects).
+                namespaces: ALL
+        # Cluster-wide RBAC for the gateway kubernetes sync, ported from
+        # hack/kind/apim/values.yaml with the namespace adjusted.
+        extraObjects:
+          - apiVersion: v1
+            kind: ServiceAccount
+            metadata:
+              name: gravitee-gateway
+          - apiVersion: rbac.authorization.k8s.io/v1
+            kind: ClusterRole
+            metadata:
+              name: gravitee-gateway-role
+            rules:
+              - apiGroups: [""]
+                resources: ["configmaps", "secrets"]
+                verbs: ["get", "watch", "list"]
+              - apiGroups: ["gravitee.io"]
+                resources: ["apidefinitions"]
+                verbs: ["get", "watch", "list"]
+          - apiVersion: rbac.authorization.k8s.io/v1
+            kind: ClusterRoleBinding
+            metadata:
+              name: gravitee-gateway-binding
+            subjects:
+              - kind: ServiceAccount
+                name: gravitee-gateway
+                namespace: gravitee
+            roleRef:
+              kind: ClusterRole
+              name: gravitee-gateway-role
+              apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Summary

- Replace the run-kind.mjs flow for the **e2e (platform-test) job only** with [gck](https://gravitee-io-labs.github.io/gck/) **v1.0.2**: the job composes the `gravitee-io/oss/apim/mongodb` registry context. The APIM image source/tag (azurecr master nightlies) are recipe vars passed via `--set imagePrefix=graviteeio.azurecr.io --set imageTag=master-latest` in the new `make start-e2e-cluster` target; ES and portal are disabled via the recipe's flags. The integration-test job and local dev keep `make start-cluster`.
- `test/platform-test/gck.yaml` is intentionally minimal and only carries what recipe vars cannot express: the `/tmp/coverage` Kind mount backing the operator coverage PV, the chart version pin (4.12 prerelease-inclusive), and gateway kubernetes sync across all namespaces with the cluster RBAC the chart cannot render itself (its managed SA only gets a namespaced Role).
- APIM lives in the `gravitee` namespace, so 6 fixtures' ManagementContext `baseUrl` move from `apim-apim3-api.default.svc:83` to `apim-api.gravitee.svc:83`. The bearer-token templating fixture intentionally keeps an unreachable host (the admission webhook fails open when APIM is unreachable but would 401 the fixture's dummy token against a real endpoint).
- e2e README cluster-bootstrap section rewritten around gck; AGENTS.md references updated.

Two gck bugs found during this migration (invalid RSA key in the registry's tls-server secret, flag patches failing to resolve context template vars) were fixed upstream in [gravitee-io-labs/gck#2](https://github.com/gravitee-io-labs/gck/pull/2); this PR pins v1.0.2 and carries no workarounds.

Verified locally on a from-scratch `gck create`: full suite green (**345 passed, 5 pre-existing skips**), gateway/mAPI running the azurecr `master-latest-debian` nightlies, mongo unaffected by the broadcast `--set` (stays `mongo:7`), mTLS port 30084 handshaking with the registry cert.

See: https://gravitee.atlassian.net/browse/GKO-2948
