### PR TITLE
test(platform-test): foundation for e2e upgrade testing (version gating + before/after flow)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -457,7 +457,7 @@ jobs:
       - run:
           name: Install gck
           command: |
-            go install github.com/gravitee-io-labs/gck@v1.0.2
+            go install github.com/gravitee-io-labs/gck@v1.1.1
             echo 'export PATH="$HOME/go/bin:$PATH"' >> "$BASH_ENV"
       - run:
           name: Start cluster
@@ -556,6 +556,71 @@ jobs:
       - store_artifacts:
           path: /tmp/xray-test-execution.txt
           destination: xray-test-execution.txt
+
+  job-e2e-upgrade-tests:
+    machine:
+      image: ubuntu-2204:2024.01.2
+      docker_layer_caching: true
+    resource_class: large
+    steps:
+      - checkout
+      - go/install:
+          version: "<< pipeline.parameters.go-version >>"
+      - kubernetes/install_kubectl:
+          kubectl_version: "<< pipeline.parameters.kubernetes-version >>"
+      - helm/install_helm_client:
+          version: "<< pipeline.parameters.helm-version >>"
+      - run:
+          name: Install kind
+          command: |
+            curl -Lo /tmp/kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
+            chmod +x /tmp/kind
+            sudo mv /tmp/kind /usr/local/bin/
+      - gravitee/docker-login:
+          registry: graviteeio.azurecr.io
+          username: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
+          password: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
+      - run:
+          name: Install gck
+          command: |
+            go install github.com/gravitee-io-labs/gck@v1.1.1
+            echo 'export PATH="$HOME/go/bin:$PATH"' >> "$BASH_ENV"
+      - run:
+          name: Build platform-test CLI
+          command: npm --prefix test/platform-test install && npm --prefix test/platform-test run build
+      # Before/after-upgrade e2e: stand up APIM on the OLD line, run the suite "up to
+      # OLD", upgrade APIM in place with `gck patch` (which, since gck v1.1.1, inherits
+      # the create-time --disable-es/--disable-portal/imagePrefix/from), then run "up
+      # to NEW". GKO lane only. Bump the version pair per release.
+      #
+      # The operator is built from source and installed from the branch helm/gko chart
+      # (chart + CRDs + local image), reusing the same manual install as job-e2e-tests
+      # for consistency. That is why the kubectl/helm/kind installs above stay (the
+      # suite also shells kubectl on PATH).
+      - run:
+          name: Run before/after-upgrade e2e (GKO lane, 4.11 -> 4.12)
+          command: |
+            set -e
+            gck create --config test/platform-test/gck.yaml --disable-es --disable-portal \
+              --set imagePrefix=graviteeio.azurecr.io --set imageTag=4.11.x-latest \
+              --set 'helmVersion=>=4.11.0-0 <4.12.0-0'
+            IMG=gko TAG=latest make docker-build \
+              && kind load docker-image gko:latest --name gravitee \
+              && helm upgrade --install gko helm/gko -n default \
+                --set manager.image.repository=gko --set manager.image.tag=latest
+            kubectl rollout status deployment/gko-controller-manager -n default --timeout=120s
+            npm --prefix test/platform-test run e2e -- --provision-with gko --run-up-to-version 4.11
+            gck patch --config test/platform-test/gck.yaml --name gravitee \
+              --set imageTag=master-latest --set 'helmVersion=>=4.12.0-0 <4.13.0-0'
+            npm --prefix test/platform-test run e2e -- --provision-with gko --run-up-to-version 4.12
+      - store_test_results:
+          path: test/platform-test/playwright-results
+      - store_artifacts:
+          path: test/platform-test/playwright-results
+          destination: playwright-results
+      - store_artifacts:
+          path: test/platform-test/playwright-report
+          destination: playwright-report
 
   job-stage-helm-chart:
     docker:
@@ -1120,6 +1185,19 @@ workflows:
                   channel: C098YUEDMGE
                   event: pass
                   template: basic_success_1
+                  branch_pattern: ".+"
+      - job-e2e-upgrade-tests:
+          name: Run upgrade end to end tests
+          context: cicd-orchestrator
+          filters:
+            branches:
+              only:
+                - master
+          post-steps:
+              - slack/notify:
+                  channel: C098YUEDMGE
+                  event: fail
+                  template: basic_fail_1
                   branch_pattern: ".+"
       - job-install-go-tools:
           name: Install GO tools (master)

