### PR TITLE
fix(template): release templating refs when parent resource is deleted (GKO-2858)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,8 @@ run:
 # This file contains only configs which differ from defaults.
 # All possible options can be found here https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
 linters-settings:
+  lll:
+    line-length: 140
   stylecheck:
     dot-import-whitelist:
     - github.com/onsi/ginkgo/v2

--- a/controllers/apim/apidefinition/controller.go
+++ b/controllers/apim/apidefinition/controller.go
@@ -55,7 +55,11 @@ func Reconcile(
 func reconcileApiTemplate(ctx context.Context, apiDefinition core.ApiDefinitionObject) (ctrl.Result, error) {
 	_, err := util.CreateOrUpdate(ctx, k8s.GetClient(), apiDefinition, func() error {
 		dc, _ := apiDefinition.DeepCopyObject().(core.ApiDefinitionObject)
-		if err := template.Compile(ctx, dc, true); err != nil {
+		if !apiDefinition.GetDeletionTimestamp().IsZero() {
+			if err := template.ReleaseReferences(ctx, apiDefinition); err != nil {
+				return err
+			}
+		} else if err := template.Compile(ctx, dc, true); err != nil {
 			return err
 		}
 
@@ -92,7 +96,11 @@ func reconcileApiDefinition(
 		util.AddFinalizer(apiDefinition, core.ApiDefinitionFinalizer)
 		k8s.AddAnnotation(apiDefinition, core.LastSpecHashAnnotation, apiDefinition.GetSpec().Hash())
 
-		if err := template.Compile(ctx, dc, true); err != nil {
+		if !apiDefinition.GetDeletionTimestamp().IsZero() {
+			if err := template.ReleaseReferences(ctx, apiDefinition); err != nil {
+				return err
+			}
+		} else if err := template.Compile(ctx, dc, true); err != nil {
 			apiDefinition.GetStatus().SetProcessingStatus(core.ProcessingStatusFailed)
 			return err
 		}

--- a/controllers/apim/apiresource/apiresource_controller.go
+++ b/controllers/apim/apiresource/apiresource_controller.go
@@ -69,7 +69,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		util.AddFinalizer(apiResource, core.ApiResourceFinalizer)
 		k8s.AddAnnotation(apiResource, core.LastSpecHashAnnotation, hash.Calculate(&apiResource.Spec))
 
-		if err := template.Compile(ctx, dc, true); err != nil {
+		if apiResource.IsBeingDeleted() {
+			if err := template.ReleaseReferences(ctx, apiResource); err != nil {
+				return err
+			}
+		} else if err := template.Compile(ctx, dc, true); err != nil {
 			return err
 		}
 

--- a/controllers/apim/application/application_controller.go
+++ b/controllers/apim/application/application_controller.go
@@ -80,13 +80,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	k8s.ResetConditionsExceptAutomationAPI(application)
+
 	dc := application.DeepCopy()
 
 	_, err := util.CreateOrUpdate(ctx, r.Client, application, func() error {
 		util.AddFinalizer(application, core.ApplicationFinalizer)
 		k8s.AddAnnotation(application, core.LastSpecHashAnnotation, hash.Calculate(&application.Spec))
 
-		if err := template.Compile(ctx, dc, true); err != nil {
+		if application.IsBeingDeleted() {
+			if err := template.ReleaseReferences(ctx, application); err != nil {
+				return err
+			}
+		} else if err := template.Compile(ctx, dc, true); err != nil {
 			application.Status.ProcessingStatus = core.ProcessingStatusFailed
 			return err
 		}

--- a/controllers/apim/dictionary/dictionary_controller.go
+++ b/controllers/apim/dictionary/dictionary_controller.go
@@ -66,7 +66,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		util.AddFinalizer(dict, core.DictionaryFinalizer)
 		k8s.AddAnnotation(dict, core.LastSpecHashAnnotation, hash.Calculate(&dict.Spec))
 
-		if err := template.Compile(ctx, dc, true); err != nil {
+		if dict.IsBeingDeleted() {
+			if err := template.ReleaseReferences(ctx, dict); err != nil {
+				return err
+			}
+		} else if err := template.Compile(ctx, dc, true); err != nil {
 			return err
 		}
 

--- a/controllers/apim/group/group_controller.go
+++ b/controllers/apim/group/group_controller.go
@@ -58,13 +58,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	events := event.NewRecorder(r.Recorder)
 
 	k8s.ResetConditionsExceptAutomationAPI(group)
+
 	dc := group.DeepCopy()
 
 	_, err := util.CreateOrUpdate(ctx, k8s.GetClient(), group, func() error {
 		util.AddFinalizer(group, core.GroupFinalizer)
 		k8s.AddAnnotation(group, core.LastSpecHashAnnotation, hash.Calculate(&group.Spec))
 
-		if err := template.Compile(ctx, dc, true); err != nil {
+		if group.IsBeingDeleted() {
+			if err := template.ReleaseReferences(ctx, group); err != nil {
+				return err
+			}
+		} else if err := template.Compile(ctx, dc, true); err != nil {
 			group.Status.ProcessingStatus = core.ProcessingStatusFailed
 			return err
 		}

--- a/controllers/apim/ingress/ingress_controller.go
+++ b/controllers/apim/ingress/ingress_controller.go
@@ -74,11 +74,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		util.AddFinalizer(ingress, core.IngressFinalizer)
 		k8s.AddAnnotation(ingress, core.LastSpecHashAnnotation, hash.Calculate(&ingress.Spec))
 
-		err := template.Compile(ctx, dc, true)
-		if err != nil {
+		if !ingress.DeletionTimestamp.IsZero() {
+			if err := template.ReleaseReferences(ctx, ingress); err != nil {
+				return err
+			}
+		} else if err := template.Compile(ctx, dc, true); err != nil {
 			return err
 		}
 
+		var err error
 		if !ingress.DeletionTimestamp.IsZero() {
 			err = events.Record(e.Delete, ingress, func() error {
 				if err := internal.Delete(ctx, dc); err != nil {

--- a/controllers/apim/managementcontext/managementcontext_controller.go
+++ b/controllers/apim/managementcontext/managementcontext_controller.go
@@ -67,13 +67,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	events := event.NewRecorder(r.Recorder)
 
 	managementContext.SetConditions([]metav1.Condition{})
+
 	dc := managementContext.DeepCopy()
 
 	_, err := util.CreateOrUpdate(ctx, r.Client, managementContext, func() error {
 		util.AddFinalizer(managementContext, core.ManagementContextFinalizer)
 		k8s.AddAnnotation(managementContext, core.LastSpecHashAnnotation, hash.Calculate(&managementContext.Spec))
 
-		if err := template.Compile(ctx, dc, true); err != nil {
+		if managementContext.IsBeingDeleted() {
+			if err := template.ReleaseReferences(ctx, managementContext); err != nil {
+				return err
+			}
+		} else if err := template.Compile(ctx, dc, true); err != nil {
 			return err
 		}
 

--- a/controllers/apim/sharedpolicygroups/sharedpolicygroups_controller.go
+++ b/controllers/apim/sharedpolicygroups/sharedpolicygroups_controller.go
@@ -69,13 +69,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	events := event.NewRecorder(r.Recorder)
 
 	k8s.ResetConditionsExceptAutomationAPI(spg)
+
 	dc := spg.DeepCopy()
 
 	_, err := util.CreateOrUpdate(ctx, r.Client, spg, func() error {
 		util.AddFinalizer(spg, core.SharedPolicyGroupFinalizer)
 		k8s.AddAnnotation(spg, core.LastSpecHashAnnotation, hash.Calculate(&spg.Spec))
 
-		if err := template.Compile(ctx, dc, true); err != nil {
+		if spg.IsBeingDeleted() {
+			if err := template.ReleaseReferences(ctx, spg); err != nil {
+				return err
+			}
+		} else if err := template.Compile(ctx, dc, true); err != nil {
 			spg.Status.ProcessingStatus = core.ProcessingStatusFailed
 			return err
 		}

--- a/controllers/apim/subscription/subscription_controller.go
+++ b/controllers/apim/subscription/subscription_controller.go
@@ -71,7 +71,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		util.AddFinalizer(subscription, core.SubscriptionFinalizer)
 		k8s.AddAnnotation(subscription, core.LastSpecHashAnnotation, hash.Calculate(&subscription.Spec))
 
-		if err := template.Compile(ctx, dc, true); err != nil {
+		if subscription.IsBeingDeleted() {
+			if err := template.ReleaseReferences(ctx, subscription); err != nil {
+				return err
+			}
+		} else if err := template.Compile(ctx, dc, true); err != nil {
 			subscription.Status.ProcessingStatus = core.ProcessingStatusFailed
 			return err
 		}

--- a/internal/template/compiler.go
+++ b/internal/template/compiler.go
@@ -25,18 +25,17 @@ import (
 	"strings"
 	"text/template"
 
-	gerrors "github.com/gravitee-io/gravitee-kubernetes-operator/internal/errors"
-	kErrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/core"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/env"
+	gerrors "github.com/gravitee-io/gravitee-kubernetes-operator/internal/errors"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/k8s"
 	util "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	v1 "k8s.io/api/core/v1"
+	kErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -81,14 +80,67 @@ func doCompile(ctx context.Context, obj client.Object, updateObjectMetadata bool
 	return runtime.DefaultUnstructuredConverter.FromUnstructured(objData, obj)
 }
 
-func exec(ctx context.Context, text, ns string, parentResourceDeleted,
-	updateObjectMetadata bool) (string, error) {
+// ReleaseReferences removes templating annotations and finalizers from Secrets and ConfigMaps
+// that still reference obj. obj must be the live object from the mutate func.
+func ReleaseReferences(ctx context.Context, obj client.Object) error {
+	if !env.Config.EnableTemplating {
+		return nil
+	}
+	if obj.GetDeletionTimestamp().IsZero() {
+		return nil
+	}
+
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return fmt.Errorf("failed to convert object to unstructured: %w", err)
+	}
+
+	objID := getUnstructuredObjectID(u)
+	ns := obj.GetNamespace()
+	annotationKey := getObjectAnnotationName(u)
+	releaseCtx := context.WithValue(
+		context.WithValue(ctx, objectIDCtxKey, objID),
+		objectAnnotationKey, annotationKey,
+	)
+
+	secretList := &v1.SecretList{}
+	if err := k8s.GetClient().List(ctx, secretList, client.InNamespace(ns)); err != nil {
+		return err
+	}
+	for i := range secretList.Items {
+		sec := &secretList.Items[i]
+		if !referencesObject(sec, annotationKey, objID) {
+			continue
+		}
+		if err := releaseFromSource(releaseCtx, sec); err != nil {
+			return err
+		}
+	}
+
+	configMapList := &v1.ConfigMapList{}
+	if err := k8s.GetClient().List(ctx, configMapList, client.InNamespace(ns)); err != nil {
+		return err
+	}
+	for i := range configMapList.Items {
+		cm := &configMapList.Items[i]
+		if !referencesObject(cm, annotationKey, objID) {
+			continue
+		}
+		if err := releaseFromSource(releaseCtx, cm); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func exec(ctx context.Context, text, ns string, updateObjectMetadata bool) (string, error) {
 	funcMap := map[string]interface{}{
 		"configmap": func(name string) (string, error) {
-			return resolveConfigmap(ctx, ns, name, parentResourceDeleted, updateObjectMetadata)
+			return resolveConfigmap(ctx, ns, name, updateObjectMetadata)
 		},
 		"secret": func(name string) (string, error) {
-			return resolveSecret(ctx, ns, name, parentResourceDeleted, updateObjectMetadata)
+			return resolveSecret(ctx, ns, name, updateObjectMetadata)
 		},
 	}
 
@@ -111,8 +163,7 @@ func exec(ctx context.Context, text, ns string, parentResourceDeleted,
 	return buf.String(), nil
 }
 
-func resolveConfigmap(ctx context.Context, ns, name string, parentResourceDeleted,
-	updateObjectMetadata bool) (string, error) {
+func resolveConfigmap(ctx context.Context, ns, name string, updateObjectMetadata bool) (string, error) {
 	if name == "" {
 		return "", fmt.Errorf("empty configmap name")
 	}
@@ -129,9 +180,6 @@ func resolveConfigmap(ctx context.Context, ns, name string, parentResourceDelete
 
 	err := cli.Get(ctx, nn, cm)
 	if kErrors.IsNotFound(err) {
-		if parentResourceDeleted {
-			return "", nil
-		}
 		return "", gerrors.NewResolveRefError(fmt.Errorf("configmap [%s/%s] not found", ns, name))
 	}
 
@@ -148,13 +196,13 @@ func resolveConfigmap(ctx context.Context, ns, name string, parentResourceDelete
 		return v, nil
 	}
 
-	totalReference, updated, err := updateAnnotation(ctx, cm, parentResourceDeleted)
+	_, updated, err := updateAnnotation(ctx, cm, false)
 	if err != nil {
 		return "", err
 	}
 
 	if updated {
-		updateFinalizer(ctx, cm, parentResourceDeleted && totalReference == 0)
+		updateFinalizer(ctx, cm, false)
 		if err := k8s.Update(ctx, cm); err != nil {
 			return "", err
 		}
@@ -163,8 +211,7 @@ func resolveConfigmap(ctx context.Context, ns, name string, parentResourceDelete
 	return v, nil
 }
 
-func resolveSecret(ctx context.Context, ns, name string, parentResourceDeleted,
-	updateObjectMetadata bool) (string, error) {
+func resolveSecret(ctx context.Context, ns, name string, updateObjectMetadata bool) (string, error) {
 	if name == "" {
 		return "", fmt.Errorf("empty secret name")
 	}
@@ -181,9 +228,6 @@ func resolveSecret(ctx context.Context, ns, name string, parentResourceDeleted,
 
 	err := cli.Get(ctx, nn, sec)
 	if kErrors.IsNotFound(err) {
-		if parentResourceDeleted {
-			return "", nil
-		}
 		return "", gerrors.NewResolveRefError(fmt.Errorf("secret [%s/%s] not found", ns, name))
 	}
 
@@ -201,13 +245,13 @@ func resolveSecret(ctx context.Context, ns, name string, parentResourceDeleted,
 		return string(v), nil
 	}
 
-	totalReference, updated, err := updateAnnotation(ctx, sec, parentResourceDeleted)
+	_, updated, err := updateAnnotation(ctx, sec, false)
 	if err != nil {
 		return "", err
 	}
 
 	if updated {
-		updateFinalizer(ctx, sec, parentResourceDeleted && totalReference == 0)
+		updateFinalizer(ctx, sec, false)
 		if err := k8s.Update(ctx, sec); err != nil {
 			return "", err
 		}
@@ -227,7 +271,7 @@ func updateFinalizer(_ context.Context, obj client.Object, unreferenced bool) {
 	}
 }
 
-func updateAnnotation(ctx context.Context, obj client.Object, parentResourceDeleted bool) (int, bool, error) {
+func updateAnnotation(ctx context.Context, obj client.Object, release bool) (int, bool, error) {
 	annotationKey, _ := ctx.Value(objectAnnotationKey).(string)
 	objID, _ := ctx.Value(objectIDCtxKey).(string)
 	annotationValue, ok := obj.GetAnnotations()[annotationKey]
@@ -249,7 +293,7 @@ func updateAnnotation(ctx context.Context, obj client.Object, parentResourceDele
 
 	updated := false
 	valueSet := sets.New(values...)
-	if parentResourceDeleted {
+	if release {
 		updated = true
 		if totalReference > 0 {
 			totalReference--
@@ -288,4 +332,36 @@ func getUnstructuredObjectID(unstructured map[string]interface{}) string {
 func getObjectAnnotationName(unstructured map[string]interface{}) string {
 	kind := unstructured["kind"]
 	return "gravitee.io/" + strings.ToLower(fmt.Sprintf("%v", kind)) + "s"
+}
+
+func referencesObject(obj client.Object, annotationKey, objID string) bool {
+	if !util.ContainsFinalizer(obj, core.TemplatingFinalizer) {
+		return false
+	}
+
+	annotationValue, ok := obj.GetAnnotations()[annotationKey]
+	if !ok {
+		return false
+	}
+
+	values := make([]string, 0)
+	if err := json.Unmarshal([]byte(annotationValue), &values); err != nil {
+		return false
+	}
+
+	return sets.New(values...).Has(objID)
+}
+
+func releaseFromSource(ctx context.Context, source client.Object) error {
+	totalReference, updated, err := updateAnnotation(ctx, source, true)
+	if err != nil {
+		return err
+	}
+	if !updated {
+		return nil
+	}
+
+	updateFinalizer(ctx, source, totalReference == 0)
+
+	return k8s.Update(ctx, source)
 }

--- a/internal/template/tree.go
+++ b/internal/template/tree.go
@@ -45,13 +45,9 @@ func traverse(ctx context.Context, obj client.Object, updateObjectMetadata bool)
 	cp["status"] = nil
 	cp["metadata"] = nil
 
-	isDeleted, err := isResourceDeleted(inner)
-	if err != nil {
-		return nil, gerrors.NewCompileTemplateError(fmt.Errorf("failed to check if resource is deleted: %w", err))
-	}
 	result, err := doTraverse(cp, func(val interface{}) (interface{}, error) {
 		if v, ok := val.(string); ok {
-			return exec(ctx, v, ns, isDeleted, updateObjectMetadata)
+			return exec(ctx, v, ns, updateObjectMetadata)
 		}
 
 		return val, nil
@@ -69,16 +65,6 @@ func traverse(ctx context.Context, obj client.Object, updateObjectMetadata bool)
 	inner["spec"] = resultMap["spec"]
 
 	return inner, nil
-}
-
-func isResourceDeleted(obj map[string]interface{}) (bool, error) {
-	metadata, ok := obj["metadata"].(map[string]interface{})
-	if !ok {
-		return false, fmt.Errorf("missing object metadata or unsupported type")
-	}
-
-	_, ok = metadata["deletionTimestamp"]
-	return ok, nil
 }
 
 func doTraverse(obj interface{}, mapper valMapper) (interface{}, error) {

--- a/test/platform-test/e2e/tests/gko/dictionaries/dictionary-templating.test.ts
+++ b/test/platform-test/e2e/tests/gko/dictionaries/dictionary-templating.test.ts
@@ -46,12 +46,7 @@ async function gatewayBaseUrl(): Promise<string> {
 }
 
 test.describe("Dictionaries — Templating", () => {
-  // GKO-2858: deleting the Dictionary leaves the referenced Secret's
-  // `finalizers.gravitee.io/templating` finalizer in place, so the Secret sticks
-  // in Terminating and cleanup (`kubectl delete`) hangs until the helper's 15s
-  // timeout. Retested on master with the GKO-2858 fix attempt (d32a1876) and it
-  // still reproduces. Re-enable (flip back to `test(...)`) once GKO-2858 is resolved.
-  test.fixme(`Dynamic dictionary with secret templates resolves in API header ${XRAY.DICTIONARIES.DYNAMIC_TEMPLATE_RESOLVE} ${TAGS.REGRESSION}`, async ({
+  test(`Dynamic dictionary with secret templates resolves in API header ${XRAY.DICTIONARIES.DYNAMIC_TEMPLATE_RESOLVE} ${TAGS.REGRESSION}`, async ({
     kubectl,
   }) => {
     const secretFixture = fixture("dictionaries/dictionary-dynamic-tpl-secret/crd.yaml");

--- a/test/unit/template/release_references_test.go
+++ b/test/unit/template/release_references_test.go
@@ -1,0 +1,343 @@
+// Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package template_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/gravitee-io/gravitee-kubernetes-operator/api/model/dictionary"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/api/v1alpha1"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/core"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/env"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/k8s"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/template"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	util "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	testNamespace            = "default"
+	totalReferenceAnnotation = "gravitee.io/references"
+)
+
+var _ = Describe("ReleaseReferences", func() {
+	var (
+		ctx             context.Context
+		scheme          *runtime.Scheme
+		prevEnableTempl bool
+		dictName        string
+		dictObjectID    string
+		deletingDict    *v1alpha1.Dictionary
+		activeDict      *v1alpha1.Dictionary
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		prevEnableTempl = env.Config.EnableTemplating
+		env.Config.EnableTemplating = true
+
+		scheme = runtime.NewScheme()
+		Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed())
+		Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
+
+		dictName = "test-dict"
+		dictObjectID = testNamespace + "/" + dictName
+		deletingDict = deletingDictionary(dictName, testNamespace)
+		activeDict = &v1alpha1.Dictionary{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: v1alpha1.GroupVersion.String(),
+				Kind:       "Dictionary",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dictName,
+				Namespace: testNamespace,
+			},
+		}
+	})
+
+	AfterEach(func() {
+		env.Config.EnableTemplating = prevEnableTempl
+	})
+
+	registerClient := func(objects ...client.Object) {
+		k8s.RegisterClient(fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(objects...).
+			Build())
+	}
+
+	getSecret := func(name string) *corev1.Secret {
+		sec := &corev1.Secret{}
+		Expect(k8s.GetClient().Get(ctx, types.NamespacedName{
+			Namespace: testNamespace,
+			Name:      name,
+		}, sec)).To(Succeed())
+		return sec
+	}
+
+	getConfigMap := func(name string) *corev1.ConfigMap {
+		cm := &corev1.ConfigMap{}
+		Expect(k8s.GetClient().Get(ctx, types.NamespacedName{
+			Namespace: testNamespace,
+			Name:      name,
+		}, cm)).To(Succeed())
+		return cm
+	}
+
+	annotationKey := func() string {
+		return templatingAnnotationKey(deletingDict)
+	}
+
+	It("is a no-op when templating is disabled", func() {
+		env.Config.EnableTemplating = false
+		sec := templatingSecret("tpl-secret", dictObjectID, 1, annotationKey())
+		registerClient(sec, deletingDict)
+
+		Expect(template.ReleaseReferences(ctx, deletingDict)).To(Succeed())
+
+		updated := getSecret("tpl-secret")
+		Expect(util.ContainsFinalizer(updated, core.TemplatingFinalizer)).To(BeTrue())
+		Expect(updated.Annotations[annotationKey()]).To(Equal(mustMarshal([]string{dictObjectID})))
+	})
+
+	It("is a no-op when the parent is not being deleted", func() {
+		sec := templatingSecret("tpl-secret", dictObjectID, 1, templatingAnnotationKey(activeDict))
+		registerClient(sec, activeDict)
+
+		Expect(template.ReleaseReferences(ctx, activeDict)).To(Succeed())
+
+		updated := getSecret("tpl-secret")
+		Expect(util.ContainsFinalizer(updated, core.TemplatingFinalizer)).To(BeTrue())
+		Expect(updated.Annotations[totalReferenceAnnotation]).To(Equal("1"))
+	})
+
+	It("removes the finalizer when releasing the last reference on a Secret", func() {
+		sec := templatingSecret("tpl-secret", dictObjectID, 1, annotationKey())
+		registerClient(sec, deletingDict)
+
+		Expect(template.ReleaseReferences(ctx, deletingDict)).To(Succeed())
+
+		updated := getSecret("tpl-secret")
+		Expect(util.ContainsFinalizer(updated, core.TemplatingFinalizer)).To(BeFalse())
+		Expect(updated.Annotations[annotationKey()]).To(Equal(mustMarshal([]string{})))
+		Expect(updated.Annotations[totalReferenceAnnotation]).To(Equal("0"))
+	})
+
+	It("keeps the finalizer when other parents still reference the Secret", func() {
+		otherParentID := testNamespace + "/other-dict"
+		sec := templatingSecret("tpl-secret", dictObjectID, 2, annotationKey(), otherParentID)
+		registerClient(sec, deletingDict)
+
+		Expect(template.ReleaseReferences(ctx, deletingDict)).To(Succeed())
+
+		updated := getSecret("tpl-secret")
+		Expect(util.ContainsFinalizer(updated, core.TemplatingFinalizer)).To(BeTrue())
+		Expect(updated.Annotations[annotationKey()]).To(Equal(mustMarshal([]string{otherParentID})))
+		Expect(updated.Annotations[totalReferenceAnnotation]).To(Equal("1"))
+	})
+
+	It("releases templating references on a ConfigMap", func() {
+		cm := templatingConfigMap("tpl-configmap", dictObjectID, 1, annotationKey())
+		registerClient(cm, deletingDict)
+
+		Expect(template.ReleaseReferences(ctx, deletingDict)).To(Succeed())
+
+		updated := getConfigMap("tpl-configmap")
+		Expect(util.ContainsFinalizer(updated, core.TemplatingFinalizer)).To(BeFalse())
+		Expect(updated.Annotations[annotationKey()]).To(Equal(mustMarshal([]string{})))
+		Expect(updated.Annotations[totalReferenceAnnotation]).To(Equal("0"))
+	})
+
+	It("ignores Secrets without the templating finalizer", func() {
+		sec := templatingSecret("tpl-secret", dictObjectID, 1, annotationKey())
+		util.RemoveFinalizer(sec, core.TemplatingFinalizer)
+		registerClient(sec, deletingDict)
+
+		Expect(template.ReleaseReferences(ctx, deletingDict)).To(Succeed())
+
+		updated := getSecret("tpl-secret")
+		Expect(util.ContainsFinalizer(updated, core.TemplatingFinalizer)).To(BeFalse())
+		Expect(updated.Annotations[annotationKey()]).To(Equal(mustMarshal([]string{dictObjectID})))
+		Expect(updated.Annotations[totalReferenceAnnotation]).To(Equal("1"))
+	})
+
+	It("ignores Secrets referenced by a different parent", func() {
+		otherParentID := testNamespace + "/other-dict"
+		sec := templatingSecret("tpl-secret", otherParentID, 1, annotationKey())
+		registerClient(sec, deletingDict)
+
+		Expect(template.ReleaseReferences(ctx, deletingDict)).To(Succeed())
+
+		updated := getSecret("tpl-secret")
+		Expect(util.ContainsFinalizer(updated, core.TemplatingFinalizer)).To(BeTrue())
+		Expect(updated.Annotations[annotationKey()]).To(Equal(mustMarshal([]string{otherParentID})))
+		Expect(updated.Annotations[totalReferenceAnnotation]).To(Equal("1"))
+	})
+
+	It("only scans Secrets in the parent namespace", func() {
+		otherNSSec := templatingSecret("other-ns-secret", dictObjectID, 1, annotationKey())
+		otherNSSec.Namespace = "other"
+		registerClient(otherNSSec, deletingDict)
+
+		Expect(template.ReleaseReferences(ctx, deletingDict)).To(Succeed())
+
+		updated := &corev1.Secret{}
+		Expect(k8s.GetClient().Get(ctx, types.NamespacedName{
+			Namespace: "other",
+			Name:      "other-ns-secret",
+		}, updated)).To(Succeed())
+		Expect(util.ContainsFinalizer(updated, core.TemplatingFinalizer)).To(BeTrue())
+		Expect(updated.Annotations[annotationKey()]).To(Equal(mustMarshal([]string{dictObjectID})))
+	})
+
+	It("releases references created by Compile", func() {
+		sec := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "provider-secret",
+				Namespace: testNamespace,
+			},
+			Data: map[string][]byte{
+				"url": []byte("https://example.com"),
+			},
+		}
+		dict := &v1alpha1.Dictionary{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: v1alpha1.GroupVersion.String(),
+				Kind:       "Dictionary",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dictName,
+				Namespace: testNamespace,
+			},
+		}
+		dict.Spec.Name = dictName
+		dict.Spec.DictionaryType = dictionary.DynamicType
+		dict.Spec.Dynamic = &dictionary.DynamicSpec{
+			Provider: &dictionary.Provider{
+				ProviderType: "HTTP",
+				URL:          "[[ secret `provider-secret/url` ]]",
+				Method:       "GET",
+			},
+			Trigger: &dictionary.Trigger{
+				Rate: 1,
+				Unit: dictionary.SecondsUnit,
+			},
+		}
+		registerClient(sec, dict)
+
+		Expect(template.Compile(ctx, dict, true)).To(Succeed())
+
+		annotationKey := templatingAnnotationKey(dict)
+		compiled := getSecret("provider-secret")
+		Expect(util.ContainsFinalizer(compiled, core.TemplatingFinalizer)).To(BeTrue())
+		Expect(compiled.Annotations[annotationKey]).To(Equal(mustMarshal([]string{dictObjectID})))
+
+		now := metav1.Now()
+		dict.DeletionTimestamp = &now
+		Expect(template.ReleaseReferences(ctx, dict)).To(Succeed())
+
+		released := getSecret("provider-secret")
+		Expect(util.ContainsFinalizer(released, core.TemplatingFinalizer)).To(BeFalse())
+		Expect(released.Annotations[annotationKey]).To(Equal(mustMarshal([]string{})))
+		Expect(released.Annotations[totalReferenceAnnotation]).To(Equal("0"))
+	})
+
+	It("releases only matching Secrets when several exist in the namespace", func() {
+		matching := templatingSecret("matching-secret", dictObjectID, 1, annotationKey())
+		other := templatingSecret("other-secret", testNamespace+"/other-dict", 1, annotationKey())
+		registerClient(matching, other, deletingDict)
+
+		Expect(template.ReleaseReferences(ctx, deletingDict)).To(Succeed())
+
+		released := getSecret("matching-secret")
+		Expect(util.ContainsFinalizer(released, core.TemplatingFinalizer)).To(BeFalse())
+
+		untouched := getSecret("other-secret")
+		Expect(util.ContainsFinalizer(untouched, core.TemplatingFinalizer)).To(BeTrue())
+	})
+})
+
+func deletingDictionary(name, namespace string) *v1alpha1.Dictionary {
+	now := metav1.Now()
+	return &v1alpha1.Dictionary{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1alpha1.GroupVersion.String(),
+			Kind:       "Dictionary",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{core.DictionaryFinalizer},
+		},
+	}
+}
+
+func templatingSecret(name, objectID string, totalRefs int, annotationKey string, extraObjectIDs ...string) *corev1.Secret {
+	objectIDs := append([]string{objectID}, extraObjectIDs...)
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+			Annotations: map[string]string{
+				annotationKey:            mustMarshal(objectIDs),
+				totalReferenceAnnotation: itoa(totalRefs),
+			},
+			Finalizers: []string{core.TemplatingFinalizer},
+		},
+	}
+}
+
+func templatingConfigMap(name, objectID string, totalRefs int, annotationKey string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+			Annotations: map[string]string{
+				annotationKey:            mustMarshal([]string{objectID}),
+				totalReferenceAnnotation: itoa(totalRefs),
+			},
+			Finalizers: []string{core.TemplatingFinalizer},
+		},
+	}
+}
+
+func mustMarshal(values []string) string {
+	b, err := json.Marshal(values)
+	Expect(err).NotTo(HaveOccurred())
+	return string(b)
+}
+
+func itoa(v int) string {
+	return strconv.Itoa(v)
+}
+
+func templatingAnnotationKey(obj client.Object) string {
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	Expect(err).NotTo(HaveOccurred())
+	return "gravitee.io/" + strings.ToLower(fmt.Sprintf("%v", u["kind"])) + "s"
+}

--- a/test/unit/template/suite_test.go
+++ b/test/unit/template/suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package template_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTemplate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Template unit tests suite")
+}


### PR DESCRIPTION
## Summary

- Fixes [GKO-2858](https://gravitee.atlassian.net/browse/GKO-2858): deleting a Dictionary (or other templating parent) no longer leaves referenced Secrets/ConfigMaps stuck with `finalizers.gravitee.io/templating`.
- Templating controllers skip `Compile` during deletion and call `ReleaseReferences` instead, which scans namespace Secrets/ConfigMaps and removes annotations/finalizers for the deleting parent.
- Simplifies the compile path by removing `parentResourceDeleted` handling from `resolveSecret`/`resolveConfigmap` and `tree.traverse`.
- Re-enables the dictionary templating e2e test (`@GKO-TBD-DICT-DYNAMIC-TPL`).

Supersedes the partial fix in #1681.

## Test plan

- [x] `go build ./...`
- [x] `make unit` (template package)
- [x] E2E: `cd test/platform-test && npm run e2e -- --grep @GKO-TBD-DICT-DYNAMIC-TPL`
- [x] Manual: create Dictionary with `[[ secret ... ]]`, delete Dictionary, verify Secret is removed without stuck finalizer

[GKO-2858]: https://gravitee.atlassian.net/browse/GKO-2858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