### PR TITLE
test(platform-test): gate 4.12-only GKO tests for the 4.11 upgrade lane

### DIFF
--- a/test/platform-test/e2e/tests/gko/admission-webhook/v4-native-kafka-ports-validation.test.ts
+++ b/test/platform-test/e2e/tests/gko/admission-webhook/v4-native-kafka-ports-validation.test.ts
@@ -28,7 +28,7 @@ import { TAGS } from "../../../helpers/tags.js";
 import type { PlanV4 } from "../../../../src/types/apim.js";
 
 test.describe("Native Kafka API — Plan ports validation", () => {
-  test(`Valid native kafka plan ports are accepted ${TAGS.REGRESSION}`, async ({ kubectl, mapi }) => {
+  test(`Valid native kafka plan ports are accepted ${TAGS.REGRESSION} @since-4.12`, async ({ kubectl, mapi }) => {
     const API_NAME = "e2e-v4-native-kafka-ports";
     const f = fixture("crds/api-v4-definitions/v4-native-kafka-ports-valid.yaml");
     await kubectl.apply(f);

--- a/test/platform-test/e2e/tests/gko/analytics/v4-analytics-extended.test.ts
+++ b/test/platform-test/e2e/tests/gko/analytics/v4-analytics-extended.test.ts
@@ -24,7 +24,7 @@
 import { test, fixture, expect } from "../../../setup.js";
 import { TAGS } from "../../../helpers/tags.js";
 
-test.describe("V4 API Analytics — Extended", () => {
+test.describe("V4 API Analytics — Extended @since-4.12", () => {
   test(`V4 API analytics fields are accepted by admission ${TAGS.REGRESSION}`, async ({
     kubectl,
     mapi,

--- a/test/platform-test/e2e/tests/gko/api-lifecycle/v4-automation-fields.test.ts
+++ b/test/platform-test/e2e/tests/gko/api-lifecycle/v4-automation-fields.test.ts
@@ -23,7 +23,7 @@
 import { test, fixture } from "../../../setup.js";
 import { TAGS } from "../../../helpers/tags.js";
 
-test.describe("V4 API — Automation API fields", () => {
+test.describe("V4 API — Automation API fields @since-4.12", () => {
   test(`Automation API fields are applied in APIM ${TAGS.REGRESSION}`, async ({ kubectl, mapi }) => {
     const API_NAME = "e2e-v4-new-fields";
     const f = fixture("crds/api-v4-definitions/v4-proxy-api-new-fields.yaml");

--- a/test/platform-test/e2e/tests/gko/api-lifecycle/v4-native-kafka-analytics.test.ts
+++ b/test/platform-test/e2e/tests/gko/api-lifecycle/v4-native-kafka-analytics.test.ts
@@ -23,7 +23,7 @@
 import { test, fixture } from "../../../setup.js";
 import { TAGS } from "../../../helpers/tags.js";
 
-test.describe("Native Kafka API — Analytics", () => {
+test.describe("Native Kafka API — Analytics @since-4.12", () => {
   test(`reporterMetricsEnabled=false is applied in APIM ${TAGS.REGRESSION}`, async ({ kubectl, mapi }) => {
     const API_NAME = "e2e-v4-native-kafka-reporter-disabled";
     const f = fixture("crds/api-v4-definitions/v4-native-kafka-reporter-disabled.yaml");

--- a/test/platform-test/e2e/tests/gko/deployment-reconciliation/cr-managed-readonly.test.ts
+++ b/test/platform-test/e2e/tests/gko/deployment-reconciliation/cr-managed-readonly.test.ts
@@ -84,7 +84,7 @@ test.describe("CR-managed resources are read-only in APIM", () => {
 
   // ── GKO-1234: Notification settings tagged origin=KUBERNETES
 
-  test(`Notification settings created via CR are origin=KUBERNETES ${XRAY.NOTIFICATIONS.CR_READONLY_VIA_MAPI} ${TAGS.REGRESSION}`, async ({
+  test(`Notification settings created via CR are origin=KUBERNETES ${XRAY.NOTIFICATIONS.CR_READONLY_VIA_MAPI} ${TAGS.REGRESSION} @since-4.12`, async ({
     kubectl,
     mapi,
   }) => {

--- a/test/platform-test/e2e/tests/gko/groups/group-lifecycle.test.ts
+++ b/test/platform-test/e2e/tests/gko/groups/group-lifecycle.test.ts
@@ -34,7 +34,7 @@ import { test, fixture, expect } from "../../../setup.js";
 import { XRAY, TAGS } from "../../../helpers/tags.js";
 import * as kubectl from "../../../helpers/kubectl.js";
 
-test.describe("Groups — Lifecycle", () => {
+test.describe("Groups — Lifecycle @since-4.12", () => {
   // Safety-net cleanup: runs even if a test times out before its inline
   // cleanup. Each del() ignores errors (the resource may already be gone).
   test.afterEach(async () => {

--- a/test/platform-test/e2e/tests/gko/members/v2-members-extended.test.ts
+++ b/test/platform-test/e2e/tests/gko/members/v2-members-extended.test.ts
@@ -81,7 +81,7 @@ test.describe("V2 API Groups, Members & PO — Extended", () => {
 
   // ── GKO-398: Add group using name (hrid) ────────────────────
 
-  test(`V2 API references group by hrid ${XRAY.MEMBERS.V2_ADD_GROUP_HRID} ${TAGS.REGRESSION}`, async ({
+  test(`V2 API references group by hrid ${XRAY.MEMBERS.V2_ADD_GROUP_HRID} ${TAGS.REGRESSION} @since-4.12`, async ({
     kubectl,
     mapi,
   }) => {
@@ -102,7 +102,7 @@ test.describe("V2 API Groups, Members & PO — Extended", () => {
 
   // ── GKO-399: Multiple groups ────────────────────────────────
 
-  test(`V2 API references multiple groups by hrid ${XRAY.MEMBERS.V2_MULTIPLE_GROUPS} ${TAGS.REGRESSION}`, async ({
+  test(`V2 API references multiple groups by hrid ${XRAY.MEMBERS.V2_MULTIPLE_GROUPS} ${TAGS.REGRESSION} @since-4.12`, async ({
     kubectl,
     mapi,
   }) => {
@@ -126,7 +126,7 @@ test.describe("V2 API Groups, Members & PO — Extended", () => {
 
   // ── GKO-400: Remove group from V2 API ───────────────────────
 
-  test(`Remove group from V2 API on re-apply ${XRAY.MEMBERS.V2_REMOVE_GROUP} ${TAGS.REGRESSION}`, async ({
+  test(`Remove group from V2 API on re-apply ${XRAY.MEMBERS.V2_REMOVE_GROUP} ${TAGS.REGRESSION} @since-4.12`, async ({
     kubectl,
     mapi,
   }) => {
@@ -215,7 +215,7 @@ test.describe("V2 API Groups, Members & PO — Extended", () => {
 
   // ── GKO-1003: Add GroupRefs to V2 API ───────────────────────
 
-  test(`V2 API references a group via groupRefs ${XRAY.MEMBERS.V2_ADD_GROUP_REFS} ${TAGS.REGRESSION}`, async ({
+  test(`V2 API references a group via groupRefs ${XRAY.MEMBERS.V2_ADD_GROUP_REFS} ${TAGS.REGRESSION} @since-4.12`, async ({
     kubectl,
     mapi,
   }) => {

--- a/test/platform-test/e2e/tests/gko/mtls-certificates/mtls-cert-lifecycle-extended.test.ts
+++ b/test/platform-test/e2e/tests/gko/mtls-certificates/mtls-cert-lifecycle-extended.test.ts
@@ -292,7 +292,7 @@ test.describe("mTLS — Application cert lifecycle", () => {
   // New Entity") collapse to the same observable: after a content change
   // the mAPI cert reflects the new PEM.
 
-  test(`Replacing cert content via CR updates the entity ${XRAY.MTLS_CERTIFICATES.CERT_UPDATE_VIA_CR} ${XRAY.MTLS_CERTIFICATES.CERT_CHANGE_NEW_ENTITY} ${TAGS.REGRESSION}`, async ({
+  test(`Replacing cert content via CR updates the entity ${XRAY.MTLS_CERTIFICATES.CERT_UPDATE_VIA_CR} ${XRAY.MTLS_CERTIFICATES.CERT_CHANGE_NEW_ENTITY} ${TAGS.REGRESSION} @since-4.12`, async ({
     kubectl,
     mapi,
   }) => {
@@ -315,7 +315,7 @@ test.describe("mTLS — Application cert lifecycle", () => {
 
   // ── GKO-2264: cert name auto-generation convention ───────────────────
 
-  test(`Unnamed cert is auto-named "<app>-<index>" in mAPI ${XRAY.MTLS_CERTIFICATES.CERT_NAMING_CONVENTION} ${TAGS.REGRESSION}`, async ({
+  test(`Unnamed cert is auto-named "<app>-<index>" in mAPI ${XRAY.MTLS_CERTIFICATES.CERT_NAMING_CONVENTION} ${TAGS.REGRESSION} @since-4.12`, async ({
     kubectl,
     mapi,
   }) => {
@@ -439,7 +439,7 @@ const STATUS_APPS = [
   "e2e-mtls-2149",
 ];
 
-test.describe("mTLS — cert date acceptance", () => {
+test.describe("mTLS — cert date acceptance @since-4.12", () => {
   let pem: string;
 
   test.beforeAll(async () => {

--- a/test/platform-test/e2e/tests/gko/mtls-certificates/mtls-cert-subscription-updates.test.ts
+++ b/test/platform-test/e2e/tests/gko/mtls-certificates/mtls-cert-subscription-updates.test.ts
@@ -73,7 +73,7 @@ test.describe("mTLS — clientCertificates visibility via mAPI", () => {
     expect(certs).toEqual([]);
   });
 
-  test(`Cert startsAt and endsAt round-trip from CRD to mAPI ${XRAY.MTLS_CERTIFICATES.CERT_INFO_DISPLAY} ${TAGS.REGRESSION}`, async ({
+  test(`Cert startsAt and endsAt round-trip from CRD to mAPI ${XRAY.MTLS_CERTIFICATES.CERT_INFO_DISPLAY} ${TAGS.REGRESSION} @since-4.12`, async ({
     kubectl,
     mapi,
   }) => {
@@ -103,7 +103,7 @@ test.describe("mTLS — clientCertificates visibility via mAPI", () => {
       });
   });
 
-  test(`Active certificate is visible on the application via mAPI ${XRAY.MTLS_CERTIFICATES.ACTIVE_CERT_DISPLAY} ${TAGS.REGRESSION}`, async ({
+  test(`Active certificate is visible on the application via mAPI ${XRAY.MTLS_CERTIFICATES.ACTIVE_CERT_DISPLAY} ${TAGS.REGRESSION} @since-4.12`, async ({
     kubectl,
     mapi,
   }) => {
@@ -124,7 +124,7 @@ test.describe("mTLS — clientCertificates visibility via mAPI", () => {
       .toBeGreaterThanOrEqual(1);
   });
 
-  test(`Past-end-date certificate is filtered out of the active cert list ${XRAY.MTLS_CERTIFICATES.EXPIRED_CERT_DISPLAY} ${TAGS.REGRESSION}`, async ({
+  test(`Past-end-date certificate is filtered out of the active cert list ${XRAY.MTLS_CERTIFICATES.EXPIRED_CERT_DISPLAY} ${TAGS.REGRESSION} @since-4.12`, async ({
     kubectl,
     mapi,
   }) => {

--- a/test/platform-test/e2e/tests/gko/notifications/notification-lifecycle.test.ts
+++ b/test/platform-test/e2e/tests/gko/notifications/notification-lifecycle.test.ts
@@ -48,7 +48,7 @@ async function createServiceAccount(mapi: { http: { managementV1Path(r: string):
 }
 
 
-test.describe("Notification Lifecycle", () => {
+test.describe("Notification Lifecycle @since-4.12", () => {
   test(`Remove notification from API ${XRAY.NOTIFICATIONS.REMOVE_NOTIFICATION}`, async ({
     kubectl,
     mapi,

--- a/test/platform-test/e2e/tests/gko/notifications/notification-recipients.test.ts
+++ b/test/platform-test/e2e/tests/gko/notifications/notification-recipients.test.ts
@@ -142,7 +142,7 @@ test.describe("Notifications — recipients & visibility", () => {
 
   // ── GKO-1219: Customise the portal-notifier target user ──────
 
-  test(`Custom group is set as portal-notifier recipient via Notification CR ${XRAY.NOTIFICATIONS.PORTAL_NOTIFIER_TARGET_USER} ${TAGS.REGRESSION}`, async ({
+  test(`Custom group is set as portal-notifier recipient via Notification CR ${XRAY.NOTIFICATIONS.PORTAL_NOTIFIER_TARGET_USER} ${TAGS.REGRESSION} @since-4.12`, async ({
     kubectl,
     mapi,
   }) => {
@@ -175,7 +175,7 @@ test.describe("Notifications — recipients & visibility", () => {
 
   // ── GKO-1239: Group members are notified via groupRefs ───────
 
-  test(`Notification CR with groupRefs propagates to PORTAL groups ${XRAY.NOTIFICATIONS.GROUP_MEMBERS_NOTIFIED} ${TAGS.REGRESSION}`, async ({
+  test(`Notification CR with groupRefs propagates to PORTAL groups ${XRAY.NOTIFICATIONS.GROUP_MEMBERS_NOTIFIED} ${TAGS.REGRESSION} @since-4.12`, async ({
     kubectl,
     mapi,
   }) => {

--- a/test/platform-test/e2e/tests/gko/pages/v2-documentation.test.ts
+++ b/test/platform-test/e2e/tests/gko/pages/v2-documentation.test.ts
@@ -328,7 +328,7 @@ test.describe("V2 API Documentation — Extended", () => {
 
   // ── GKO-315: Private page with groups ───────────────────────
 
-  test(`V2 PRIVATE page with group access control ${XRAY.PAGES.V2_DOC_PRIVATE_GROUPS} ${TAGS.REGRESSION}`, async ({
+  test(`V2 PRIVATE page with group access control ${XRAY.PAGES.V2_DOC_PRIVATE_GROUPS} ${TAGS.REGRESSION} @since-4.12`, async ({
     kubectl,
     mapi,
   }) => {
@@ -353,7 +353,7 @@ test.describe("V2 API Documentation — Extended", () => {
 
   // ── GKO-316: Private page with excluded groups ──────────────
 
-  test(`V2 PRIVATE page with excluded group ${XRAY.PAGES.V2_DOC_PRIVATE_EXCLUDED} ${TAGS.REGRESSION}`, async ({
+  test(`V2 PRIVATE page with excluded group ${XRAY.PAGES.V2_DOC_PRIVATE_EXCLUDED} ${TAGS.REGRESSION} @since-4.12`, async ({
     kubectl,
     mapi,
   }) => {

--- a/test/platform-test/e2e/tests/gko/subscriptions/subscription-security.test.ts
+++ b/test/platform-test/e2e/tests/gko/subscriptions/subscription-security.test.ts
@@ -104,7 +104,7 @@ test.describe("Subscriptions — Security Plans", () => {
 
   // ── GKO-799: V2 JWT subscription ───────────────────────────────
 
-  test(`V2 JWT subscription ${XRAY.SUBSCRIPTIONS.V2_JWT_SUBSCRIPTION} ${TAGS.REGRESSION}`, async ({
+  test(`V2 JWT subscription ${XRAY.SUBSCRIPTIONS.V2_JWT_SUBSCRIPTION} ${TAGS.REGRESSION} @since-4.12`, async ({
     kubectl,
     mapi,
   }) => {
@@ -169,7 +169,7 @@ test.describe("Subscriptions — Security Plans", () => {
 
   // ── GKO-818: V2 OAuth2 subscription ────────────────────────────
 
-  test(`V2 OAuth2 subscription ${XRAY.SUBSCRIPTIONS.V2_OAUTH2_SUBSCRIPTION} ${TAGS.REGRESSION}`, async ({
+  test(`V2 OAuth2 subscription ${XRAY.SUBSCRIPTIONS.V2_OAUTH2_SUBSCRIPTION} ${TAGS.REGRESSION} @since-4.12`, async ({
     kubectl,
     mapi,
   }) => {
@@ -234,7 +234,7 @@ test.describe("Subscriptions — Security Plans", () => {
 
   // ── GKO-797: Auto-validate V2 subscription despite manual approval ──
 
-  test(`Auto-validate V2 subscription despite manual approval ${XRAY.SUBSCRIPTIONS.AUTO_VALIDATE_V2} ${TAGS.REGRESSION}`, async ({
+  test(`Auto-validate V2 subscription despite manual approval ${XRAY.SUBSCRIPTIONS.AUTO_VALIDATE_V2} ${TAGS.REGRESSION} @since-4.12`, async ({
     kubectl,
     mapi,
   }) => {
@@ -301,7 +301,7 @@ test.describe("Subscriptions — Security Plans", () => {
 
   // ── GKO-808: Call V2 gateway with JWT plan ──────────────────────
 
-  test(`Call V2 gateway with JWT plan ${XRAY.SUBSCRIPTIONS.V2_GATEWAY_JWT_CALL} ${TAGS.REGRESSION}`, async ({
+  test(`Call V2 gateway with JWT plan ${XRAY.SUBSCRIPTIONS.V2_GATEWAY_JWT_CALL} ${TAGS.REGRESSION} @since-4.12`, async ({
     kubectl,
     gateway,
   }) => {

--- a/test/platform-test/e2e/tests/gko/subscriptions/v2-subscriptions-advanced.test.ts
+++ b/test/platform-test/e2e/tests/gko/subscriptions/v2-subscriptions-advanced.test.ts
@@ -61,7 +61,7 @@ test.describe("V2 Subscriptions — Advanced", () => {
 
   // ── GKO-796: Cross-mgmt-context subscription is rejected ────
 
-  test(`Subscription across different mgmt contexts is rejected ${XRAY.SUBSCRIPTIONS.CROSS_MGMT_CONTEXT_ERROR} ${TAGS.REGRESSION}`, async ({
+  test(`Subscription across different mgmt contexts is rejected ${XRAY.SUBSCRIPTIONS.CROSS_MGMT_CONTEXT_ERROR} ${TAGS.REGRESSION} @since-4.12`, async ({
     kubectl,
   }) => {
     test.slow(); // V2 API + two mgmt contexts takes extra reconcile time.
@@ -127,7 +127,7 @@ test.describe("V2 Subscriptions — Advanced", () => {
 
   // ── GKO-821: Delete V2 JWT subscription ─────────────────────
 
-  test(`Delete V2 JWT subscription closes access ${XRAY.SUBSCRIPTIONS.V2_JWT_DELETE} ${TAGS.REGRESSION}`, async ({
+  test(`Delete V2 JWT subscription closes access ${XRAY.SUBSCRIPTIONS.V2_JWT_DELETE} ${TAGS.REGRESSION} @since-4.12`, async ({
     kubectl,
     gateway,
   }) => {
@@ -154,7 +154,7 @@ test.describe("V2 Subscriptions — Advanced", () => {
 
   // ── GKO-825: Delete V2 OAuth2 subscription ──────────────────
 
-  test(`Delete V2 OAuth2 subscription closes access ${XRAY.SUBSCRIPTIONS.V2_OAUTH2_DELETE} ${TAGS.REGRESSION}`, async ({
+  test(`Delete V2 OAuth2 subscription closes access ${XRAY.SUBSCRIPTIONS.V2_OAUTH2_DELETE} ${TAGS.REGRESSION} @since-4.12`, async ({
     kubectl,
   }) => {
     test.slow();

--- a/test/platform-test/e2e/tests/scenarios/groups/groups.scenario.ts
+++ b/test/platform-test/e2e/tests/scenarios/groups/groups.scenario.ts
@@ -41,9 +41,10 @@ forEachProvisioner(
     },
     xray: { gko: XRAY.GROUPS.CREATE_WITH_MEMBER, terraform: XRAY.TERRAFORM.GROUP_CREATE },
     tags: [TAGS.REGRESSION],
-    // The Terraform apim_group resource ships in 4.12; the GKO Group CRD is older,
-    // so only the Terraform arm is version-gated.
-    since: { terraform: "4.12" },
+    // Both arms write the group through the Automation API, whose `groups`
+    // endpoint ships in 4.12 (the GKO admission webhook dry-runs against it and
+    // the Terraform apim_group resource targets it), so both arms are gated.
+    since: { gko: "4.12", terraform: "4.12" },
   },
   async ({ provisioned, mapi }) => {
     // The shared invariant: both provisioners write the group through the


### PR DESCRIPTION
## Summary

The before/after-upgrade CI job (`job-e2e-upgrade-tests`, added in #1702)
runs the GKO lane against APIM 4.11 before upgrading to 4.12. Its 4.11
"before-upgrade" phase failed 38 tests that depend on 4.12-only APIM
behaviour but were never tagged `@since-4.12`, so the
`--run-up-to-version 4.11` cap did not skip them.

This adds `@since-4.12` to exactly those tests, at the narrowest scope:

- **Groups** (and everything that applies a Group CR: members,
  notifications, V2 doc group ACLs, the GKO arm of the shared groups
  scenario) — the admission webhook dry-runs `PUT /automation/.../groups`,
  which 4.11 returns 404 for.
- **V2 subscriptions** — subscriptions route through the Automation API;
  for legacy-managed V2 APIs that uses the UUID path, which is 4.12-only
  (V4 HRID subscriptions work on 4.11, so only the V2 cases are gated).
- **V4 automation/analytics fields, native-kafka plan ports, notification
  `origin=KUBERNETES`, and mTLS clientCertificate visibility via mAPI** —
  all 4.12-only surfaces.

Mixed files are gated per-test so the cases that still pass on 4.11 keep
running; whole-`describe` gating only where every case is 4.12.

Verified locally: the 4.11 lane now skips all 38 and reports 0 failures
(253 passed, 64 skipped). The 4.12 lane runs the same suite as the
existing green `job-e2e-tests`.

See: https://gravitee.atlassian.net/browse/GKO-1898