--- a/test/platform-test/AGENTS.md
+++ b/test/platform-test/AGENTS.md
@@ -104,14 +104,17 @@ shared assertions. The shared body uses only the provisioner-agnostic handle (`p
 and the per-provisioner Xray id.
 
 **Selecting a provisioner lane:** `npm run e2e -- --provision-with gko` (or the `npm run e2e:gko` /
-`e2e:terraform` shortcuts) runs only that provisioner's tests — the matrix arms plus the
-`*-gko-only` / `*-tf-only` files, which carry the tag on their `describe`. Do **not** use
-`--grep @gko`: Playwright's CLI `--grep` is case-insensitive, so `@gko` also matches every `@GKO-NNNN`
-Xray tag and selects the whole suite. The lane filter is a case-sensitive grep applied in
-`playwright.config.ts` from the `E2E_PROVISIONER` env var (which `--provision-with` sets); `--grep
-@GKO-NNNN` still works for selecting a single test. The `scripts/e2e.mjs` wrapper also accepts
-`--run-up-to-version <semver>` as a reserved seam for future version-gating (accepted but not yet
-enforced).
+`e2e:terraform` shortcuts) runs that provisioner's whole lane: every test under `tests/gko/` (or
+`tests/terraform/`) PLUS the matching arm of each shared `tests/scenarios/` file. The config
+implements this from the `E2E_PROVISIONER` env var by ignoring the OTHER provisioner's `tests/` folder
+(`testIgnore`) and dropping its arm from shared scenarios with a case-sensitive `grepInvert`. Do
+**not** use `--grep @gko`: Playwright's CLI `--grep` is case-insensitive, so `@gko` also matches every
+`@GKO-NNNN` Xray tag and selects the whole suite; `--grep @GKO-NNNN` still works for a single test.
+
+**Capping at a version:** `scripts/e2e.mjs` also accepts `--run-up-to-version <semver>`, which skips
+tests tagged `@since-<newer>` (declare with `since("4.12")` from `e2e/helpers/tags.ts`; untagged tests
+are baseline and always run). Enforced by an automatic fixture in `e2e/setup.ts`. The two flags
+combine, e.g. `--provision-with gko --run-up-to-version 4.11`.
 
 ```ts
 import { forEachProvisioner } from "../../../../helpers/for-each-provisioner.js";

--- a/test/platform-test/e2e/README.md
+++ b/test/platform-test/e2e/README.md
@@ -48,7 +48,7 @@ Elasticsearch and portal disabled).
 Install gck (same version CI pins in `.circleci/config.yml`):
 
 ```bash
-go install github.com/gravitee-io-labs/gck@v1.0.2
+go install github.com/gravitee-io-labs/gck@v1.1.1
 ```
 
 Mirrors what CI runs in `.circleci/config.yml` (`job-e2e-tests`):
@@ -143,8 +143,9 @@ npm run e2e -- --grep @GKO-110
 
 ### Run one provisioner lane
 
