### PR TITLE
test(platform-test): make the e2e upgrade lane manual-only (and target 4.12.x-latest)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -611,7 +611,7 @@ jobs:
             kubectl rollout status deployment/gko-controller-manager -n default --timeout=120s
             npm --prefix test/platform-test run e2e -- --provision-with gko --run-up-to-version 4.11
             gck patch --config test/platform-test/gck.yaml --name gravitee \
-              --set imageTag=master-latest --set 'helmVersion=>=4.12.0-0 <4.13.0-0'
+              --set imageTag=4.12.x-latest --set 'helmVersion=>=4.12.0-0 <4.13.0-0'
             npm --prefix test/platform-test run e2e -- --provision-with gko --run-up-to-version 4.12
       - store_test_results:
           path: test/platform-test/playwright-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ parameters:
     enum:
       - test
       - e2e
+      - upgrade-e2e
       - rollout-apim
       - release
       - freeze
@@ -1186,19 +1187,6 @@ workflows:
                   event: pass
                   template: basic_success_1
                   branch_pattern: ".+"
-      - job-e2e-upgrade-tests:
-          name: Run upgrade end to end tests
-          context: cicd-orchestrator
-          filters:
-            branches:
-              only:
-                - master
-          post-steps:
-              - slack/notify:
-                  channel: C098YUEDMGE
-                  event: fail
-                  template: basic_fail_1
-                  branch_pattern: ".+"
       - job-install-go-tools:
           name: Install GO tools (master)
           filters:
@@ -1411,6 +1399,34 @@ workflows:
     jobs:
       - job-e2e-tests:
           name: Run end to end tests
+          context: cicd-orchestrator
+          post-steps:
+            - when:
+                condition: << pipeline.parameters.notify >>
+                steps:
+                  - slack/notify:
+                      channel: C098YUEDMGE
+                      event: fail
+                      template: basic_fail_1
+                      branch_pattern: ".+"
+                  - slack/notify:
+                      channel: C098YUEDMGE
+                      event: pass
+                      template: basic_success_1
+                      branch_pattern: ".+"
+
+  # Upgrade e2e is manual-only (on-demand via the "Trigger Upgrade E2E" GitHub
+  # Action, which sets trigger=upgrade-e2e). It is intentionally NOT in the
+  # post-merge workflow: it is resource-heavy (runs the suite twice across an
+  # in-place APIM upgrade) and not needed on every merge.
+  upgrade-e2e-test:
+    when:
+      equal:
+        - upgrade-e2e
+        - << pipeline.parameters.trigger >>
+    jobs:
+      - job-e2e-upgrade-tests:
+          name: Run upgrade end to end tests
           context: cicd-orchestrator
           post-steps:
             - when:

--- a/.github/workflows/trigger-upgrade-e2e.yml
+++ b/.github/workflows/trigger-upgrade-e2e.yml
@@ -1,0 +1,39 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Trigger Upgrade E2E
+
+on:
+  workflow_dispatch:
+    inputs:
+      pipeline-branch:
+        description: "CircleCI pipeline branch"
+        required: false
+        default: ""
+        type: string
+jobs:
+  trigger-upgrade-test-suite:
+    runs-on: ubuntu-latest
+    env:
+      CIRCLECI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
+      PIPELINE_BRANCH: ${{ inputs.pipeline-branch }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: "Trigger upgrade E2E pipeline"
+        run: |
+          echo "🧪 Triggering upgrade E2E test pipeline"
+          npx zx hack/scripts/trigger-upgrade-e2e-test.mjs --notify true --pipeline-branch ${PIPELINE_BRANCH}

--- a/hack/scripts/trigger-upgrade-e2e-test.mjs
+++ b/hack/scripts/trigger-upgrade-e2e-test.mjs
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { triggerPipeline } from "./lib/circleci.mjs";
+
+import { toggleVerbosity, LOG } from "./lib/index.mjs";
+
+const VERBOSE = argv.verbose;
+const PIPELINE_BRANCH = argv["pipeline-branch"];
+const NOTIFY = argv["notify"] === "true" || argv["notify"] === true;
+
+toggleVerbosity(VERBOSE);
+
+LOG.blue(`Triggering upgrade E2E test pipeline`);
+
+const parameters = {
+  trigger: "upgrade-e2e",
+  notify: NOTIFY,
+};
+
+LOG.blue(`
+  Parameters: ${JSON.stringify(parameters)},
+`);
+
+const pipelineURL = await triggerPipeline(parameters, PIPELINE_BRANCH);
+
+LOG.blue(`Pipeline is running at ${pipelineURL}`);

--- a/test/platform-test/e2e/README.md
+++ b/test/platform-test/e2e/README.md
@@ -201,7 +201,7 @@ npm --prefix test/platform-test run e2e -- --provision-with gko --run-up-to-vers
 
 # Upgrade APIM to 4.12 in place (Mongo preserved), then regress on 4.12.
 gck patch --config test/platform-test/gck.yaml --name gravitee \
-  --set imageTag=master-latest --set 'helmVersion=>=4.12.0-0 <4.13.0-0'
+  --set imageTag=4.12.x-latest --set 'helmVersion=>=4.12.0-0 <4.13.0-0'
 npm --prefix test/platform-test run e2e -- --provision-with gko --run-up-to-version 4.12
 ```
 


### PR DESCRIPTION
## Summary

The before/after-upgrade e2e lane (`job-e2e-upgrade-tests`) runs the full
GKO suite twice across an in-place APIM upgrade. Two problems:

1. Its **after-upgrade phase is red** — all `mtls-certificates` tests time
   out under the 2nd-pass cumulative load (every non-mTLS test passes).
   Root cause is under investigation in GKO-2980; it is **not** the
   `@since-4.12` gate (that only skips tests — it just unblocked the 4.11
   phase so the after-upgrade phase ran for the first time and revealed it).
2. It is **resource-heavy** and ran on every merge, so it both burned CI
   and kept master red.

This PR:

- **Moves the upgrade lane off post-merge to an on-demand trigger**
  (implements GKO-2979): a new `upgrade-e2e` pipeline trigger + an
  `upgrade-e2e-test` workflow gated on it, a "Trigger Upgrade E2E" GitHub
  Action, and `hack/scripts/trigger-upgrade-e2e-test.mjs`. Run it from the
  Actions tab, like "Trigger E2E". Post-merge e2e is now the single-pass
  `job-e2e-tests` only.
- **Fixes the upgrade target**: `master-latest` → `4.12.x-latest`, so it is
  a real 4.11 → 4.12 release-line upgrade matching the 4.12 chart
  constraint (was a moving nightly that would silently become 4.13 once
  master branches).

This makes post-merge green by removing the heavy lane from it; the mTLS
after-upgrade failure itself is tracked separately in GKO-2980, so manual
upgrade runs stay red until that is fixed.

Related: GKO-1898, GKO-2979, GKO-2980
