### PR TITLE
test: e2e coverage for v4 Automation API + native Kafka fields (GKO-2955)

### DIFF
--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-native-kafka-reporter-disabled.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-native-kafka-reporter-disabled.yaml
@@ -20,8 +20,11 @@ spec:
   contextRef:
     name: "dev-ctx"
     namespace: "default"
-  name: "e2e-v4-native-kafka-ports"
-  description: "E2E test: Native Kafka API plan ports validation"
+  # Unique identity (name + Kafka host + broker port range). This fixture used
+  # to share spec.name/host/ports with v4-native-kafka-ports-valid.yaml, which
+  # mapped both to the same APIM API and made the suite order-dependent.
+  name: "e2e-v4-native-kafka-reporter-disabled"
+  description: "E2E test: Native Kafka API with reporter metrics disabled"
   version: "1.0.0"
   type: NATIVE
   state: STOPPED
@@ -33,7 +36,7 @@ spec:
     syncFrom: MANAGEMENT
   listeners:
     - type: KAFKA
-      host: "kafka.example.local"
+      host: "kafka-reporter.example.local"
       port: 9092
       entrypoints:
         - type: native-kafka
@@ -46,7 +49,7 @@ spec:
           type: native-kafka
           inheritConfiguration: false
           configuration:
-            bootstrapServers: "kafka.example.local:9092"
+            bootstrapServers: "kafka-reporter.example.local:9092"
           secondary: false
           sharedConfigurationOverride:
             security:
@@ -57,7 +60,7 @@ spec:
       name: "Free plan"
       security:
         type: "KEY_LESS"
-      bootstrapPort: 9092
-      brokerRangeStart: 9100
-      brokerRangeEnd: 9102
+      bootstrapPort: 9292
+      brokerRangeStart: 9300
+      brokerRangeEnd: 9302
 

--- a/test/platform-test/e2e/tests/gko/admission-webhook/v4-native-kafka-ports-validation.test.ts
+++ b/test/platform-test/e2e/tests/gko/admission-webhook/v4-native-kafka-ports-validation.test.ts
@@ -25,12 +25,26 @@
 
 import { test, fixture, expect } from "../../../setup.js";
 import { TAGS } from "../../../helpers/tags.js";
+import type { PlanV4 } from "../../../../src/types/apim.js";
 
 test.describe("Native Kafka API — Plan ports validation", () => {
-  test(`Valid native kafka plan ports are accepted ${TAGS.REGRESSION}`, async ({ kubectl }) => {
+  test(`Valid native kafka plan ports are accepted ${TAGS.REGRESSION}`, async ({ kubectl, mapi }) => {
+    const API_NAME = "e2e-v4-native-kafka-ports";
     const f = fixture("crds/api-v4-definitions/v4-native-kafka-ports-valid.yaml");
     await kubectl.apply(f);
-    await kubectl.waitForCondition("apiv4definition", "e2e-v4-native-kafka-ports", "Accepted");
+    await kubectl.waitForCondition("apiv4definition", API_NAME, "Accepted");
+
+    // Beyond passing admission, the port-based-routing fields must round-trip
+    // through the management API GET endpoint (GKO-2919 / PR #1684).
+    const apiId = (await kubectl.getStatus<{ id: string }>("apiv4definition", API_NAME)).id;
+    await expect
+      .poll(async () => ((await mapi.listApiPlans(apiId)) as PlanV4[])[0])
+      .toMatchObject({
+        bootstrapPort: 9092,
+        brokerRangeStart: 9100,
+        brokerRangeEnd: 9102,
+      });
+
     await kubectl.del(f).catch(() => {});
   });
 

--- a/test/platform-test/e2e/tests/gko/api-lifecycle/v4-native-kafka-analytics.test.ts
+++ b/test/platform-test/e2e/tests/gko/api-lifecycle/v4-native-kafka-analytics.test.ts
@@ -25,7 +25,7 @@ import { TAGS } from "../../../helpers/tags.js";
 
 test.describe("Native Kafka API — Analytics", () => {
   test(`reporterMetricsEnabled=false is applied in APIM ${TAGS.REGRESSION}`, async ({ kubectl, mapi }) => {
-    const API_NAME = "e2e-v4-native-kafka-ports";
+    const API_NAME = "e2e-v4-native-kafka-reporter-disabled";
     const f = fixture("crds/api-v4-definitions/v4-native-kafka-reporter-disabled.yaml");
 
     await kubectl.apply(f);

--- a/test/platform-test/e2e/tests/gko/import-export/v4-import-export-extended.test.ts
+++ b/test/platform-test/e2e/tests/gko/import-export/v4-import-export-extended.test.ts
@@ -103,13 +103,11 @@ test.describe("V4 Import/Export — Extended", () => {
   // or produces an unimportable CRD, the apply will fail or the reconciliation
   // will move off Accepted.
 
-  // Skipped pending GKO-2919: the GKO ApiV4Definition CRD does not declare
-  // `spec.allowedInApiProducts` or `spec.allowMultiJwtOauth2Subscriptions`,
-  // but APIM PR #17029 (commit d3c94cd7) added both to the v2 CRD export spec,
-  // so re-applying the exported YAML fails strict field validation on
-  // CircleCI. Re-enable once GKO adds the two fields to ApiV4Definition and
-  // regenerates the CRD.
-  test.skip(`V4 CRD export/import round-trip preserves identity ${XRAY.IMPORT_EXPORT.V4_EXPORT_IMPORT_ROUND_TRIP} ${TAGS.REGRESSION}`, async ({
+  // Re-enabled after GKO-2919: the ApiV4Definition CRD now declares
+  // `spec.allowedInApiProducts` and `spec.allowMultiJwtOauth2Subscriptions`
+  // (PR #1684), so the exported YAML no longer trips strict field validation
+  // on re-apply.
+  test(`V4 CRD export/import round-trip preserves identity ${XRAY.IMPORT_EXPORT.V4_EXPORT_IMPORT_ROUND_TRIP} ${TAGS.REGRESSION}`, async ({
     kubectl,
     mapi,
   }) => {

--- a/test/platform-test/src/types/apim.ts
+++ b/test/platform-test/src/types/apim.ts
@@ -365,6 +365,10 @@ export interface GenericPlan {
 export interface PlanV4 extends GenericPlan {
   definitionVersion: "V4";
   flows?: FlowV4[];
+  /** Port-based routing fields, native Kafka APIs only  */
+  bootstrapPort?: number;
+  brokerRangeStart?: number;
+  brokerRangeEnd?: number;
 }
 
 export interface PlanV2 extends GenericPlan {


### PR DESCRIPTION
Follow-up QA coverage for the v4 fields added in #1684 (GKO-2919):

- Assert the native Kafka plan port fields (`bootstrapPort`, `brokerRangeStart`, `brokerRangeEnd`) round-trip through the management GET endpoint.
- Fix a flaky native Kafka analytics test (waited on the wrong CR name; de-collided the fixture identity).
- Re-enable the GKO-1472 V4 export/import round-trip test now that the CRD declares the new fields.

See: https://gravitee.atlassian.net/browse/GKO-2955