-`npm run e2e` runs every provisioner. To run only one (the matrix arms for that
-provisioner plus its `*-gko-only` / `*-tf-only` tests):
+`npm run e2e` runs every provisioner. To run only one lane (all tests under
+`tests/<provisioner>/` plus the matching arm of every shared scenario in
+`tests/scenarios/`):
 
 ```bash
 npm run e2e -- --provision-with gko          # GKO only
@@ -156,15 +157,56 @@ npm run e2e:terraform                        # shortcut for --provision-with ter
 The flags are parsed by [`scripts/e2e.mjs`](../scripts/e2e.mjs), which sets
 `E2E_PROVISIONER` and forwards everything else (e.g. `--grep`, `--headed`) to
 Playwright. The env var works directly too, which is what the CI matrix uses:
-`E2E_PROVISIONER=gko npm run e2e`.
+`E2E_PROVISIONER=gko npm run e2e`. Under the hood the config ignores the other
+provisioner's `tests/` folder and drops its arm from shared scenarios via a
+case-sensitive `grepInvert`.
 
 > Do **not** select a lane with `--grep @gko`: Playwright's CLI `--grep` is
 > case-insensitive, so `@gko` also matches every `@GKO-NNNN` Xray tag and runs
-> the whole suite. `--grep @GKO-NNNN` for a single test is fine.
+> the whole suite. Use `--provision-with`. `--grep @GKO-NNNN` for a single test is fine.
 
-`scripts/e2e.mjs` also accepts `--run-up-to-version <semver>` as a reserved seam
-for future version-gating; today it is accepted but not enforced (it prints a
-notice and runs the full selection).
+### Run up to an APIM version
+
+`scripts/e2e.mjs` also accepts `--run-up-to-version <semver>` to cap a run at an
+APIM version. Tests tagged `@since-<newer>` (via `since()` in
+[`helpers/tags.ts`](helpers/tags.ts)) are skipped; untagged tests are baseline and
+always run. Enforced by an auto fixture in [`setup.ts`](setup.ts). Combine it with
+a lane:
+
+```bash
+npm run e2e -- --provision-with gko --run-up-to-version 4.11   # GKO suite, up to 4.11
+npm run e2e -- --run-up-to-version 4.12                        # whole suite, up to 4.12
+```
+
+### Upgrade testing (before / after an APIM upgrade)
+
+The upgrade flow is a short sequence of `gck` + `e2e` commands (it runs in the
+post-merge CI job `job-e2e-upgrade-tests`; reproduce it locally with the same steps,
+run from the repo root). It stands up APIM on the OLD line, runs the suite "up to OLD",
+upgrades APIM in place with `gck patch`, then runs "up to NEW". Since gck v1.1.1,
+`gck patch` inherits the create-time `--disable-es` / `imagePrefix` / `from`, so the
+upgrade only passes the version deltas:
+
+```bash
+# Stand up APIM 4.11 + the branch operator.
+gck create --config test/platform-test/gck.yaml --disable-es --disable-portal \
+  --set imagePrefix=graviteeio.azurecr.io --set imageTag=4.11.x-latest \
+  --set 'helmVersion=>=4.11.0-0 <4.12.0-0'
+IMG=gko TAG=latest make docker-build && kind load docker-image gko:latest --name gravitee
+helm upgrade --install gko helm/gko -n default \
+  --set manager.image.repository=gko --set manager.image.tag=latest
+
+# Baseline on 4.11.
+npm --prefix test/platform-test run e2e -- --provision-with gko --run-up-to-version 4.11
+
+# Upgrade APIM to 4.12 in place (Mongo preserved), then regress on 4.12.
+gck patch --config test/platform-test/gck.yaml --name gravitee \
+  --set imageTag=master-latest --set 'helmVersion=>=4.12.0-0 <4.13.0-0'
+npm --prefix test/platform-test run e2e -- --provision-with gko --run-up-to-version 4.12
+```
+
+For a different pair (e.g. 4.12 -> 4.13), change the `imageTag` / `helmVersion` values
+on the `create` and `patch` lines and the `--run-up-to-version` arguments.
 
 ### CI: run the lanes in parallel
 

--- a/test/platform-test/e2e/helpers/for-each-provisioner.ts
+++ b/test/platform-test/e2e/helpers/for-each-provisioner.ts
@@ -51,6 +51,14 @@ export interface ScenarioDef<P> {
   pending?: Partial<Record<ProvisionerId, string>>;
   /** Per-provisioner Playwright timeout override (ms). */
   timeoutMs?: Partial<Record<ProvisionerId, number>>;
+  /**
+   * Per-provisioner minimum APIM version (the version a feature shipped in). The
+   * arm's title gets `@since-<v>`, so `--run-up-to-version` skips it on older
+   * clusters. Per-provisioner on purpose: a feature can land in each driver at a
+   * different version (e.g. the Terraform `apim_group` resource is newer than the
+   * GKO Group CRD).
+   */
+  since?: Partial<Record<ProvisionerId, string>>;
 }
 
 export interface ScenarioBodyArgs<P> {
@@ -94,7 +102,14 @@ function buildTitle<P>(scenario: ScenarioDef<P>, provisionerId: ProvisionerId): 
   let xrayIds: string[] = [];
   if (Array.isArray(xray)) xrayIds = xray;
   else if (xray) xrayIds = [xray];
-  const tokens = [scenario.title, ...xrayIds, `@${provisionerId}`, ...(scenario.tags ?? [])];
+  const sinceVersion = scenario.since?.[provisionerId];
+  const tokens = [
+    scenario.title,
+    ...xrayIds,
+    `@${provisionerId}`,
+    ...(scenario.tags ?? []),
+    ...(sinceVersion ? [`@since-${sinceVersion}`] : []),
+  ];
   return tokens.filter((t): t is string => Boolean(t)).join(" ");
 }
 

--- a/test/platform-test/e2e/helpers/tags.ts
+++ b/test/platform-test/e2e/helpers/tags.ts
@@ -604,3 +604,18 @@ export const PROVISIONER = {
   GKO: "@gko",
   TERRAFORM: "@terraform",
 } as const;
+
+/**
+ * Version-gating tag. `since("4.12")` -> "@since-4.12". Append it to a test title
+ * to declare the oldest APIM version the test needs (i.e. the version a feature
+ * was introduced in):
+ *
+ *   test(`Deploy new 4.12 thing ${XRAY.AREA.ID} ${since("4.12")}`, ...)
+ *
+ * A test with no @since tag is treated as available on the baseline and always
+ * runs. With `npm run e2e -- --run-up-to-version <v>`, any test whose @since
+ * version is newer than <v> is skipped. Enforcement lives in `e2e/setup.ts`.
+ */
+export function since(version: string): string {
+  return `@since-${version}`;
+}

--- a/test/platform-test/e2e/playwright.config.ts
+++ b/test/platform-test/e2e/playwright.config.ts
@@ -21,14 +21,29 @@ import path from "node:path";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Optional provisioner-lane filter, set by `scripts/e2e.mjs` from
-// `--provision-with <p>` (or directly via the env var in CI). Built as a
-// CASE-SENSITIVE RegExp on purpose: Playwright's --grep CLI flag is
-// case-insensitive, so a bare `@gko` there would also match every `@GKO-1234`
-// Xray tag and select the whole suite. A case-sensitive `@gko` matches only the
-// lowercase provisioner tag that the matrix arms and *-gko-only files carry.
+// `--provision-with <p>` (or directly via the env var in CI).
+//
+// A lane = that provisioner's OWN tests + the matching arm of every shared
+// scenario. Legacy single-provisioner tests live under `tests/gko/` or
+// `tests/terraform/`; shared `*.scenario.ts` files emit one arm per provisioner,
+// each tagged `@gko` / `@terraform`. So we select a lane by (1) IGNORING the other
+// provisioner's folder and (2) DROPPING the other arm from shared scenarios via a
+// case-sensitive grepInvert (case-sensitive on purpose: Playwright's --grep CLI
+// flag is case-insensitive, so a bare `@gko` there would also match every
+// `@GKO-1234` Xray tag). This makes `--provision-with gko` run the FULL GKO suite,
+// not just the migrated scenarios.
 const provisioner = process.env["E2E_PROVISIONER"]?.trim().toLowerCase();
+let laneTestIgnore: RegExp | undefined;
+let laneGrepInvert: RegExp | undefined;
+if (provisioner === "gko") {
+  laneTestIgnore = /[/\\]tests[/\\]terraform[/\\]/;
+  laneGrepInvert = /@terraform\b/;
+} else if (provisioner === "terraform") {
+  laneTestIgnore = /[/\\]tests[/\\]gko[/\\]/;
+  laneGrepInvert = /@gko\b/;
+}
 if (provisioner) {
-  console.log(`[e2e] provisioner lane: @${provisioner}`);
+  console.log(`[e2e] provisioner lane: ${provisioner}`);
 }
 
 export default defineConfig({
@@ -37,7 +52,8 @@ export default defineConfig({
   // `*.test.ts` are plain test files; `*.scenario.ts` are provisioner-matrix
   // files that expand into one test per provisioner via forEachProvisioner.
   testMatch: ["**/*.test.ts", "**/*.scenario.ts"],
-  grep: provisioner ? new RegExp(String.raw`@${provisioner}\b`) : undefined,
+  testIgnore: laneTestIgnore,
+  grepInvert: laneGrepInvert,
   timeout: 30_000,
   retries: 0,
   workers: 1,

--- a/test/platform-test/e2e/setup.ts
+++ b/test/platform-test/e2e/setup.ts
@@ -22,6 +22,7 @@ import {
   type Gateway,
 } from "../src/index.js";
 import * as kubectl from "./helpers/kubectl.js";
+import { versionSkipReason } from "../src/utils/version/index.js";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -55,7 +56,23 @@ async function initClients(): Promise<{ mapi: Mapi; gateway: Gateway; mtlsGatewa
   return { mapi: sharedMapi, gateway: sharedGateway, mtlsGatewayBaseUrl: sharedMtlsGatewayBaseUrl };
 }
 
-export const test = base.extend<E2EFixtures>({
+export const test = base.extend<E2EFixtures & { runUpToVersion: void }>({
+  /**
+   * Enforce `--run-up-to-version` (E2E_MAX_VERSION): skip any test whose
+   * `@since-<version>` title tag is newer than the cap. Declared as an automatic,
+   * value-less fixture so it applies to every test (matrix and plain) with no
+   * per-file hook. A test with no @since tag is baseline and always runs.
+   */
+  runUpToVersion: [
+    async ({}, use) => {
+      // titlePath includes the describe blocks + test title, so a `@since-<v>` tag
+      // can sit on a single describe() to gate a whole file/feature, or on one test.
+      const reason = versionSkipReason(test.info().titlePath.join(" "), process.env["E2E_MAX_VERSION"]);
+      test.skip(reason !== undefined, reason ?? "");
+      await use();
+    },
+    { auto: true },
+  ],
   mapi: async ({}, use) => {
     const { mapi } = await initClients();
     await use(mapi);

--- a/test/platform-test/e2e/tests/gko/dictionaries/dictionary-dynamic-lifecycle.test.ts
+++ b/test/platform-test/e2e/tests/gko/dictionaries/dictionary-dynamic-lifecycle.test.ts
@@ -68,7 +68,7 @@ function headerValue(headers: Record<string, string> | undefined, name: string):
   return headers[name] ?? headers[name.toLowerCase()];
 }
 
-test.describe("Dictionaries — Dynamic lifecycle", () => {
+test.describe("Dictionaries — Dynamic lifecycle @since-4.12", () => {
   // Safety-net cleanup: if any test times out before its inline cleanup runs,
   // these still execute. Each del() ignores errors because the resource may
   // already have been removed by the test itself.

--- a/test/platform-test/e2e/tests/gko/dictionaries/dictionary-lifecycle.test.ts
+++ b/test/platform-test/e2e/tests/gko/dictionaries/dictionary-lifecycle.test.ts
@@ -46,7 +46,7 @@ async function gatewayBaseUrl(): Promise<string> {
   return config.gateway?.baseUrl ?? "http://localhost:30082";
 }
 
-test.describe("Dictionaries — Lifecycle", () => {
+test.describe("Dictionaries — Lifecycle @since-4.12", () => {
   // Safety-net cleanup: runs even if a test times out before its inline
   // cleanup. Each del() ignores errors (the resource may already be gone).
   test.afterEach(async () => {

--- a/test/platform-test/e2e/tests/gko/dictionaries/dictionary-templating.test.ts
+++ b/test/platform-test/e2e/tests/gko/dictionaries/dictionary-templating.test.ts
@@ -45,7 +45,7 @@ async function gatewayBaseUrl(): Promise<string> {
   return config.gateway?.baseUrl ?? "http://localhost:30082";
 }
 
-test.describe("Dictionaries — Templating", () => {
+test.describe("Dictionaries — Templating @since-4.12", () => {
   test(`Dynamic dictionary with secret templates resolves in API header ${XRAY.DICTIONARIES.DYNAMIC_TEMPLATE_RESOLVE} ${TAGS.REGRESSION}`, async ({
     kubectl,
   }) => {

--- a/test/platform-test/e2e/tests/scenarios/groups/groups.scenario.ts
+++ b/test/platform-test/e2e/tests/scenarios/groups/groups.scenario.ts
@@ -41,6 +41,9 @@ forEachProvisioner(
     },
     xray: { gko: XRAY.GROUPS.CREATE_WITH_MEMBER, terraform: XRAY.TERRAFORM.GROUP_CREATE },
     tags: [TAGS.REGRESSION],
+    // The Terraform apim_group resource ships in 4.12; the GKO Group CRD is older,
+    // so only the Terraform arm is version-gated.
+    since: { terraform: "4.12" },
   },
   async ({ provisioned, mapi }) => {
     // The shared invariant: both provisioners write the group through the

--- a/test/platform-test/e2e/tests/scenarios/subscriptions/apikey/apikey-gko-only.test.ts
+++ b/test/platform-test/e2e/tests/scenarios/subscriptions/apikey/apikey-gko-only.test.ts
@@ -50,7 +50,7 @@ function fullGko(subName: string): Provisioner<ApiKeyParams> {
   })();
 }
 
-test.describe(`GKO-only: api-key admission, templating, idempotency ${PROVISIONER.GKO}`, () => {
+test.describe(`GKO-only: api-key admission, templating, idempotency ${PROVISIONER.GKO} @since-4.12`, () => {
   let handle: Provisioned<ApiKeyParams> | undefined;
   let provisioner: Provisioner<ApiKeyParams> | undefined;
   let secretName: string | undefined;

--- a/test/platform-test/e2e/tests/scenarios/subscriptions/apikey/apikey-tf-only.test.ts
+++ b/test/platform-test/e2e/tests/scenarios/subscriptions/apikey/apikey-tf-only.test.ts
@@ -30,7 +30,7 @@ import { tfScenario } from "../../../../helpers/provisioner-env.js";
 import { isTerraform, type Provisioned } from "../../../../../src/provisioners/index.js";
 import { tfApiKeyVars, uniqueKey, RUN_ID, type ApiKeyParams } from "./params.js";
 
-test.describe(`Terraform-only: api-key provider behaviour ${PROVISIONER.TERRAFORM}`, () => {
+test.describe(`Terraform-only: api-key provider behaviour ${PROVISIONER.TERRAFORM} @since-4.12`, () => {
   let handle: Provisioned<ApiKeyParams> | undefined;
   let ws: terraform.TfWorkspace | undefined;
 

--- a/test/platform-test/e2e/tests/scenarios/subscriptions/apikey/apikey.scenario.ts
+++ b/test/platform-test/e2e/tests/scenarios/subscriptions/apikey/apikey.scenario.ts
@@ -28,7 +28,7 @@
  */
 
 import { test, expect } from "../../../../setup.js";
-import { XRAY, TAGS } from "../../../../helpers/tags.js";
+import { XRAY, TAGS, since } from "../../../../helpers/tags.js";
 import { forEachProvisioner } from "../../../../helpers/for-each-provisioner.js";
 import { gkoScenario, tfScenario } from "../../../../helpers/provisioner-env.js";
 import { subscriptionYaml } from "../../../../../src/provisioners/index.js";
@@ -67,7 +67,8 @@ function apikeyTfCustom(hridSuffix: string) {
   });
 }
 
-const REGRESSION = [TAGS.REGRESSION];
+// api-key plan subscriptions ship in APIM 4.12, for both provisioners.
+const REGRESSION = [TAGS.REGRESSION, since("4.12")];
 
 // ── Auto-generated single key, reachable via gateway ──────────────────────────
 // GKO splits this into a count check (2825) + a gateway check (2826); the TF

--- a/test/platform-test/e2e/tests/terraform/groups.test.ts
+++ b/test/platform-test/e2e/tests/terraform/groups.test.ts
@@ -43,7 +43,7 @@ import type { TfWorkspace } from "../../helpers/terraform.js";
 
 // ── Resource lifecycle (shared workspace, read-only assertions) ──────
 
-test.describe("Terraform — Groups · Resource lifecycle", () => {
+test.describe("Terraform — Groups · Resource lifecycle @since-4.12", () => {
   let ws: TfWorkspace;
   let groupHrid: string;
 
@@ -82,7 +82,7 @@ test.describe("Terraform — Groups · Resource lifecycle", () => {
 
 // ── In-place update ─────────────────────────────────────────────────
 
-test.describe("Terraform — Groups · Update", () => {
+test.describe("Terraform — Groups · Update @since-4.12", () => {
   test(`terraform apply updates a group in place ${XRAY.TERRAFORM.GROUP_UPDATE} ${TAGS.REGRESSION}`, async ({
     mapi,
   }) => {
@@ -137,7 +137,7 @@ test.describe("Terraform — Groups · Update", () => {
 
 // ── Destroy ─────────────────────────────────────────────────────────
 
-test.describe("Terraform — Groups · Destroy", () => {
+test.describe("Terraform — Groups · Destroy @since-4.12", () => {
   test(`terraform destroy removes the group from APIM ${XRAY.TERRAFORM.GROUP_DESTROY} ${TAGS.REGRESSION}`, async ({
     mapi,
   }) => {
@@ -162,7 +162,7 @@ test.describe("Terraform — Groups · Destroy", () => {
 
 // ── Members ─────────────────────────────────────────────────────────
 
-test.describe("Terraform — Groups · Members", () => {
+test.describe("Terraform — Groups · Members @since-4.12", () => {
   test(`member lifecycle — add and remove members ${XRAY.TERRAFORM.GROUP_MEMBER_LIFECYCLE} ${TAGS.REGRESSION}`, async ({
     mapi,
   }) => {
@@ -279,7 +279,7 @@ test.describe("Terraform — Groups · Members", () => {
 
 // ── Replacement, drift & import ──────────────────────────────────────
 
-test.describe("Terraform — Groups · Replacement, drift & import", () => {
+test.describe("Terraform — Groups · Replacement, drift & import @since-4.12", () => {
   test(`changing the hrid replaces the group ${XRAY.TERRAFORM.GROUP_HRID_REPLACEMENT} ${TAGS.REGRESSION}`, async ({
     mapi,
   }) => {
@@ -361,7 +361,7 @@ test.describe("Terraform — Groups · Replacement, drift & import", () => {
 
 // ── Schema validation (negative) ─────────────────────────────────────
 
-test.describe("Terraform — Groups · Validation", () => {
+test.describe("Terraform — Groups · Validation @since-4.12", () => {
   test(`an invalid hrid is rejected by the provider ${XRAY.TERRAFORM.GROUP_INVALID_HRID} ${TAGS.REGRESSION}`, async () => {
     test.setTimeout(terraform.TF_WORKSPACE_TIMEOUT_MS);
 
@@ -397,7 +397,7 @@ test.describe("Terraform — Groups · Validation", () => {
 
 // ── Data source ─────────────────────────────────────────────────────
 
-test.describe("Terraform — Groups · Data source", () => {
+test.describe("Terraform — Groups · Data source @since-4.12", () => {
   test(`data "apim_group" reads a group back by hrid ${XRAY.TERRAFORM.GROUP_DATA_SOURCE} ${TAGS.REGRESSION}`, async () => {
     test.setTimeout(terraform.TF_WORKSPACE_TIMEOUT_MS);
 

--- a/test/platform-test/gck.yaml
+++ b/test/platform-test/gck.yaml
@@ -26,6 +26,15 @@
 #
 # Unlike run-kind.mjs, `gck create` errors if the cluster already exists —
 # run `make delete-cluster` first.
+#
+# `helmVersion` is the apim recipe's own var for the chart version constraint. The
+# default targets the 4.12 line, so the normal `make start-e2e-cluster` flow is
+# unchanged; the upgrade flow drives it with `--set helmVersion=...` to stand up an
+# older line and then `gck patch` forward.
+vars:
+  helmVersion:
+    default: ">=4.12.0-0 <4.13.0-0"
+
 from:
   - gravitee-io/oss/apim/mongodb
 
@@ -44,9 +53,9 @@ components:
   # differences from the recipe are declared here.
   - name: apim
     helm:
-      # Pin to the 4.12 line; the "-0" prerelease bound is required to match
-      # milestone builds (currently resolves to 4.12.0-milestone.2).
-      version: ">=4.12.0-0 <4.13.0-0"
+      # Chart version comes from the `helmVersion` var (default = the 4.12 line).
+      # The "-0" prerelease bound is required to match milestone builds.
+      version: "{{ .helmVersion }}"
       values:
         gateway:
           managedServiceAccount: false

--- a/test/platform-test/scripts/e2e.mjs
+++ b/test/platform-test/scripts/e2e.mjs
@@ -24,9 +24,9 @@
  *
  *   --provision-with <gko|terraform>  Run only one provisioner lane.
  *                                     -> E2E_PROVISIONER (case-sensitive @tag grep).
- *   --run-up-to-version <semver>      Run only features available at that version.
- *                                     -> E2E_MAX_VERSION. STUBBED: accepted but not
- *                                        enforced yet (version-gating is future work).
+ *   --run-up-to-version <semver>      Run only features available at that version,
+ *                                     i.e. skip tests tagged @since-<newer>.
+ *                                     -> E2E_MAX_VERSION (enforced in e2e/setup.ts).
  *   <anything else>                   Forwarded verbatim to `playwright test`
  *                                     (e.g. --grep @GKO-2828, --headed, a file path).
  *
@@ -83,9 +83,8 @@ for (let i = 0; i < args.length; i++) {
 }
 
 if (env.E2E_MAX_VERSION) {
-  console.warn(
-    `[e2e] --run-up-to-version=${env.E2E_MAX_VERSION} is accepted but NOT enforced yet: ` +
-      `version-gating (@since-<semver> tags + skip) is not implemented. Running the full selection.`,
+  console.log(
+    `[e2e] capping at APIM version ${env.E2E_MAX_VERSION}: skipping tests tagged @since-<newer>`,
   );
 }
 

--- a/test/platform-test/src/utils/version/index.ts
+++ b/test/platform-test/src/utils/version/index.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Version helpers for the `--run-up-to-version` filter.
+ *
+ * A test declares the oldest APIM version it needs with a `@since-<version>` tag
+ * in its title (see `since()` in `e2e/helpers/tags.ts`). When the suite is run
+ * with `--run-up-to-version <v>` (which sets `E2E_MAX_VERSION`), any test whose
+ * `@since` version is newer than `<v>` is skipped. A test with no `@since` tag is
+ * treated as baseline and always runs. The skip itself is wired in
+ * `e2e/setup.ts`; everything here is pure and unit-tested.
+ */
+
+/** A parsed (major, minor, patch) tuple. */
+export type Version = [number, number, number];
+
+/**
+ * Parse a dotted version string into (major, minor, patch). Tolerates a leading
+ * "v", a missing patch (defaults to 0), and any pre-release / build suffix:
+ *   "4.12" -> [4,12,0]   "v4.12.3" -> [4,12,3]   "4.12.0-milestone.2" -> [4,12,0]
+ * Returns undefined when there is no leading `major.minor` (e.g. "master-latest").
+ */
+export function parseVersion(input: string): Version | undefined {
+  const match = /^v?(\d+)\.(\d+)(?:\.(\d+))?/.exec(input.trim());
+  if (!match) return undefined;
+  return [Number(match[1]), Number(match[2]), match[3] === undefined ? 0 : Number(match[3])];
+}
+
+/**
+ * Compare two version strings by (major, minor, patch). Returns -1, 0, or 1.
+ * If either side is unparseable, returns 0 so callers fail open (never gate by
+ * mistake on something like "master-latest").
+ */
+export function compareVersions(a: string, b: string): number {
+  const pa = parseVersion(a);
+  const pb = parseVersion(b);
+  if (!pa || !pb) return 0;
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] < pb[i] ? -1 : 1;
+  }
+  return 0;
+}
+
+const SINCE_RE = /@since-(\S+)/;
+
+/** Extract the `@since-<version>` value from a test title, if present. */
+export function sinceFromTitle(title: string): string | undefined {
+  const match = SINCE_RE.exec(title);
+  return match ? match[1] : undefined;
+}
+
+/**
+ * Decide whether a test should be skipped when the run is capped at `maxVersion`
+ * (the `--run-up-to-version` / `E2E_MAX_VERSION` value). Returns a human-readable
+ * reason to skip, or undefined to run.
+ *
+ * - No cap set -> run everything.
+ * - No `@since` tag -> baseline -> always run.
+ * - `@since-X` with X strictly newer than the cap -> skip.
+ */
+export function versionSkipReason(
+  title: string,
+  maxVersion: string | undefined | null,
+): string | undefined {
+  if (!maxVersion) return undefined;
+  const since = sinceFromTitle(title);
+  if (since === undefined) return undefined;
+  if (compareVersions(since, maxVersion) > 0) {
+    return `requires APIM ${since}, run capped at ${maxVersion} (--run-up-to-version)`;
+  }
+  return undefined;
+}

--- a/test/platform-test/test/utils/version.test.ts
+++ b/test/platform-test/test/utils/version.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  parseVersion,
+  compareVersions,
+  sinceFromTitle,
+  versionSkipReason,
+} from "../../src/utils/version/index.js";
+
+describe("parseVersion", () => {
+  it("parses major.minor with a default patch", () => {
+    expect(parseVersion("4.12")).toEqual([4, 12, 0]);
+  });
+  it("parses full semver and ignores any pre-release suffix", () => {
+    expect(parseVersion("4.12.3")).toEqual([4, 12, 3]);
+    expect(parseVersion("4.12.0-milestone.2")).toEqual([4, 12, 0]);
+  });
+  it("tolerates a leading v", () => {
+    expect(parseVersion("v4.11")).toEqual([4, 11, 0]);
+  });
+  it("returns undefined for non-versions", () => {
+    expect(parseVersion("master-latest")).toBeUndefined();
+    expect(parseVersion("")).toBeUndefined();
+  });
+});
+
+describe("compareVersions", () => {
+  it("orders by major, then minor, then patch", () => {
+    expect(compareVersions("4.11", "4.12")).toBe(-1);
+    expect(compareVersions("4.12", "4.11")).toBe(1);
+    expect(compareVersions("4.12", "4.12.0")).toBe(0);
+    expect(compareVersions("4.12.1", "4.12.0")).toBe(1);
+    expect(compareVersions("5.0", "4.99")).toBe(1);
+  });
+  it("treats unparseable input as equal (fail open)", () => {
+    expect(compareVersions("master-latest", "4.12")).toBe(0);
+  });
+});
+
+describe("sinceFromTitle", () => {
+  it("extracts the @since tag value from a title", () => {
+    expect(sinceFromTitle("Deploy something @GKO-123 @since-4.12 @regression")).toBe("4.12");
+  });
+  it("returns undefined when there is no @since tag", () => {
+    expect(sinceFromTitle("Deploy something @GKO-123 @regression")).toBeUndefined();
+  });
+});
+
+describe("versionSkipReason", () => {
+  it("runs everything when no cap is set", () => {
+    expect(versionSkipReason("x @since-4.12", undefined)).toBeUndefined();
+    expect(versionSkipReason("x @since-4.12", null)).toBeUndefined();
+  });
+  it("runs baseline (untagged) tests under any cap", () => {
+    expect(versionSkipReason("plain test @regression", "4.11")).toBeUndefined();
+  });
+  it("skips a test that needs a newer version than the cap", () => {
+    expect(versionSkipReason("new feature @since-4.12", "4.11")).toMatch(/requires APIM 4\.12/);
+  });
+  it("runs a test at or below the cap", () => {
+    expect(versionSkipReason("feature @since-4.12", "4.12")).toBeUndefined();
+    expect(versionSkipReason("feature @since-4.11", "4.12")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Foundation for automated upgrade testing in the platform-test e2e suite: the
reusable parts (version gating, lane selection, before/after-upgrade
orchestration). The dedicated "do old resources survive the upgrade?" survival
check is a follow-up built on this (see below).

- **Lane selection now covers the full suite.** `--provision-with gko|terraform`
  runs that provisioner's whole lane (its `tests/<lane>/` folder plus the matching
  arm of every shared scenario), instead of only the migrated scenarios. The config
  ignores the other lane's folder and drops its arm with a case-sensitive grepInvert.
- **Version gating.** `--run-up-to-version <semver>` is enforced: an automatic
  fixture skips any test tagged `@since-<newer>` than the cap. The tag can sit on a
  single `describe()` to gate a whole file, and the matrix runner supports a
  per-provisioner `since`. Untagged tests are baseline and always run.
- **Before/after-upgrade CI flow.** A post-merge job stands up APIM on the old line
  with `gck create`, runs the suite "up to old", upgrades APIM in place with
  `gck patch`, then runs "up to new". Since gck v1.1.1, `gck patch` inherits the
  create-time context, so the upgrade is a short inline sequence of `gck`/`e2e`
  commands (no orchestration script). The APIM chart version is the apim recipe's
  native `helmVersion` var (default unchanged, so the normal start-e2e-cluster flow
  is untouched).
- **Labels.** The 4.12-only features are tagged `@since-4.12`: api-key plan
  subscriptions (both provisioners), the Terraform `apim_group` resource (Terraform
  arm only) and dictionaries.

What this is **not** yet: it runs the suite before and after the upgrade, but each
test self-cleans, so it does not prove that resources created on the old version
survive the upgrade and stay mutable. That survival check is the next piece, built
on this foundation via the provisioner `attach()` seam (follow-up).

Verified end-to-end on a local kind cluster: `gck create` 4.11 → run → `gck patch`
to 4.12 (Mongo preserved) → run, green. Everything lives under `test/platform-test/`
except the one CI job in `.circleci/config.yml`.

See: https://gravitee.atlassian.net/browse/GKO-1898