### PR TITLE
test(platform-test): deepen upgrade survival checks

### DIFF
--- a/test/platform-test/e2e/fixtures/upgrade/api-legacy-updated.yaml
+++ b/test/platform-test/e2e/fixtures/upgrade/api-legacy-updated.yaml
@@ -47,6 +47,26 @@ spec:
           secondary: false
   analytics:
     enabled: true
+  flowExecution:
+    mode: DEFAULT
+    matchRequired: false
+  # Same response policy as api-legacy.yaml - kept here so the post-upgrade
+  # description update does not drop the carried-over policy.
+  flows:
+    - name: "Stamp survivor header"
+      enabled: true
+      selectors:
+        - type: HTTP
+          path: "/"
+          pathOperator: STARTS_WITH
+      response:
+        - name: "Transform Headers"
+          enabled: true
+          policy: transform-headers
+          configuration:
+            addHeaders:
+              - name: "X-Upgrade-Survivor"
+                value: "legacy-api"
   plans:
     JWT:
       name: "JWT plan"

--- a/test/platform-test/e2e/fixtures/upgrade/api-legacy-with-mtls.yaml
+++ b/test/platform-test/e2e/fixtures/upgrade/api-legacy-with-mtls.yaml
@@ -43,6 +43,23 @@ spec:
   flowExecution:
     mode: DEFAULT
     matchRequired: false
+  # Same response policy as api-legacy.yaml - kept here so adding the mTLS plan
+  # does not drop the carried-over policy.
+  flows:
+    - name: "Stamp survivor header"
+      enabled: true
+      selectors:
+        - type: HTTP
+          path: "/"
+          pathOperator: STARTS_WITH
+      response:
+        - name: "Transform Headers"
+          enabled: true
+          policy: transform-headers
+          configuration:
+            addHeaders:
+              - name: "X-Upgrade-Survivor"
+                value: "legacy-api"
   plans:
     JWT:
       name: "JWT plan"

--- a/test/platform-test/e2e/fixtures/upgrade/api-legacy.yaml
+++ b/test/platform-test/e2e/fixtures/upgrade/api-legacy.yaml
@@ -44,6 +44,27 @@ spec:
           secondary: false
   analytics:
     enabled: true
+  flowExecution:
+    mode: DEFAULT
+    matchRequired: false
+  # An API-level response policy. The survival check asserts this policy is still
+  # part of the API definition after the upgrade (the "policies survive" dimension),
+  # alongside the plan, analytics and endpoint configuration.
+  flows:
+    - name: "Stamp survivor header"
+      enabled: true
+      selectors:
+        - type: HTTP
+          path: "/"
+          pathOperator: STARTS_WITH
+      response:
+        - name: "Transform Headers"
+          enabled: true
+          policy: transform-headers
+          configuration:
+            addHeaders:
+              - name: "X-Upgrade-Survivor"
+                value: "legacy-api"
   plans:
     JWT:
       name: "JWT plan"

