### PR TITLE
test(platform-test): readable provisioner test API + groups shared scenario

### DIFF
--- a/test/platform-test/AGENTS.md
+++ b/test/platform-test/AGENTS.md
@@ -58,7 +58,7 @@ test/platform-test/
     setup.ts                      # Playwright fixtures: { mapi, gateway, kubectl, mtlsGatewayBaseUrl } + fixture()
     helpers/
       kubectl.ts terraform.ts     # thin shims/adapters over src/provisioners/engines (existing imports still work)
-      for-provisioners.ts         # forProvisioners(): expand a scenario into 1 tagged test per provisioner
+      for-each-provisioner.ts     # forEachProvisioner(): expand a scenario into 1 tagged test per provisioner
       provisioner-env.ts          # gkoScenario()/tfScenario(): bind engines + config + fixture() to provisioners
       tags.ts                     # XRAY.* test-ID constants + TAGS.REGRESSION
     fixtures/<domain>/<scenario>/ # one folder per scenario, referenced via fixture("<domain>/<scenario>/...")
@@ -95,11 +95,11 @@ test/platform-test/
 ## Provisioner layer: one intent, every provisioner
 
 For behaviour that should hold no matter how a resource was created, write it ONCE as a
-`*.scenario.ts` under `tests/scenarios/<domain>/` and let `forProvisioners` run it against every
+`*.scenario.ts` under `tests/scenarios/<domain>/` and let `forEachProvisioner` run it against every
 provisioner the scenario supports. The current provisioners are GKO and Terraform, and the layer is
 built to grow: adding another (e.g. a UI path) means implementing the `Provisioner` interface under
 `src/provisioners/` and listing it in the scenario, with no change to the scenario bodies or the
-shared assertions. The shared body uses only the provisioner-agnostic handle (`provision`) plus
+shared assertions. The shared body uses only the provisioner-agnostic handle (`provisioned`) plus
 `mapi`/`gateway`; each generated test's title carries its provisioner tag (e.g. `@gko`, `@terraform`)
 and the per-provisioner Xray id.
 
@@ -114,10 +114,10 @@ Xray tag and selects the whole suite. The lane filter is a case-sensitive grep a
 enforced).
 
 ```ts
-import { forProvisioners } from "../../../../helpers/for-provisioners.js";
+import { forEachProvisioner } from "../../../../helpers/for-each-provisioner.js";
 import { gkoScenario, tfScenario } from "../../../../helpers/provisioner-env.js";
 
-forProvisioners<MyParams>(
+forEachProvisioner<MyParams>(
   {
     title: "API is started and reachable",
     provisioners: {
@@ -132,29 +132,32 @@ forProvisioners<MyParams>(
     tags: [TAGS.REGRESSION],
     timeoutMs: { gko: 60_000 },                     // TF defaults to TF_WORKSPACE_TIMEOUT_MS
   },
-  async ({ provision, mapi, gateway }) => {
-    await mapi.waitForApiStarted(await provision.id("api"));
-    await gateway.assertResponds(await provision.contextPath(), { status: 200 });
+  async ({ provisioned, mapi, gateway }) => {
+    await mapi.waitForApiStarted(await provisioned.apiId());
+    await gateway.assertResponds(await provisioned.contextPath(), { status: 200 });
   },
   {} as MyParams,                                   // initial params
 );
 ```
 
 Rules of thumb:
-- **Handle surface:** `provision.id(role?)`, `provision.ref(role?)`, `provision.contextPath()`,
-  `provision.update(params)` (rotation-style re-provision), `provision.destroy()`. `id`/`contextPath`
-  are resolved once then cached. The generator destroys the handle for you, with an `afterEach` safety
-  net that survives a test timeout.
-- **Roles -> ids:** GKO reads `.status.id` of the role's CR (kind derived by convention:
-  `api`->apiv4definition, `application`->application, `subscription`->subscription; use the full
-  `{ kind, name }` form otherwise). Terraform reads `terraform output` (`api`->`api_id`,
-  `subscription`->`sub_id`, `application`->`app_id`; override via `outputs`). Paired TF fixtures MUST
-  expose `api_id`, `sub_id`, `api_context_path` (and `<role>_id` for extra roles).
+- **Handle surface:** `provisioned.apiId()` / `subscriptionId()` / `applicationId()` / `groupId()` return
+  the resource's APIM UUID (pass an optional label like `apiId("two-plans")` only when a scenario has
+  two of the same kind). Plus `provisioned.contextPath()`, `provisioned.update(params)` (rotation-style
+  re-provision), `provisioned.remove(role)`, `provisioned.destroy()`. Ids/contextPath are resolved once then
+  cached. The generator destroys the handle for you, with an `afterEach` safety net that survives a test
+  timeout.
+- **Adding a kind's getter / roles -> ids:** the getters live once in `BaseProvisioned` and delegate to
+  each provisioner's `resolveId(role)` (the "role" string stays internal). GKO reads `.status.id` of the
+  role's CR (kind by convention: `api`->apiv4definition, `application`->application,
+  `subscription`->subscription, `group`->group; use the full `{ kind, name }` role form otherwise).
+  Terraform reads `terraform output` (`api`->`api_id`, `subscription`->`sub_id`, `application`->`app_id`,
+  `group`->`group_id`; override via `outputs`). Gateway scenarios expose `api_context_path`.
 - **Parameterization** that differs structurally per provisioner (e.g. "set the api-keys") lives in a
   small co-located `params.ts` exposing one shared param type plus the per-provisioner apply closures
   (the GKO `applyParams` closure, the TF `toVars` closure). See
   `tests/scenarios/subscriptions/apikey/` for the reference pilot.
-- **Provisioner-specific assertions** (no shared-layer home) go in `provision.checks`, narrowed by a
+- **Provisioner-specific assertions** (no shared-layer home) go in `provisioned.checks`, narrowed by a
   per-provisioner type guard (`isGko(...)` / `isTerraform(...)`): GKO conditions/events/`.status`, TF
   drift/idempotency/redaction. Behaviour whose *assertion* (not just provisioning) is
   provisioner-specific stays in a plain `*-gko-only.test.ts` / `*-tf-only.test.ts` rather than the matrix.

