### PR TITLE
chore: restore APIM helm chart pin to 4.12.* for 4.12.x line

### DIFF
--- a/hack/apim.yaml
+++ b/hack/apim.yaml
@@ -18,5 +18,4 @@ apim:
     version: 4.12.x-latest
   chart:
     registry: oci://graviteeio.azurecr.io/helm/apim3
-    # 4.13.x chart renders allowMultiplePortalPerEnv; the 4.12.x image (above) carries the gating code
-    version: 4.13.*
+    version: 4.12.*

--- a/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-native-kafka-reporter-disabled.yaml
+++ b/test/platform-test/e2e/fixtures/crds/api-v4-definitions/v4-native-kafka-reporter-disabled.yaml
@@ -20,8 +20,11 @@ spec:
   contextRef:
     name: "dev-ctx"
     namespace: "default"
-  name: "e2e-v4-native-kafka-ports"
-  description: "E2E test: Native Kafka API plan ports validation"
+  # Unique identity (name + Kafka host + broker port range). This fixture used
+  # to share spec.name/host/ports with v4-native-kafka-ports-valid.yaml, which
+  # mapped both to the same APIM API and made the suite order-dependent.
+  name: "e2e-v4-native-kafka-reporter-disabled"
+  description: "E2E test: Native Kafka API with reporter metrics disabled"
   version: "1.0.0"
   type: NATIVE
   state: STOPPED
@@ -33,7 +36,7 @@ spec:
     syncFrom: MANAGEMENT
   listeners:
     - type: KAFKA
-      host: "kafka.example.local"
+      host: "kafka-reporter.example.local"
       port: 9092
       entrypoints:
         - type: native-kafka
@@ -46,7 +49,7 @@ spec:
           type: native-kafka
           inheritConfiguration: false
           configuration:
-            bootstrapServers: "kafka.example.local:9092"
+            bootstrapServers: "kafka-reporter.example.local:9092"
           secondary: false
           sharedConfigurationOverride:
             security:
@@ -57,7 +60,7 @@ spec:
       name: "Free plan"
       security:
         type: "KEY_LESS"
-      bootstrapPort: 9092
-      brokerRangeStart: 9100
-      brokerRangeEnd: 9102
+      bootstrapPort: 9292
+      brokerRangeStart: 9300
+      brokerRangeEnd: 9302
 

--- a/test/platform-test/e2e/tests/gko/api-lifecycle/v4-native-kafka-analytics.test.ts
+++ b/test/platform-test/e2e/tests/gko/api-lifecycle/v4-native-kafka-analytics.test.ts
@@ -25,7 +25,7 @@ import { TAGS } from "../../../helpers/tags.js";
 
 test.describe("Native Kafka API — Analytics", () => {
   test(`reporterMetricsEnabled=false is applied in APIM ${TAGS.REGRESSION}`, async ({ kubectl, mapi }) => {
-    const API_NAME = "e2e-v4-native-kafka-ports";
+    const API_NAME = "e2e-v4-native-kafka-reporter-disabled";
     const f = fixture("crds/api-v4-definitions/v4-native-kafka-reporter-disabled.yaml");
 
     await kubectl.apply(f);


### PR DESCRIPTION
## What
Restores the APIM Helm chart pin in `hack/apim.yaml` from the temporary `4.13.*` back to `4.12.*` on the `4.12.x` line.

## Why
The portal-automation backport (#1704) had to pin the chart to `4.13.*` because the `allowMultiplePortalPerEnv` flag template only existed in a 4.13 chart (and, on 4.12.x, only in the pre-release `4.12.0-milestone.5` — which `4.12.*` won't select). That was a stopgap to get the integration tests green; a 4.13 chart on the 4.12.x line is not what we want for the official release.

## ⛔ Waiting / do not merge yet
`4.12.*` currently resolves to chart `4.12.0`, which does **not** render `allowMultiplePortalPerEnv`, so the portal/docs integration tests will fail if merged now.

Merge this only once a **stable `4.12.x`** chart containing the flag template is released — then `4.12.*` resolves to it and CI passes.

## Notes
- The image pin (`4.12.x-latest`) is unchanged — it already carries the gating code.
