### PR TITLE
test: raise integration gateway memory limit to avoid OOM

### DIFF
--- a/hack/kind/apim/values-dbless.yaml
+++ b/hack/kind/apim/values-dbless.yaml
@@ -33,7 +33,12 @@ ratelimit:
     none
 
 gateway:
-  managedServixceAccount: false
+  managedServiceAccount: false
+  resources:
+    requests:
+      memory: 512Mi
+    limits:
+      memory: 1Gi
   image:
     repository: gravitee-apim-gateway
     tag: dev

--- a/hack/kind/apim/values.yaml
+++ b/hack/kind/apim/values.yaml
@@ -70,6 +70,11 @@ portal:
 
 gateway:
   managedServiceAccount: false
+  resources:
+    requests:
+      memory: 512Mi
+    limits:
+      memory: 1Gi
   deployment:
     serviceAccount: gravitee-gateway
   image:


### PR DESCRIPTION
## Summary

The APIM gateway in the integration test cluster runs with the
chart-default **512Mi** memory limit. Its working set (anon RSS) peaks at
**~526Mi** during the `apiresource` `withContext` suite, so the kernel
**OOMKills** it mid-suite (`exit 137`, `reason: OOMKilled`). The restart
surfaces in the tests as `read: connection reset by peer` on the gateway
NodePort (`:30082`), failing whichever spec is in flight; a second spec in
the same run typically flakes. The failing spec name varies run to run
(redis / keycloak / ldap / inline-auth) because it is the OOM, not the
spec, that fails.

This is a sizing issue, not a test or gateway-code bug: the gateway idles
at ~460Mi anon (90% of the 512Mi cap) and has no headroom for the resource
plugins (Keycloak, LDAP, OAuth2, redis cache) the suite loads.

### Change
Set the gateway memory `request` to `512Mi` and `limit` to `1Gi`. CPU is
left at the chart defaults via Helm value coalescing (verified: the
rendered deployment keeps `cpu 200m/500m`).

### Verified locally
Single-variable A/B on a kind cluster with the exact CI image
(`master-latest`), full `withContext` lane both times:

| | anon peak | oom_kill | restarts | suite |
|---|---|---|---|---|
| 512Mi (before) | rode the cap (`memory.peak == 512Mi`) | edge | passed by luck | flaky |
| 1Gi (after) | 526.6Mi (fits, ~470Mi spare) | 0 | 0 | passed |