--- a/test/platform-test/e2e/helpers/tags.ts
+++ b/test/platform-test/e2e/helpers/tags.ts
@@ -49,6 +49,8 @@ export const XRAY = {
     V4_SURVIVES_UPGRADE: "@GKO-1061",
     V2_SURVIVES_UPGRADE: "@GKO-1060",
     V4_RECONCILE_CYCLE_SURVIVES: "@GKO-2984",
+    // Placeholder - synced to a real Jira Test by /xray-sync-tests.
+    DATASTORE_SURVIVES_UPGRADE: "@GKO-TBD-datastore-survives-upgrade",
     START_STOP_V2_V4_NATIVE: "@GKO-1464",
     POLICY_ON_API_WITHOUT_PLANS: "@GKO-1465",
     ENTRYPOINT_POLICY_MATRIX: "@GKO-1474",

--- a/test/platform-test/e2e/tests/upgrade/survival-scenario.ts
+++ b/test/platform-test/e2e/tests/upgrade/survival-scenario.ts
@@ -45,6 +45,18 @@ export const SURVIVAL = {
 } as const;
 
 /**
+ * Shared constants for the datastore-continuity check: the before-phase records
+ * the MongoDB pod identity into a ConfigMap, the after-phase reads it back and
+ * asserts the same pod survived the in-place upgrade (it was neither replaced nor
+ * restarted). The pod is matched by name substring so the check does not depend
+ * on the cluster recipe's MongoDB labels.
+ */
+export const DATASTORE = {
+  podNamePattern: "mongo",
+  stateConfigMap: "upgrade-survival-datastore",
+} as const;
+
+/**
  * Factory for the survival scenario's GKO provisioner. Both phases call this to
  * get a provisioner bound to the same CRs: the before-phase calls `provision()`,
  * the after-phase calls `attach()` (rebuilding the handle from the still-present

--- a/test/platform-test/e2e/tests/upgrade/survival.after.spec.ts
+++ b/test/platform-test/e2e/tests/upgrade/survival.after.spec.ts
@@ -36,6 +36,7 @@ import * as kubectl from "../../helpers/kubectl.js";
 import { signJwt } from "../../helpers/jwt.js";
 import { createTlsFetch } from "../../../src/utils/http/tls.js";
 import { compareVersions } from "../../../src/utils/version/index.js";
+import type { ApiV4 } from "../../../src/types/apim.js";
 import { XRAY } from "../../helpers/tags.js";
 import {
   survivalScenario,
@@ -100,6 +101,55 @@ test(`upgrade survival: reconnect, verify, update, delete on the new line ${XRAY
     await mapi.assertSubscriptionAccepted(apiId, subId);
     // Still reachable through the gateway after the operator + APIM upgrade.
     await gateway.assertResponds(ctx, { status: 401 });
+    await gateway.assertResponds(ctx, { status: 200, headers: bearer() });
+  });
+
+  await test.step("the carried-over API kept its full configuration", async () => {
+    // Survival is more than "still answers 200": the API's whole definition must
+    // come through the data migration intact. Assert the core fields, the plan,
+    // and the policy - a dropped plan, flipped origin, or lost policy would slip
+    // past a reachability-only check.
+    await mapi.assertApiMatches(apiId, {
+      name: SURVIVAL.apiName,
+      apiVersion: "1.0",
+      definitionVersion: "V4",
+      type: "PROXY",
+      analytics: { enabled: true },
+      originContext: { origin: "KUBERNETES" },
+      // APIM normalises the context path with a trailing slash.
+      listeners: [{ type: "HTTP", paths: [{ path: `${SURVIVAL.contextPath}/` }] }],
+      endpointGroups: [{ endpoints: [{ configuration: { target: "https://api.gravitee.io/echo" } }] }],
+    });
+
+    // Exactly one plan survived, still JWT and still PUBLISHED.
+    const plans = await mapi.listApiPlans(apiId);
+    expect(plans).toHaveLength(1);
+    expect(plans[0]).toMatchObject({ status: "PUBLISHED", security: { type: "JWT" } });
+
+    // The transform-headers policy is still part of the API definition.
+    const api = (await mapi.fetchApi(apiId)) as ApiV4;
+    const policies = (api.flows ?? []).flatMap((f) => f.response ?? []).map((s) => s.policy);
+    expect(policies).toContain("transform-headers");
+  });
+
+  await test.step("the new operator does not churn the carried-over API", async () => {
+    // Re-applying the UNCHANGED 4.11 manifest on the new operator must be a no-op:
+    // an identical spec must not bump metadata.generation. A bump means the new
+    // operator's admission/defaulting diverged from the old one, which would churn
+    // every carried-over resource on the first reconcile after an upgrade.
+    const generation = () =>
+      kubectl.getField<number>("apiv4definition", SURVIVAL.apiName, "{.metadata.generation}");
+    const genBefore = Number(await generation());
+
+    await kubectl.apply(fixture("upgrade/api-legacy.yaml"));
+    await kubectl.waitForCondition("apiv4definition", SURVIVAL.apiName, "Accepted");
+
+    expect(
+      Number(await generation()),
+      "an identical re-apply must not bump metadata.generation (operator churn)",
+    ).toBe(genBefore);
+    // Ownership stayed with Kubernetes and the data plane was not disrupted.
+    await mapi.assertApiMatches(apiId, { originContext: { origin: "KUBERNETES" } });
     await gateway.assertResponds(ctx, { status: 200, headers: bearer() });
   });
 
@@ -197,6 +247,16 @@ test(`upgrade survival (V2): keyless V2 API survives the upgrade ${XRAY.API_LIFE
 
   await test.step("V2 API survived the upgrade (control plane + gateway)", async () => {
     await mapi.assertApiHttpStatus(apiId, 200); // still present in the management API
+    // Its definition came through intact: still a Kubernetes-owned V2 API with
+    // its keyless plan, not just a reachable context path.
+    await mapi.assertApiMatches(apiId, {
+      name: SURVIVAL_V2.apiName,
+      definitionVersion: "V2",
+      originContext: { origin: "KUBERNETES" },
+    });
+    const plans = await mapi.listApiPlans(apiId);
+    expect(plans).toHaveLength(1);
+    expect(plans[0]).toMatchObject({ status: "PUBLISHED", security: { type: "KEY_LESS" } });
     await gateway.assertResponds(ctx, { status: 200 });
   });
 

--- a/test/platform-test/e2e/tests/upgrade/survival.after.spec.ts
+++ b/test/platform-test/e2e/tests/upgrade/survival.after.spec.ts
@@ -45,6 +45,7 @@ import {
   SURVIVAL_V2,
   survivalV2SubScenario,
   SURVIVAL_V2_SUB,
+  DATASTORE,
 } from "./survival-scenario.js";
 
 /**
@@ -71,6 +72,37 @@ test.afterAll(async () => {
   for (const f of order) {
     await kubectl.del(fixture(`upgrade/${f}.yaml`)).catch(() => {});
   }
+  await kubectl.deleteResource("configmap", DATASTORE.stateConfigMap).catch(() => {});
+});
+
+// Runs FIRST, on purpose: it reads the before-phase snapshot ConfigMap, which the
+// afterAll deletes. Playwright restarts the worker after a test failure (firing the
+// file-scoped afterAll early), so a later API-survival failure would otherwise wipe
+// the snapshot and make this skip. Ordering it before the API tests keeps it
+// independent of their outcome.
+test(`upgrade survival: the datastore survived the upgrade in place ${XRAY.API_LIFECYCLE.DATASTORE_SURVIVES_UPGRADE} @upgrade @after`, async () => {
+  // The whole survival check rests on APIM's data surviving the upgrade, which
+  // lives in MongoDB. This proves the upgrade was truly in-place: the same Mongo
+  // pod recorded by the before-phase is still here, neither replaced (same uid)
+  // nor restarted (same restartCount). A wiped or rolled datastore that APIM
+  // happened to re-seed would still pass the reachability checks but is a real
+  // upgrade defect this catches.
+  const recorded = await kubectl.readConfigMap(DATASTORE.stateConfigMap);
+  test.skip(
+    recorded === null,
+    `no datastore snapshot (ConfigMap ${DATASTORE.stateConfigMap}) from the before-phase`,
+  );
+  if (recorded === null) return; // narrow for the type-checker (test.skip already bailed)
+
+  const current = await kubectl.findPod(DATASTORE.podNamePattern);
+  if (current === null) {
+    throw new Error("the MongoDB pod recorded before the upgrade is gone");
+  }
+  expect(current.uid, "the MongoDB pod was replaced during the upgrade").toBe(recorded["uid"]);
+  expect(
+    current.restartCount,
+    "the MongoDB container restarted during the upgrade",
+  ).toBe(Number(recorded["restartCount"]));
 });
 
 test(`upgrade survival: reconnect, verify, update, delete on the new line ${XRAY.API_LIFECYCLE.V4_SURVIVES_UPGRADE} @upgrade @after`, async ({

--- a/test/platform-test/e2e/tests/upgrade/survival.before.spec.ts
+++ b/test/platform-test/e2e/tests/upgrade/survival.before.spec.ts
@@ -28,8 +28,9 @@
  */
 
 import { test } from "../../setup.js";
+import * as kubectl from "../../helpers/kubectl.js";
 import { signJwt } from "../../helpers/jwt.js";
-import { survivalScenario, survivalV2Scenario } from "./survival-scenario.js";
+import { DATASTORE, survivalScenario, survivalV2Scenario } from "./survival-scenario.js";
 
 test("upgrade survival: provision and verify on the old line @upgrade @before", async ({
   mapi,
@@ -65,4 +66,26 @@ test("upgrade survival (V2): keyless V2 API reachable on the old line @upgrade @
   // provision() already waited for the V2 API CR to reconcile (Accepted); the
   // keyless plan means the gateway serves it without a token. Leave it running.
   await gateway.assertResponds(ctx, { status: 200 });
+});
+
+test("upgrade survival: record the datastore identity before the upgrade @upgrade @before", async () => {
+  // Snapshot the MongoDB pod's identity so the after-phase can prove the same
+  // pod survived the in-place upgrade (the APIM data lives there). Recorded in a
+  // ConfigMap because the two phases run in separate processes and only share
+  // state through the cluster. If no MongoDB pod is found, record nothing - the
+  // after-phase then skips rather than failing on a cluster shaped differently.
+  const mongo = await kubectl.findPod(DATASTORE.podNamePattern);
+  if (!mongo) {
+    console.warn(
+      `[upgrade] no pod matching "${DATASTORE.podNamePattern}" found; ` +
+        "skipping datastore-continuity recording",
+    );
+    return;
+  }
+  await kubectl.writeConfigMap(DATASTORE.stateConfigMap, {
+    uid: mongo.uid,
+    restartCount: String(mongo.restartCount),
+    name: mongo.name,
+    namespace: mongo.namespace,
+  });
 });

--- a/test/platform-test/src/provisioners/engines/kubectl.ts
+++ b/test/platform-test/src/provisioners/engines/kubectl.ts
@@ -254,6 +254,83 @@ export async function waitForRollout(
   );
 }
 
+/** Identity + restart counters for a single pod, used by the upgrade survival check. */
+export interface PodInfo {
+  name: string;
+  namespace: string;
+  /** Pod object uid - changes if the pod is replaced (e.g. a StatefulSet rollout). */
+  uid: string;
+  /** Sum of container restartCounts - increases if a container restarts in place. */
+  restartCount: number;
+  creationTimestamp: string;
+}
+
+/**
+ * Find the first pod whose name CONTAINS `namePattern`, across all namespaces
+ * (or a single one when `namespace` is given). Returns null if none match.
+ *
+ * Matching by name substring rather than a label keeps the datastore-continuity
+ * check independent of how a given cluster recipe labels its MongoDB pod.
+ */
+export async function findPod(
+  namePattern: string,
+  namespace?: string,
+): Promise<PodInfo | null> {
+  const scope = namespace ? ["-n", namespace] : ["--all-namespaces"];
+  const { stdout } = await run(["get", "pods", ...scope, "-o", "json"]);
+  const list = JSON.parse(stdout) as {
+    items: Array<{
+      metadata: { name: string; namespace: string; uid: string; creationTimestamp: string };
+      status?: { containerStatuses?: Array<{ restartCount?: number }> };
+    }>;
+  };
+  const pod = list.items.find((p) => p.metadata.name.includes(namePattern));
+  if (!pod) return null;
+  const restartCount = (pod.status?.containerStatuses ?? []).reduce(
+    (sum, c) => sum + (c.restartCount ?? 0),
+    0,
+  );
+  return {
+    name: pod.metadata.name,
+    namespace: pod.metadata.namespace,
+    uid: pod.metadata.uid,
+    restartCount,
+    creationTimestamp: pod.metadata.creationTimestamp,
+  };
+}
+
+/**
+ * Create (or overwrite) a ConfigMap carrying a small string map. Used to hand a
+ * snapshot from the before-phase to the after-phase of the upgrade survival
+ * check - a plain ConfigMap persists untouched across an in-place APIM upgrade.
+ */
+export async function writeConfigMap(
+  name: string,
+  data: Record<string, string>,
+  namespace = NAMESPACE,
+): Promise<void> {
+  const body = [
+    "apiVersion: v1",
+    "kind: ConfigMap",
+    "metadata:",
+    `  name: ${name}`,
+    "data:",
+    ...Object.entries(data).map(([k, v]) => `  ${k}: ${JSON.stringify(v)}`),
+    "",
+  ].join("\n");
+  await applyString(body, namespace);
+}
+
+/** Read a ConfigMap's `data` map, or null if the ConfigMap does not exist. */
+export async function readConfigMap(
+  name: string,
+  namespace = NAMESPACE,
+): Promise<Record<string, string> | null> {
+  if (!(await exists("configmap", name, namespace))) return null;
+  const cm = await get<{ data?: Record<string, string> }>("configmap", name, namespace);
+  return cm.data ?? {};
+}
+
 /** Apply a YAML string via stdin (useful for dynamically generated manifests). */
 export async function applyString(
   yamlContent: string,


### PR DESCRIPTION
Deepens the upgrade survival check (#1708) so "survived" means the resource
actually came through the upgrade intact, not just that the gateway still
answers 200.

Three checks across the before/after phases:

- The carried-over API keeps its full config (plans, policy, analytics,
  Kubernetes origin), not just a reachable path.
- The MongoDB pod survives the upgrade in place (same pod, no restart), so a
  datastore that got wiped and re-seeded would be caught.
- Re-applying the unchanged old manifest on the new operator doesn't churn the
  resource (no generation bump).

Verified locally with a full before/after run; split into a fidelity/no-churn
commit and a datastore commit.