--- a/test/platform-test/e2e/README.md
+++ b/test/platform-test/e2e/README.md
@@ -225,7 +225,7 @@ e2e/
   helpers/
     kubectl.ts           # kubectl CLI wrapper (shim over src/provisioners/engines/kubectl.ts)
     terraform.ts         # Terraform workspace lifecycle (adapter over src/provisioners/engines)
-    for-provisioners.ts  # forProvisioners(): one scenario -> one tagged test per provisioner
+    for-each-provisioner.ts  # forEachProvisioner(): one scenario -> one tagged test per provisioner
     provisioner-env.ts   # gkoScenario()/tfScenario(): build provisioners from fixture-relative specs
     tags.ts              # Xray test ID constants
   fixtures/              # one folder per domain; see "Fixture convention" below
@@ -239,7 +239,7 @@ e2e/
   tests/
     gko/                 # GKO-only operator tests
     terraform/           # Terraform-only provider tests
-    scenarios/           # *.scenario.ts: one shared intent run across every provisioner via forProvisioners
+    scenarios/           # *.scenario.ts: one shared intent run across every provisioner via forEachProvisioner
 ```
 
 ## Fixture convention

--- a/test/platform-test/e2e/helpers/for-each-provisioner.ts
+++ b/test/platform-test/e2e/helpers/for-each-provisioner.ts
@@ -15,9 +15,9 @@
  */
 
 /**
- * Playwright binding for the provisioner layer. `forProvisioners` expands ONE
+ * Playwright binding for the provisioner layer. `forEachProvisioner` expands ONE
  * scenario into ONE tagged test per provisioner. The body is
- * provisioner-agnostic: it gets a `provision` handle plus the shared mapi/gateway
+ * provisioner-agnostic: it gets a `provisioned` handle plus the shared mapi/gateway
  * fixtures and runs the SAME assertions regardless of how the resource was
  * created. Each test's provisioner tag (e.g. `@gko`/`@terraform`) and its
  * per-provisioner Xray id are appended to the title so `--grep` selection keeps
@@ -55,7 +55,7 @@ export interface ScenarioDef<P> {
 
 export interface ScenarioBodyArgs<P> {
   /** Live handle to the provisioned scenario for the current provisioner. */
-  provision: Provisioned<P>;
+  provisioned: Provisioned<P>;
   mapi: Mapi;
   gateway: Gateway;
 }
@@ -64,7 +64,7 @@ export type ScenarioBody<P> = (args: ScenarioBodyArgs<P>) => Promise<void>;
 
 interface ActiveProvision {
   provisioner: Provisioner<unknown>;
-  provision?: Provisioned<unknown>;
+  provisioned?: Provisioned<unknown>;
 }
 
 /**
@@ -82,8 +82,8 @@ async function teardownActive(): Promise<void> {
   if (!current) return;
   // destroy()/cleanup() are documented to never throw, but guard anyway so a
   // teardown failure never masks the test's own result.
-  if (current.provision) {
-    await current.provision.destroy().catch(() => {});
+  if (current.provisioned) {
+    await current.provisioned.destroy().catch(() => {});
   } else if (current.provisioner.cleanup) {
     await current.provisioner.cleanup().catch(() => {});
   }
@@ -106,10 +106,19 @@ function buildTitle<P>(scenario: ScenarioDef<P>, provisionerId: ProvisionerId): 
  *   never a silent skip, never red).
  * - A provisioner absent from both is N/A and emits nothing.
  */
-export function forProvisioners<P>(
+// Overloads: a param-free scenario omits initialParams; a parameterized one must
+// pass it (so `forEachProvisioner<ApiKeyParams>(s, body)` is a compile error, not
+// an `undefined` params crash at runtime).
+export function forEachProvisioner(scenario: ScenarioDef<void>, body: ScenarioBody<void>): void;
+export function forEachProvisioner<P>(
   scenario: ScenarioDef<P>,
   body: ScenarioBody<P>,
   initialParams: P,
+): void;
+export function forEachProvisioner<P>(
+  scenario: ScenarioDef<P>,
+  body: ScenarioBody<P>,
+  initialParams?: P,
 ): void {
   // Safety net, file-scoped (this runs during the scenario file's load).
   // Registered per call; redundant hooks are harmless no-ops once `active` is
@@ -139,9 +148,9 @@ export function forProvisioners<P>(
       const tracked: ActiveProvision = { provisioner };
       active = tracked;
       try {
-        const provision = (await provisioner.provision(initialParams)) as Provisioned<P>;
-        tracked.provision = provision;
-        await body({ provision, mapi, gateway });
+        const provisioned = (await provisioner.provision(initialParams)) as Provisioned<P>;
+        tracked.provisioned = provisioned;
+        await body({ provisioned, mapi, gateway });
       } finally {
         await teardownActive();
       }

--- a/test/platform-test/e2e/helpers/provisioner-env.ts
+++ b/test/platform-test/e2e/helpers/provisioner-env.ts
@@ -23,7 +23,7 @@
  * Scenario authors use `gkoScenario(...)` / `tfScenario(...)` with
  * fixture-RELATIVE paths; this module resolves them to the absolute paths /
  * env the provisioner constructors expect, and returns the `() => Provisioner`
- * factories that `forProvisioners` consumes.
+ * factories that `forEachProvisioner` consumes.
  */
 
 import { fixture as resolveFixture } from "../setup.js";

--- a/test/platform-test/e2e/helpers/tags.ts
+++ b/test/platform-test/e2e/helpers/tags.ts
@@ -596,7 +596,7 @@ export const TAGS = {
 
 /**
  * Provisioner-lane tags. The matrix arms get these automatically from
- * `forProvisioners`; single-provisioner (`*-gko-only` / `*-tf-only`) tests carry
+ * `forEachProvisioner`; single-provisioner (`*-gko-only` / `*-tf-only`) tests carry
  * them on their describe so `npm run e2e -- --provision-with <p>` selects them.
  * Lowercase on purpose, distinct from the uppercase `@GKO-` Xray prefix.
  */

--- a/test/platform-test/e2e/playwright.config.ts
+++ b/test/platform-test/e2e/playwright.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
   globalSetup: "./global-setup.ts",
   testDir: "./tests",
   // `*.test.ts` are plain test files; `*.scenario.ts` are provisioner-matrix
-  // files that expand into one test per provisioner via forProvisioners.
+  // files that expand into one test per provisioner via forEachProvisioner.
   testMatch: ["**/*.test.ts", "**/*.scenario.ts"],
   grep: provisioner ? new RegExp(String.raw`@${provisioner}\b`) : undefined,
   timeout: 30_000,

--- a/test/platform-test/e2e/tests/gko/groups/group-lifecycle.test.ts
+++ b/test/platform-test/e2e/tests/gko/groups/group-lifecycle.test.ts
@@ -50,24 +50,8 @@ test.describe("Groups — Lifecycle", () => {
 
   // ── GKO-983: Create Group with existing user ────────────────
 
-  test(`Create Group with existing user ${XRAY.GROUPS.CREATE_WITH_MEMBER} ${TAGS.REGRESSION}`, async ({
-    kubectl,
-  }) => {
-    const GROUP_NAME = "e2e-group-simple";
-    const fixturePath = fixture("groups/lifecycle/crd.yaml");
-
-    await test.step("Apply group CRD", async () => {
-      await kubectl.apply(fixturePath);
-      await kubectl.waitForCondition("group", GROUP_NAME, "Accepted");
-    });
-
-    await test.step("Group has an ID in status", async () => {
-      const status = await kubectl.getStatus<{ id: string }>("group", GROUP_NAME);
-      expect(status.id).toBeTruthy();
-    });
-
-    await kubectl.del(fixturePath);
-  });
+  // Moved to the gko arm of the shared tests/scenarios/groups/groups.scenario.ts
+  // (create group -> lands in APIM with origin KUBERNETES), tagged @GKO-983.
 
   // ── GKO-984: Create Group with non-existing user ────────────
 

--- a/test/platform-test/e2e/tests/scenarios/groups/groups.scenario.ts
+++ b/test/platform-test/e2e/tests/scenarios/groups/groups.scenario.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Group creation, shared across provisioners. A Group created through any
+ * provisioner must land in APIM via the Automation API (origin KUBERNETES).
+ *
+ * This is a deliberately small, param-free scenario: no params.ts, no closures,
+ * no gateway/contextPath. The provisioner-specific group behaviour (GKO member
+ * reconciliation / admission; Terraform drift, import, data source, validation)
+ * stays in the per-provisioner suites under tests/gko/groups and
+ * tests/terraform/groups.test.ts.
+ */
+
+import { XRAY, TAGS } from "../../../helpers/tags.js";
+import { forEachProvisioner } from "../../../helpers/for-each-provisioner.js";
+import { gkoScenario, tfScenario } from "../../../helpers/provisioner-env.js";
+
+forEachProvisioner(
+  {
+    title: "Group created through a provisioner lands in APIM",
+    provisioners: {
+      gko: gkoScenario<void>({
+        manifests: ["groups/lifecycle/crd.yaml"],
+        roles: { group: "e2e-group-simple" },
+      }),
+      terraform: tfScenario<void>({ fixture: "groups/lifecycle" }),
+    },
+    xray: { gko: XRAY.GROUPS.CREATE_WITH_MEMBER, terraform: XRAY.TERRAFORM.GROUP_CREATE },
+    tags: [TAGS.REGRESSION],
+  },
+  async ({ provisioned, mapi }) => {
+    // The shared invariant: both provisioners write the group through the
+    // Automation API, so APIM records it with origin KUBERNETES.
+    const groupId = await provisioned.groupId();
+    await mapi.waitForGroupMatchesById(groupId, { origin: "KUBERNETES" });
+  },
+);

--- a/test/platform-test/e2e/tests/scenarios/subscriptions/apikey/apikey-gko-only.test.ts
+++ b/test/platform-test/e2e/tests/scenarios/subscriptions/apikey/apikey-gko-only.test.ts
@@ -144,8 +144,8 @@ test.describe(`GKO-only: api-key admission, templating, idempotency ${PROVISIONE
     await kubectl.applyString(apiKeySecretYaml(secretName, secretValue));
     const h = await provisionTracked(fullGko(sub), { keys: [{ key: templateRef }] });
 
-    const apiId = await h.id("api");
-    const subId = await h.id("subscription");
+    const apiId = await h.apiId();
+    const subId = await h.subscriptionId();
 
     // The discriminator: APIM stores the RESOLVED secret value, not the literal
     // `[[ secret ... ]]`. A templating regression would leave the literal (or
@@ -171,8 +171,8 @@ test.describe(`GKO-only: api-key admission, templating, idempotency ${PROVISIONE
     const KEY = uniqueKey("idempotent-key");
     const h = await provisionTracked(fullGko("e2e-sub-apikey-idempotent"), { keys: [{ key: KEY }] });
 
-    const apiId = await h.id("api");
-    const subId = await h.id("subscription");
+    const apiId = await h.apiId();
+    const subId = await h.subscriptionId();
     const [active] = await mapi.waitForSubscriptionApiKeyCount(apiId, subId, 1);
     expect(active.key).toBe(KEY);
 

--- a/test/platform-test/e2e/tests/scenarios/subscriptions/apikey/apikey.scenario.ts
+++ b/test/platform-test/e2e/tests/scenarios/subscriptions/apikey/apikey.scenario.ts
@@ -17,7 +17,7 @@
 /**
  * V4 API-Key plan subscriptions, exercised through every supported provisioner
  * (currently GKO and Terraform) from a single shared intent. Each
- * `forProvisioners` block defines the platform behaviour once; the matrix runs
+ * `forEachProvisioner` block defines the platform behaviour once; the matrix runs
  * it against each provisioner, tags the arms (e.g. `@gko` / `@terraform`), and
  * carries the original per-provisioner Xray ids so coverage tracking is unchanged.
  *
@@ -29,7 +29,7 @@
 
 import { test, expect } from "../../../../setup.js";
 import { XRAY, TAGS } from "../../../../helpers/tags.js";
-import { forProvisioners } from "../../../../helpers/for-provisioners.js";
+import { forEachProvisioner } from "../../../../helpers/for-each-provisioner.js";
 import { gkoScenario, tfScenario } from "../../../../helpers/provisioner-env.js";
 import { subscriptionYaml } from "../../../../../src/provisioners/index.js";
 import {
@@ -61,7 +61,7 @@ function apikeyTfCustom(hridSuffix: string) {
   return tfScenario<ApiKeyParams>({
     fixture: "subscriptions/apikey-custom",
     toVars: tfApiKeyVars(hridSuffix),
-    // Lets provision.remove("subscription") drop the subscription from the
+    // Lets provisioned.remove("subscription") drop the subscription from the
     // desired state and re-apply (the count-gated resource in apikey-custom).
     removeVars: { subscription: { create_subscription: false } },
   });
@@ -72,7 +72,7 @@ const REGRESSION = [TAGS.REGRESSION];
 // ── Auto-generated single key, reachable via gateway ──────────────────────────
 // GKO splits this into a count check (2825) + a gateway check (2826); the TF
 // auto test (2879) does both. The shared body covers both, for every provisioner arm.
-forProvisioners<ApiKeyParams>(
+forEachProvisioner<ApiKeyParams>(
   {
     title: "Single api-key generated on api-key plan subscription, reachable via gateway",
     provisioners: {
@@ -86,10 +86,10 @@ forProvisioners<ApiKeyParams>(
     tags: REGRESSION,
     timeoutMs: { gko: 60_000 },
   },
-  async ({ provision, mapi, gateway }) => {
-    const apiId = await provision.id("api");
-    const subId = await provision.id("subscription");
-    const ctx = await provision.contextPath();
+  async ({ provisioned, mapi, gateway }) => {
+    const apiId = await provisioned.apiId();
+    const subId = await provisioned.subscriptionId();
+    const ctx = await provisioned.contextPath();
 
     // Exactly one active key, and no asynchronous second insert (APIM-13686).
     const [active] = await mapi.waitForSubscriptionApiKeyCount(apiId, subId, 1);
@@ -112,7 +112,7 @@ forProvisioners<ApiKeyParams>(
 // ── Custom api-key value honored end-to-end ───────────────────────────────────
 {
   const CUSTOM_KEY = uniqueKey("custom-apikey");
-  forProvisioners<ApiKeyParams>(
+  forEachProvisioner<ApiKeyParams>(
     {
       title: "Custom api-key value is honored end-to-end",
       provisioners: {
@@ -123,10 +123,10 @@ forProvisioners<ApiKeyParams>(
       tags: REGRESSION,
       timeoutMs: { gko: 60_000 },
     },
-    async ({ provision, mapi, gateway }) => {
-      const apiId = await provision.id("api");
-      const subId = await provision.id("subscription");
-      const ctx = await provision.contextPath();
+    async ({ provisioned, mapi, gateway }) => {
+      const apiId = await provisioned.apiId();
+      const subId = await provisioned.subscriptionId();
+      const ctx = await provisioned.contextPath();
 
       // The discriminator: APIM persists exactly the declared value.
       const [active] = await mapi.waitForSubscriptionApiKeyCount(apiId, subId, 1);
@@ -149,7 +149,7 @@ forProvisioners<ApiKeyParams>(
   const KEY = uniqueKey("expire-apikey");
   // 30 min keeps the test deterministic (admission rejects expireAt < 1 min).
   const expireAt = new Date(Date.now() + 30 * 60 * 1_000).toISOString();
-  forProvisioners<ApiKeyParams>(
+  forEachProvisioner<ApiKeyParams>(
     {
       title: "expireAt on a custom api-key is propagated to APIM",
       provisioners: {
@@ -160,9 +160,9 @@ forProvisioners<ApiKeyParams>(
       tags: REGRESSION,
       timeoutMs: { gko: 60_000 },
     },
-    async ({ provision, mapi }) => {
-      const apiId = await provision.id("api");
-      const subId = await provision.id("subscription");
+    async ({ provisioned, mapi }) => {
+      const apiId = await provisioned.apiId();
+      const subId = await provisioned.subscriptionId();
 
       const [active] = await mapi.waitForSubscriptionApiKeyCount(apiId, subId, 1);
       expect(active.key).toBe(KEY);
@@ -181,7 +181,7 @@ forProvisioners<ApiKeyParams>(
   const k32 = uniqueKey("bnd-32"); // padded to exactly 32 chars
   const prefix = `bnd-256-${RUN_ID}-`;
   const k256 = prefix + "y".repeat(256 - prefix.length);
-  forProvisioners<ApiKeyParams>(
+  forEachProvisioner<ApiKeyParams>(
     {
       title: "Api-keys at the 32 and 256 char boundaries are accepted",
       provisioners: {
@@ -192,9 +192,9 @@ forProvisioners<ApiKeyParams>(
       tags: REGRESSION,
       timeoutMs: { gko: 90_000 },
     },
-    async ({ provision, mapi }) => {
-      const apiId = await provision.id("api");
-      const subId = await provision.id("subscription");
+    async ({ provisioned, mapi }) => {
+      const apiId = await provisioned.apiId();
+      const subId = await provisioned.subscriptionId();
 
       await test.step("32-char key accepted (lower boundary)", async () => {
         expect(k32).toHaveLength(32);
@@ -204,7 +204,7 @@ forProvisioners<ApiKeyParams>(
 
       await test.step("256-char key accepted (upper boundary)", async () => {
         expect(k256).toHaveLength(256);
-        await provision.update({ keys: [{ key: k256 }] });
+        await provisioned.update({ keys: [{ key: k256 }] });
         await expect
           .poll(
             async () => {
@@ -224,7 +224,7 @@ forProvisioners<ApiKeyParams>(
 {
   const KEY_A = uniqueKey("rot-instant-A");
   const KEY_B = uniqueKey("rot-instant-B");
-  forProvisioners<ApiKeyParams>(
+  forEachProvisioner<ApiKeyParams>(
     {
       title: "Instant api-key rotation revokes old key and activates new key",
       provisioners: {
@@ -235,17 +235,17 @@ forProvisioners<ApiKeyParams>(
       tags: REGRESSION,
       timeoutMs: { gko: 150_000 },
     },
-    async ({ provision, mapi, gateway }) => {
-      const apiId = await provision.id("api");
-      const subId = await provision.id("subscription");
-      const ctx = await provision.contextPath();
+    async ({ provisioned, mapi, gateway }) => {
+      const apiId = await provisioned.apiId();
+      const subId = await provisioned.subscriptionId();
+      const ctx = await provisioned.contextPath();
 
       const [active] = await mapi.waitForSubscriptionApiKeyCount(apiId, subId, 1);
       expect(active.key).toBe(KEY_A);
       await gateway.assertResponds(ctx, { status: 200, headers: { "X-Gravitee-Api-Key": KEY_A } });
 
       await test.step("Replace KEY_A with KEY_B", async () => {
-        await provision.update({ keys: [{ key: KEY_B }] });
+        await provisioned.update({ keys: [{ key: KEY_B }] });
         await expect
           .poll(
             async () => {
@@ -273,7 +273,7 @@ forProvisioners<ApiKeyParams>(
 {
   const KEY_A = uniqueKey("rot-gradual-A");
   const KEY_B = uniqueKey("rot-gradual-B");
-  forProvisioners<ApiKeyParams>(
+  forEachProvisioner<ApiKeyParams>(
     {
       title: "Gradual api-key rotation supports two active keys then deprecates the old",
       provisioners: {
@@ -284,21 +284,21 @@ forProvisioners<ApiKeyParams>(
       tags: REGRESSION,
       timeoutMs: { gko: 180_000 },
     },
-    async ({ provision, mapi, gateway }) => {
-      const apiId = await provision.id("api");
-      const subId = await provision.id("subscription");
-      const ctx = await provision.contextPath();
+    async ({ provisioned, mapi, gateway }) => {
+      const apiId = await provisioned.apiId();
+      const subId = await provisioned.subscriptionId();
+      const ctx = await provisioned.contextPath();
       await mapi.waitForSubscriptionApiKeyCount(apiId, subId, 1);
 
       await test.step("Add KEY_B alongside KEY_A; both active", async () => {
-        await provision.update({ keys: [{ key: KEY_A }, { key: KEY_B }] });
+        await provisioned.update({ keys: [{ key: KEY_A }, { key: KEY_B }] });
         await mapi.waitForSubscriptionApiKeyCount(apiId, subId, 2, { timeoutMs: 30_000 });
         await gateway.assertResponds(ctx, { status: 200, headers: { "X-Gravitee-Api-Key": KEY_A } });
         await gateway.assertResponds(ctx, { status: 200, headers: { "X-Gravitee-Api-Key": KEY_B } });
       });
 
       await test.step("Remove KEY_A; APIM revokes it and keeps KEY_B active", async () => {
-        await provision.update({ keys: [{ key: KEY_B }] });
+        await provisioned.update({ keys: [{ key: KEY_B }] });
         await expect
           .poll(
             async () => {
@@ -323,7 +323,7 @@ forProvisioners<ApiKeyParams>(
 {
   const KEY_A = uniqueKey("reactivation-A");
   const KEY_B = uniqueKey("reactivation-B");
-  forProvisioners<ApiKeyParams>(
+  forEachProvisioner<ApiKeyParams>(
     {
       title: "Previously revoked api-key is reactivated when re-added to spec",
       provisioners: {
@@ -334,14 +334,14 @@ forProvisioners<ApiKeyParams>(
       tags: REGRESSION,
       timeoutMs: { gko: 180_000 },
     },
-    async ({ provision, mapi, gateway }) => {
-      const apiId = await provision.id("api");
-      const subId = await provision.id("subscription");
-      const ctx = await provision.contextPath();
+    async ({ provisioned, mapi, gateway }) => {
+      const apiId = await provisioned.apiId();
+      const subId = await provisioned.subscriptionId();
+      const ctx = await provisioned.contextPath();
       await mapi.waitForSubscriptionApiKeyCount(apiId, subId, 1);
 
       await test.step("Replace KEY_A with KEY_B; KEY_A becomes revoked", async () => {
-        await provision.update({ keys: [{ key: KEY_B }] });
+        await provisioned.update({ keys: [{ key: KEY_B }] });
         await expect
           .poll(
             async () => {
@@ -357,7 +357,7 @@ forProvisioners<ApiKeyParams>(
       });
 
       await test.step("Re-add KEY_A alongside KEY_B; KEY_A is reactivated", async () => {
-        await provision.update({ keys: [{ key: KEY_A }, { key: KEY_B }] });
+        await provisioned.update({ keys: [{ key: KEY_A }, { key: KEY_B }] });
         await expect
           .poll(
             async () => {
@@ -384,7 +384,7 @@ forProvisioners<ApiKeyParams>(
   const KEY_V3 = uniqueKey("stagger-v3");
   const expireV1 = new Date(Date.now() + 30 * 60 * 1_000).toISOString();
   const expireV2 = new Date(Date.now() + 90 * 60 * 1_000).toISOString();
-  forProvisioners<ApiKeyParams>(
+  forEachProvisioner<ApiKeyParams>(
     {
       title: "Multi-key subscription with staggered expirations supports zero-downtime rotation",
       provisioners: {
@@ -395,10 +395,10 @@ forProvisioners<ApiKeyParams>(
       tags: REGRESSION,
       timeoutMs: { gko: 180_000 },
     },
-    async ({ provision, mapi, gateway }) => {
-      const apiId = await provision.id("api");
-      const subId = await provision.id("subscription");
-      const ctx = await provision.contextPath();
+    async ({ provisioned, mapi, gateway }) => {
+      const apiId = await provisioned.apiId();
+      const subId = await provisioned.subscriptionId();
+      const ctx = await provisioned.contextPath();
       await mapi.waitForSubscriptionApiKeyCount(apiId, subId, 3, { timeoutMs: 30_000 });
 
       await test.step("APIM stores each key with the correct expireAt (or none)", async () => {
@@ -423,7 +423,7 @@ forProvisioners<ApiKeyParams>(
       });
 
       await test.step("Drop KEY_V1; APIM revokes it while v2 and v3 stay active", async () => {
-        await provision.update({ keys: [{ key: KEY_V2, expireAt: expireV2 }, { key: KEY_V3 }] });
+        await provisioned.update({ keys: [{ key: KEY_V2, expireAt: expireV2 }, { key: KEY_V3 }] });
         await expect
           .poll(
             async () => {
@@ -449,7 +449,7 @@ forProvisioners<ApiKeyParams>(
 // ── Mixed: api-key plan coexists with a keyless plan on the same API ──────────
 {
   const CUSTOM_KEY = uniqueKey("mixed-apikey");
-  forProvisioners<ApiKeyParams>(
+  forEachProvisioner<ApiKeyParams>(
     {
       title: "Api-key plan coexists with keyless plan on the same API",
       provisioners: {
@@ -483,10 +483,10 @@ forProvisioners<ApiKeyParams>(
       tags: REGRESSION,
       timeoutMs: { gko: 90_000 },
     },
-    async ({ provision, mapi, gateway }) => {
-      const apiId = await provision.id("api");
-      const subId = await provision.id("subscription");
-      const ctx = await provision.contextPath();
+    async ({ provisioned, mapi, gateway }) => {
+      const apiId = await provisioned.apiId();
+      const subId = await provisioned.subscriptionId();
+      const ctx = await provisioned.contextPath();
       const [active] = await mapi.waitForSubscriptionApiKeyCount(apiId, subId, 1);
       expect(active.key).toBe(CUSTOM_KEY);
 
@@ -516,7 +516,7 @@ forProvisioners<ApiKeyParams>(
 // endpoint vanished.
 {
   const CUSTOM_KEY = uniqueKey("revoke-apikey");
-  forProvisioners<ApiKeyParams>(
+  forEachProvisioner<ApiKeyParams>(
     {
       title: "Removing the subscription revokes its api-key while the API stays up",
       provisioners: {
@@ -527,15 +527,15 @@ forProvisioners<ApiKeyParams>(
       tags: REGRESSION,
       timeoutMs: { gko: 90_000 },
     },
-    async ({ provision, mapi, gateway }) => {
-      const apiId = await provision.id("api");
-      const subId = await provision.id("subscription");
-      const ctx = await provision.contextPath();
+    async ({ provisioned, mapi, gateway }) => {
+      const apiId = await provisioned.apiId();
+      const subId = await provisioned.subscriptionId();
+      const ctx = await provisioned.contextPath();
       await mapi.waitForSubscriptionApiKeyCount(apiId, subId, 1);
       await gateway.assertResponds(ctx, { status: 200, headers: { "X-Gravitee-Api-Key": CUSTOM_KEY } });
 
       await test.step("Remove only the subscription; the key stops working, the API stays up", async () => {
-        await provision.remove("subscription");
+        await provisioned.remove("subscription");
         await gateway.assertNotResponds(ctx, { notStatus: 200, headers: { "X-Gravitee-Api-Key": CUSTOM_KEY } });
       });
     },

--- a/test/platform-test/e2e/tests/terraform/groups.test.ts
+++ b/test/platform-test/e2e/tests/terraform/groups.test.ts
@@ -63,16 +63,8 @@ test.describe("Terraform — Groups · Resource lifecycle", () => {
     if (ws) await terraform.destroyWorkspace(ws);
   });
 
-  test(`terraform apply creates the group in APIM ${XRAY.TERRAFORM.GROUP_CREATE} ${TAGS.REGRESSION}`, async ({
-    mapi,
-  }) => {
-    // The provider writes through the Automation API, so the group lands with
-    // origin KUBERNETES — the discriminator that it was not console-created.
-    await mapi.waitForGroupMatches(groupHrid, {
-      name: "e2e-tf-group",
-      origin: "KUBERNETES",
-    });
-  });
+  // Moved to the terraform arm of the shared tests/scenarios/groups/groups.scenario.ts
+  // (create group -> lands in APIM with origin KUBERNETES), tagged @GKO-2865.
 
   test(`notify_members is propagated to APIM ${XRAY.TERRAFORM.GROUP_NOTIFY_MEMBERS} ${TAGS.REGRESSION}`, async ({
     mapi,

--- a/test/platform-test/src/assertions/apim/mapi.ts
+++ b/test/platform-test/src/assertions/apim/mapi.ts
@@ -415,6 +415,35 @@ export class Mapi {
     );
   }
 
+  /** Fetch a single group directly by its APIM id (UUID). @throws if not found. */
+  async fetchGroupById(id: string): Promise<Group> {
+    const path = this.http.managementV1Path(`/configuration/groups/${id}`);
+    const res = await this.http.get<Group>(path);
+    if (res.status !== 200) {
+      throw new Error(
+        `Failed to fetch group ${id}: ${res.status} ${res.statusText} - ${JSON.stringify(res.body)}`,
+      );
+    }
+    return res.body;
+  }
+
+  /** Fetch a group by APIM id and assert it partially matches the expected shape. */
+  async assertGroupMatchesById(id: string, expected: DeepPartial<Group>): Promise<void> {
+    const group = await this.fetchGroupById(id);
+    throwIfFailed(deepPartialMatch(group, expected));
+  }
+
+  async waitForGroupMatchesById(
+    id: string,
+    expected: DeepPartial<Group>,
+    options: PollOptions = {},
+  ): Promise<void> {
+    await poll(
+      () => this.assertGroupMatchesById(id, expected),
+      { description: `group ${id} matches expected shape`, ...options },
+    );
+  }
+
   /** List the resolved members of a group (v1 management API). */
   async fetchGroupMembers(groupId: string): Promise<GroupMember[]> {
     const path = this.http.managementV1Path(`/configuration/groups/${groupId}/members`);

--- a/test/platform-test/src/index.ts
+++ b/test/platform-test/src/index.ts
@@ -47,11 +47,10 @@ export { HttpClient, createTlsFetch } from "./utils/http/index.js";
 // ── Config / CLI helpers ──────────────────────────────────────
 export { loadGraviteeConfig, createMapiFromConfig, applyEnvVars } from "./cmd/config.js";
 
-// ── Provisioners (GKO-2915) ───────────────────────────────────
+// ── Provisioners ──────────────────────────────────────────────
 export type {
   ProvisionerId,
   Role,
-  ResourceRef,
   Provisioned,
   Provisioner,
   ProvisionerChecks,

--- a/test/platform-test/src/provisioners/base.ts
+++ b/test/platform-test/src/provisioners/base.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Provisioned, ProvisionerChecks, ProvisionerId, Role } from "./types.js";
+
+/** Build the internal role string from a kind + optional disambiguating label. */
+function roleFor(kind: string, label?: string): Role {
+  return (label ? `${kind}:${label}` : kind) as Role;
+}
+
+/**
+ * Shared base for the concrete provisioned handles. It defines the plain id
+ * getters (`apiId()`, `subscriptionId()`, ...) ONCE, each delegating to a single
+ * `resolveId(role)` that GKO/Terraform implement. A test author calls
+ * `provision.apiId()`; the "role" string stays an internal detail. Add a new
+ * kind's getter here in one line.
+ */
+export abstract class BaseProvisioned<P = unknown> implements Provisioned<P> {
+  abstract readonly provisionerId: ProvisionerId;
+  abstract readonly checks: ProvisionerChecks;
+
+  /** Resolve a logical role to its APIM id (UUID). Resolved once, then cached. */
+  protected abstract resolveId(role: Role): Promise<string>;
+
+  abstract contextPath(): Promise<string>;
+  abstract update(params: P): Promise<void>;
+  abstract remove(role: Role): Promise<void>;
+  abstract destroy(): Promise<void>;
+
+  apiId(label?: string): Promise<string> {
+    return this.resolveId(roleFor("api", label));
+  }
+  subscriptionId(label?: string): Promise<string> {
+    return this.resolveId(roleFor("subscription", label));
+  }
+  applicationId(label?: string): Promise<string> {
+    return this.resolveId(roleFor("application", label));
+  }
+  groupId(label?: string): Promise<string> {
+    return this.resolveId(roleFor("group", label));
+  }
+}

--- a/test/platform-test/src/provisioners/gko/gko-provisioner.ts
+++ b/test/platform-test/src/provisioners/gko/gko-provisioner.ts
@@ -15,7 +15,8 @@
  */
 
 import * as kubectl from "../engines/kubectl.js";
-import type { Provisioned, Provisioner, ResourceRef, Role } from "../types.js";
+import type { Provisioned, Provisioner, Role } from "../types.js";
+import { BaseProvisioned } from "../base.js";
 import type { GkoChecks } from "./checks.js";
 
 /** The kubectl engine surface a parameterized apply step receives. */
@@ -36,6 +37,7 @@ const DEFAULT_KIND_BY_ROLE: Record<string, string> = {
   api: "apiv4definition",
   application: "application",
   subscription: "subscription",
+  group: "group",
 };
 
 /**
@@ -55,8 +57,8 @@ export interface GkoScenarioSpec<P = unknown> {
    * awaited right after the static manifests.
    */
   dynamicRoles?: Role[];
-  /** Gateway context path (GKO has no output to read it from). */
-  contextPath: string;
+  /** Gateway context path (GKO has no output to read it from). Omit when the scenario never hits the gateway. */
+  contextPath?: string;
   /**
    * Optional parameterized apply (e.g. a Subscription with a given key set).
    * Runs at provision() after the static manifests, and again on every update().
@@ -70,7 +72,7 @@ interface ResolvedGkoSpec<P> {
   manifests: string[];
   roles: Record<string, GkoRoleBinding>;
   dynamicRoles: Role[];
-  contextPath: string;
+  contextPath?: string;
   applyParams?: (k: KubectlEngine, params: P) => Promise<void>;
   namespace?: string;
 }
@@ -140,16 +142,17 @@ async function teardownGko<P>(spec: ResolvedGkoSpec<P>): Promise<void> {
   }
 }
 
-class GkoProvisioned<P> implements Provisioned<P> {
+class GkoProvisioned<P> extends BaseProvisioned<P> {
   readonly provisionerId = "gko" as const;
   readonly checks: GkoChecks;
   private readonly idCache = new Map<string, string>();
 
   constructor(private readonly spec: ResolvedGkoSpec<P>) {
+    super();
     this.checks = buildGkoChecks(spec);
   }
 
-  async id(role: Role = "api"): Promise<string> {
+  protected async resolveId(role: Role): Promise<string> {
     const cached = this.idCache.get(role);
     if (cached) return cached;
     const b = resolveBinding(this.spec, role);
@@ -161,18 +164,10 @@ class GkoProvisioned<P> implements Provisioned<P> {
     return status.id;
   }
 
-  async ref(role: Role = "api"): Promise<ResourceRef> {
-    const b = resolveBinding(this.spec, role);
-    const id = await this.id(role);
-    return {
-      id,
-      name: b.name,
-      kind: b.kind,
-      hrid: `${this.spec.namespace ?? "default"}-${b.name}`,
-    };
-  }
-
   async contextPath(): Promise<string> {
+    if (this.spec.contextPath === undefined) {
+      throw new Error("GKO scenario has no contextPath; declare it to use gateway assertions");
+    }
     return this.spec.contextPath;
   }
 

--- a/test/platform-test/src/provisioners/index.ts
+++ b/test/platform-test/src/provisioners/index.ts
@@ -20,7 +20,6 @@
 export type {
   ProvisionerId,
   Role,
-  ResourceRef,
   Provisioned,
   Provisioner,
   ProvisionerChecks,

--- a/test/platform-test/src/provisioners/terraform/terraform-provisioner.ts
+++ b/test/platform-test/src/provisioners/terraform/terraform-provisioner.ts
@@ -16,7 +16,8 @@
 
 import * as tfCore from "../engines/terraform-core.js";
 import type { TfWorkspace } from "../engines/terraform-core.js";
-import type { Provisioned, Provisioner, ResourceRef, Role } from "../types.js";
+import type { Provisioned, Provisioner, Role } from "../types.js";
+import { BaseProvisioned } from "../base.js";
 import type { TerraformChecks } from "./checks.js";
 
 /** Convention mapping a role to a default `terraform output` name. */
@@ -24,6 +25,7 @@ const DEFAULT_OUTPUT_BY_ROLE: Record<string, string> = {
   api: "api_id",
   subscription: "sub_id",
   application: "app_id",
+  group: "group_id",
 };
 const DEFAULT_CONTEXT_PATH_OUTPUT = "api_context_path";
 
@@ -85,7 +87,7 @@ function buildTerraformChecks(ws: TfWorkspace): TerraformChecks {
   };
 }
 
-class TerraformProvisioned<P> implements Provisioned<P> {
+class TerraformProvisioned<P> extends BaseProvisioned<P> {
   readonly provisionerId = "terraform" as const;
   readonly checks: TerraformChecks;
   private readonly idCache = new Map<string, string>();
@@ -96,19 +98,16 @@ class TerraformProvisioned<P> implements Provisioned<P> {
     private readonly spec: TfScenarioSpec<P>,
     private lastVars: Record<string, unknown>,
   ) {
+    super();
     this.checks = buildTerraformChecks(ws);
   }
 
-  async id(role: Role = "api"): Promise<string> {
+  protected async resolveId(role: Role): Promise<string> {
     const cached = this.idCache.get(role);
     if (cached) return cached;
     const value = await tfCore.output(this.ws, outputNameFor(this.spec, role));
     this.idCache.set(role, value);
     return value;
-  }
-
-  async ref(role: Role = "api"): Promise<ResourceRef> {
-    return { id: await this.id(role) };
   }
 
   async contextPath(): Promise<string> {

--- a/test/platform-test/src/provisioners/types.ts
+++ b/test/platform-test/src/provisioners/types.ts
@@ -34,22 +34,6 @@ export type ProvisionerId = "gko" | "terraform";
  */
 export type Role = "api" | "application" | "subscription" | "plan" | (string & {});
 
-/** A resolved reference to a provisioned APIM resource. */
-export interface ResourceRef {
-  /** APIM id (UUID). GKO reads `.status.id`; Terraform reads `terraform output`. */
-  id: string;
-  /** Human-readable name where known (CR metadata.name, or TF resource name). */
-  name?: string;
-  /**
-   * Stable cross-lifecycle identifier (k8s namespace+name, or TF hrid). Drives
-   * upgrade-style re-attachment: APIM derives a deterministic UUIDv3 from the
-   * HRID, so a handle can be rebuilt from this alone. See {@link Provisioner.attach}.
-   */
-  hrid?: string;
-  /** The provisioner-native kind, e.g. "ApiV4Definition" | "apim_apiv4". Diagnostic. */
-  kind?: string;
-}
-
 /**
  * Provisioner-specific assertion surface, reached via {@link Provisioned.checks}
  * and narrowed by the `isGko`/`isTerraform` type guards. The base only carries
@@ -67,11 +51,15 @@ export interface Provisioned<P = unknown> {
   /** Which provisioner produced this handle. */
   readonly provisionerId: ProvisionerId;
 
-  /** APIM id for a logical role (default "api"). Resolved once, then cached. */
-  id(role?: Role): Promise<string>;
-
-  /** Full ref for a role (id + name/hrid/kind where available). */
-  ref(role?: Role): Promise<ResourceRef>;
+  /**
+   * The resource's APIM id (UUID), by kind. Pass an optional `label` only for
+   * the rare scenario that has two of the same kind (e.g. `apiId("two-plans")`);
+   * omit it for the usual single-resource case. Resolved once, then cached.
+   */
+  apiId(label?: string): Promise<string>;
+  subscriptionId(label?: string): Promise<string>;
+  applicationId(label?: string): Promise<string>;
+  groupId(label?: string): Promise<string>;
 
   /** The API gateway context path (e.g. "/e2e-...") for data-plane assertions. */
   contextPath(): Promise<string>;


### PR DESCRIPTION
### Mainly 2 things
* improved readability for provisioner layer 
* a second shared test (shared meaning one test for 2 provisioner: GKO & TF)


### Further details
- **Plain id accessors.** `provision.id("api")` becomes `provision.apiId()` (and `subscriptionId()` / `applicationId()` / `groupId()`), with an optional label for the rare two-of-a-kind case (`apiId("two-plans")`). The getters live once in `BaseProvisioned`, each delegating to the provisioner's `resolveId(role)` - the "role" string stays internal. Dropped the unused `ref()` / `ResourceRef`, and made `contextPath` optional so a non-gateway scenario stays short.
- **`forProvisioners` -> `forEachProvisioner`** (clearer, matches `test.each`), with the params type defaulting to `void` and the initial-params argument optional - so a param-free scenario drops the `<void>` and trailing `undefined`.
- **Groups matrixed.** "Create a group -> lands in APIM with origin KUBERNETES" now runs through one shared, **param-free** `groups.scenario.ts` across both provisioners (doubles as the "this is how short a normal scenario is" example). Added a group-by-id mapi assertion (`waitForGroupMatchesById`) so the body uses `provision.groupId()` uniformly, keeping HRID out of scope. The two redundant per-provisioner create tests are removed; their `@GKO-983` / `@GKO-2865` ids now ride the shared arms. Provisioner-specific group behaviour (members, drift, import, validation) stays per-provisioner.
