### PR TITLE
test: cross-provisioner dictionary parity scenario + parity docs

### DIFF
--- a/test/platform-test/AGENTS.md
+++ b/test/platform-test/AGENTS.md
@@ -168,6 +168,33 @@ Rules of thumb:
   `pending: { terraform: "<reason or tracking ref>" }` and renders as a visible `test.fixme`, never a
   silent skip. A provisioner simply absent from `provisioners`/`pending` emits nothing (N/A by design).
 
+### Adding a cross-provisioner parity scenario
+
+The provisioner layer is how we close GKO↔Terraform coverage gaps. The current
+status and the prioritised backlog live in [PARITY.md](./PARITY.md) — pick a row there.
+
+1. **Confirm the resource exists on both drivers.** GKO has a CRD for it; the Terraform
+   provider must expose a matching resource (registry README lists `apim_apiv4`,
+   `apim_application`, `apim_subscription`, `apim_group`, `apim_dictionary`,
+   `apim_shared_policy_group`). If Terraform can't express it, leave the area GKO-only
+   in PARITY.md and move on.
+2. **Author one shared intent**, not two tests. Reuse the existing GKO fixtures; add a
+   sibling `main.tf` under the same `fixtures/<domain>/<scenario>/` folder.
+3. **Verify through a provisioner-agnostic invariant** — `mapi.*` (e.g. the resource
+   lands with `origin: KUBERNETES`) or `gateway` (data-plane resolution). The body must
+   not branch on `provisionerId` for the shared assertion.
+4. **De-dup:** once the GKO arm covers what a standalone GKO test did, **remove that
+   test from the `*-gko-only` / per-driver file** (keep its Xray id on the scenario's
+   GKO arm) so it does not run twice. Leave genuinely GKO-only behaviour in place.
+5. **Tag & sync:** each arm carries its own Xray id; add a `@GKO-TBD-*` placeholder for
+   the new driver in `helpers/tags.ts`, then run `/xray-sync-tests` to file the real
+   Jira Test. Update the PARITY.md row.
+
+Worked examples: `tests/scenarios/subscriptions/apikey/` (parameterized, `params.ts` +
+`*-only` files) and `tests/scenarios/dictionaries/dictionary.scenario.ts` (param-free,
+gateway-resolution — the dictionary value is injected by a `transform-headers` flow and
+asserted in the echo response; the TF arm proves an inline `flows` block is authorable).
+
 ## Polling & eventual consistency
 
 Both `kubectl apply` (GKO) and `terraform apply` (provider) return before

--- a/test/platform-test/PARITY.md
+++ b/test/platform-test/PARITY.md
@@ -1,0 +1,119 @@
+# GKO ↔ Terraform e2e test parity
+
+Status of e2e coverage across the two provisioners the suite drives: the **GKO**
+operator (Kubernetes CRs) and the **Terraform** APIM provider (`gravitee-io/apim`).
+This is the analysis deliverable for GKO-2907 and the living backlog for GKO-2918.
+
+> Counts are regenerated from the tree, not hand-maintained. As of **2026-06-29**:
+> `tests/gko/` = **310** `test()` blocks across 21 areas, `tests/terraform/` = **20**,
+> `tests/scenarios/` = **11** cross-provisioner scenarios (→ 22 runtime tests) + 7
+> driver-specific = **29** runtime tests. Re-count with the snippet at the bottom.
+
+We do **not** want full parity. A large share of GKO coverage exercises
+Kubernetes-only mechanics (admission, status conditions, templating, operator
+restart) that have no Terraform equivalent, and Terraform has its own surface
+(drift, redaction, plan exit codes). Parity means: **the APIM resources every
+customer touches should be exercised through both drivers**, preferably once, as a
+shared scenario in the provisioner layer (`tests/scenarios/`).
+
+---
+
+## The provisioner layer (where parity lives)
+
+A shared scenario is authored once and run against every provisioner via
+`forEachProvisioner` (`e2e/helpers/for-each-provisioner.ts`) with
+`gkoScenario()` / `tfScenario()` (`e2e/helpers/provisioner-env.ts`). The body is
+provisioner-agnostic (`provisioned` + `mapi`/`gateway`); each arm carries its own
+Xray id. See the worked example + authoring guide in
+[AGENTS.md](./AGENTS.md#adding-a-cross-provisioner-parity-scenario).
+
+Today only **subscriptions/apikey** (10 scenarios), **groups** (1), and
+**dictionaries** (1, this change) live there. Everything else is per-driver.
+
+---
+
+## Parity matrix (APIM resources — parity candidates)
+
+| Feature area | GKO `tests/gko` | TF `tests/terraform` | Scenario layer | Status |
+|---|---:|---:|---|---|
+| V4/V2 API lifecycle (start/stop, visibility) | 37 | 1 (post-apply create) | — | ❌ gap |
+| Applications (CRUD + members) | 26 | 1 (delete) | — | ❌ gap |
+| Subscriptions — api-key | 25 | 2 (errors) | ✅ apikey (10) | 🟢 done via scenario |
+| Subscriptions — other plan types | (incl. above) | 0 | — | ❌ gap |
+| Plans & policies | 10 | 1 (general conditions) | — | ❌ gap |
+| Groups + members | 5 | 13 | ✅ groups (1) | 🟡 TF-led; scenario covers create |
+| Categories & labels | 10 | 0 | — | ❌ gap |
+| **Dictionaries** | 7 | 1 (new) | ✅ dictionary (1) | 🟡 in progress (GKO-2997) |
+| Pages / documentation | 25 | ~1 (hierarchy) | — | ❌ gap |
+| Shared Policy Groups | 4 | 0 | — | ❌ gap |
+| Notifications | 11 | 0 | — | ❌ gap |
+| Message APIs (V4) | 9 | 0 | — | ❌ gap |
+| Analytics | 1 | 0 | — | ❌ gap |
+
+Legend: ✅ covered · 🟢 parity met · 🟡 partial / in progress · ❌ no TF coverage.
+
+---
+
+## Intentionally GKO-only (no Terraform parity expected)
+
+These exercise Kubernetes/operator mechanics the Terraform provider has no concept
+of. They stay in `tests/gko/` and are **out of scope** for parity.
+
+| Area | `tests/gko` | Why GKO-only |
+|---|---:|---|
+| Admission webhooks | 27 | CRD schema/dry-run validation at the K8s admission layer |
+| Deployment & reconciliation | 15 | CR `.status` conditions, observedGeneration, operator restart |
+| mTLS certificates (Application CRs) | 29 | Secret-backed Application TLS settings resolved from the cluster |
+| Import / export | 10 | YAML CRD export/import round-trips |
+| ConfigMap/Secret templating | 8 | `{{ … }}` resolution from cluster ConfigMaps/Secrets |
+| ManagementContext CRD | 5 | Kubernetes custom resource lifecycle |
+| CRD defaults | 4 | CRD spec field defaulting |
+| Local ConfigMap | 2 | In-cluster ConfigMap locality/cleanup |
+
+## Intentionally Terraform-only (no GKO parity expected)
+
+| Behaviour | Where | Why TF-only |
+|---|---|---|
+| Drift detection | `terraform plan` / group drift | HCL desired-state vs server reconciliation |
+| Sensitive redaction | apikey sensitive-in-plan | provider `Sensitive` attribute handling |
+| Plan exit codes / idempotency | post-apply, group import | `terraform plan -detailed-exitcode` semantics |
+
+---
+
+## Parity backlog (GKO-2918 follow-up scope)
+
+Prioritised by customer impact × effort. **This change delivers dictionaries only;
+the rest is explicitly deferred to future tickets**, tracked here.
+
+| # | Area | Approx. new TF/scenario tests | Notes | Status |
+|---|---|---:|---|---|
+| 1 | **Dictionaries** | 1+ | MANUAL resolve via gateway. Pattern reference. | 🟡 this change (GKO-2997) |
+| 2 | Applications (CRUD + members) | ~6 | `apim_application` exists; mirror app lifecycle | ⏳ future ticket |
+| 3 | Categories & labels | ~4 | check provider resource availability first | ⏳ future ticket |
+| 4 | Plans (keyless, JWT, OAuth2, mTLS) | ~6 | `apim_apiv4.plans[]` already used | ⏳ future ticket |
+| 5 | V4/V2 API lifecycle (start/stop, visibility) | ~6 | extend `post-apply` into scenarios | ⏳ future ticket |
+| 6 | Shared Policy Groups | ~4 | `apim_shared_policy_group` exists in provider | ⏳ future ticket |
+| 7 | Pages / documentation | ~6 | provider page/doc resources | ⏳ future ticket |
+| 8 | Notifications | ~4 | confirm provider support | ⏳ future ticket |
+| 9 | Message APIs (V4) | ~4 | confirm provider support | ⏳ future ticket |
+
+When picking up a backlog row, prefer **migrating the GKO test into a shared
+scenario** (one intent, two arms) over writing a standalone TF test, and follow the
+de-dup rule (remove the now-shared assertion from the GKO-only file). Confirm the
+provider exposes the resource first — the registry README lists `apim_apiv4`,
+`apim_application`, `apim_subscription`, `apim_group`, `apim_dictionary`,
+`apim_shared_policy_group`.
+
+---
+
+## Re-generating the counts
+
+```sh
+cd test/platform-test/e2e/tests
+# per-area GKO counts
+for d in gko/*/; do printf "%-32s %s\n" "$d" \
+  "$(grep -rhoE '\btest(\.(skip|fixme|only))?\(' "$d" --include='*.ts' | wc -l)"; done
+# TF + scenario totals
+grep -rhoE '\btest(\.(skip|fixme|only))?\(' terraform --include='*.ts' | wc -l
+grep -rhoE 'forEachProvisioner(<[^>]*>)?\(' scenarios --include='*.ts' | wc -l   # ×2 drivers
+```

--- a/test/platform-test/e2e/fixtures/dictionaries/manual-resolve/main.tf
+++ b/test/platform-test/e2e/fixtures/dictionaries/manual-resolve/main.tf
@@ -1,0 +1,157 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Terraform arm of the cross-provisioner `dictionaries/manual-resolve` scenario:
+# a MANUAL dictionary plus a keyless API whose transform-headers flow injects the
+# dictionary value into a response header. The shared scenario body asserts the
+# gateway resolves `{#dictionaries['<hrid>']['env']}` to "test". Mirrors the GKO
+# arm (fixtures/dictionaries/{dictionary-manual,api-with-dictionary}/crd.yaml).
+terraform {
+  required_providers {
+    apim = {
+      source = "gravitee-io/apim"
+    }
+  }
+}
+
+provider "apim" {}
+
+variable "environment_id" {
+  type    = string
+  default = "DEFAULT"
+}
+
+variable "organization_id" {
+  type    = string
+  default = "DEFAULT"
+}
+
+variable "hrid_suffix" {
+  type    = string
+  default = "resolve"
+}
+
+resource "apim_dictionary" "dict" {
+  environment_id  = var.environment_id
+  organization_id = var.organization_id
+  hrid            = "e2e-tf-dict-${var.hrid_suffix}"
+  name            = "e2e-tf-dict-${var.hrid_suffix}"
+  description     = "E2E test: TF MANUAL dictionary resolved at the gateway"
+  type            = "MANUAL"
+  deployed        = true
+  manual = {
+    properties = {
+      env = "test"
+    }
+  }
+}
+
+resource "apim_apiv4" "api" {
+  environment_id  = var.environment_id
+  organization_id = var.organization_id
+  hrid            = "e2e-tf-dictapi-${var.hrid_suffix}"
+  name            = "e2e-tf-dictapi-${var.hrid_suffix}"
+  description     = "E2E test: API injecting a dictionary value via transform-headers"
+  version         = "1"
+  type            = "PROXY"
+  state           = "STARTED"
+  lifecycle_state = "PUBLISHED"
+  visibility      = "PRIVATE"
+
+  listeners = [
+    {
+      http = {
+        type = "HTTP"
+        paths = [
+          { path = "/e2e-tf-dictapi-${var.hrid_suffix}" }
+        ]
+        entrypoints = [
+          { type = "http-proxy" }
+        ]
+      }
+    }
+  ]
+
+  endpoint_groups = [
+    {
+      name = "Default HTTP proxy group"
+      type = "http-proxy"
+      endpoints = [
+        {
+          name                  = "default-endpoint"
+          type                  = "http-proxy"
+          inherit_configuration = false
+          configuration         = jsonencode({ target = "https://api.gravitee.io/echo" })
+        }
+      ]
+    }
+  ]
+
+  flow_execution = {
+    mode           = "DEFAULT"
+    match_required = false
+  }
+
+  # Inject the dictionary value into a request header the echo endpoint reflects.
+  # The EL key is the dictionary HRID (APIM keys deployed dictionaries by HRID).
+  flows = [
+    {
+      enabled = true
+      name    = "Add dictionary header"
+      selectors = [
+        {
+          http = {
+            type          = "HTTP"
+            path          = "/"
+            path_operator = "STARTS_WITH"
+          }
+        }
+      ]
+      request = [
+        {
+          enabled = true
+          name    = "Transform Headers"
+          policy  = "transform-headers"
+          configuration = jsonencode({
+            addHeaders = [
+              {
+                name  = "X-Dict-Env"
+                value = "{#dictionaries['${apim_dictionary.dict.hrid}']['env']}"
+              }
+            ]
+          })
+        }
+      ]
+    }
+  ]
+
+  plans = [
+    {
+      hrid     = "keyless"
+      name     = "Free plan"
+      type     = "API"
+      mode     = "STANDARD"
+      status   = "PUBLISHED"
+      security = { type = "KEY_LESS" }
+    }
+  ]
+}
+
+output "api_id" {
+  value = apim_apiv4.api.id
+}
+
+output "api_context_path" {
+  value = "/e2e-tf-dictapi-${var.hrid_suffix}"
+}

--- a/test/platform-test/e2e/helpers/tags.ts
+++ b/test/platform-test/e2e/helpers/tags.ts
@@ -456,6 +456,9 @@ export const XRAY = {
     GROUP_INVALID_HRID: "@GKO-2876",
     GROUP_INVALID_NAME: "@GKO-2877",
     GROUP_DATA_SOURCE: "@GKO-2878",
+    // ── GKO-2997: apim_dictionary resource (TF parity with the GKO Dictionary CRD) ──
+    // @parent: GKO-2997
+    DICTIONARY_MANUAL_RESOLVE: "@GKO-2998",
   },
   PAGES: {
     MARKDOWN_PAGE_CRUD_V4: "@GKO-277",

--- a/test/platform-test/e2e/tests/gko/dictionaries/dictionary-lifecycle.test.ts
+++ b/test/platform-test/e2e/tests/gko/dictionaries/dictionary-lifecycle.test.ts
@@ -18,10 +18,13 @@
  * Dictionaries Lifecycle tests.
  *
  * Xray tests:
- *   GKO-2903: Create a manual dictionary and verify resolution in API response
  *   GKO-2904: Create a dynamic dictionary and verify resolution in API response
  *   GKO-2905: Delete a dictionary
  *   GKO-2912: Admission webhook rejects DYNAMIC dictionary with manual field set
+ *
+ * GKO-2903 (manual dictionary resolved at the gateway) is now the GKO arm of the
+ * cross-provisioner scenario tests/scenarios/dictionaries/dictionary.scenario.ts,
+ * so it is intentionally not duplicated here.
  *
  * Preconditions:
  *   - APIM, Gateway, and GKO operator are running
@@ -38,8 +41,6 @@ import { fileURLToPath } from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const DICT_NAME = "e2e-dict-manual";
-const API_NAME = "e2e-api-with-dict";
-const API_PATH = "/e2e-api-with-dict";
 
 async function gatewayBaseUrl(): Promise<string> {
   const config = await loadGraviteeConfig(path.resolve(__dirname, "../../../../config.yaml"));
@@ -58,45 +59,6 @@ test.describe("Dictionaries — Lifecycle @since-4.12", () => {
     ]) {
       await kubectl.del(fixture(f)).catch(() => {});
     }
-  });
-
-  test(`Create dictionary and resolve in API header ${XRAY.DICTIONARIES.CREATE_AND_RESOLVE} ${TAGS.REGRESSION}`, async ({
-    kubectl,
-  }) => {
-    const dictFixture = fixture("dictionaries/dictionary-manual/crd.yaml");
-    const apiFixture = fixture("dictionaries/api-with-dictionary/crd.yaml");
-
-    await test.step("Apply dictionary CRD", async () => {
-      await kubectl.apply(dictFixture);
-      await kubectl.waitForCondition("dictionary", DICT_NAME, "Accepted");
-    });
-
-    await test.step("Dictionary has an ID in status", async () => {
-      const status = await kubectl.getStatus<{ id: string }>("dictionary", DICT_NAME);
-      expect(status.id).toBeTruthy();
-    });
-
-    await test.step("Apply API that uses the dictionary in a header", async () => {
-      await kubectl.apply(apiFixture);
-      await kubectl.waitForCondition("apiv4definition", API_NAME, "Accepted");
-    });
-
-    await test.step("Gateway resolves dictionary value in echo response", async () => {
-      const baseUrl = await gatewayBaseUrl();
-      await poll(
-        async () => {
-          const res = await fetch(`${baseUrl}${API_PATH}`);
-          expect(res.status).toBe(200);
-          const body = (await res.json()) as { headers?: Record<string, string> };
-          expect(body.headers).toBeDefined();
-          expect(body.headers!["X-Dict-Env"] ?? body.headers!["x-dict-env"]).toBe("test");
-        },
-        { timeoutMs: 30_000, intervalMs: 2_000, description: "dictionary header resolved" },
-      );
-    });
-
-    await kubectl.del(apiFixture);
-    await kubectl.del(dictFixture);
   });
 
   // ── GKO-2564: Dynamic dictionary — resolve echo header via JOLT ──

--- a/test/platform-test/e2e/tests/scenarios/dictionaries/dictionary.scenario.ts
+++ b/test/platform-test/e2e/tests/scenarios/dictionaries/dictionary.scenario.ts
@@ -1,0 +1,100 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Manual dictionary resolution, shared across provisioners. A MANUAL dictionary
+ * created through any provisioner must be deployed and resolvable at the gateway:
+ * an API whose transform-headers flow injects `{#dictionaries['<hrid>']['env']}`
+ * sees the value reflected by the echo endpoint.
+ *
+ * The shared invariant (gateway resolves the value to "test") is provisioner-
+ * agnostic; each arm references its own dictionary HRID in its own fixtures
+ * (GKO `default-e2e-dict-manual`, Terraform `e2e-tf-dict-resolve`). The
+ * provisioner-specific dictionary behaviour (GKO dynamic/JOLT, delete, admission,
+ * templating) stays in the per-provisioner suite under tests/gko/dictionaries.
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect } from "../../../setup.js";
+import { loadGraviteeConfig, poll } from "../../../../src/index.js";
+import { XRAY, TAGS } from "../../../helpers/tags.js";
+import { forEachProvisioner } from "../../../helpers/for-each-provisioner.js";
+import { gkoScenario, tfScenario } from "../../../helpers/provisioner-env.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+async function gatewayBaseUrl(): Promise<string> {
+  const config = await loadGraviteeConfig(path.resolve(__dirname, "../../../../config.yaml"));
+  return config.gateway?.baseUrl ?? "http://localhost:30082";
+}
+
+forEachProvisioner(
+  {
+    title: "Manual dictionary value resolves in the gateway response",
+    provisioners: {
+      gko: gkoScenario<void>({
+        // Apply the dictionary first, then the API that references it by HRID.
+        manifests: [
+          "dictionaries/dictionary-manual/crd.yaml",
+          "dictionaries/api-with-dictionary/crd.yaml",
+        ],
+        roles: {
+          api: "e2e-api-with-dict",
+          // Full { kind, name } form: there is no shorthand convention for the
+          // dictionary role, and we only need provision() to await it Accepted.
+          dictionary: { kind: "dictionary", name: "e2e-dict-manual" },
+        },
+        contextPath: "/e2e-api-with-dict",
+      }),
+      terraform: tfScenario<void>({ fixture: "dictionaries/manual-resolve" }),
+    },
+    xray: {
+      gko: XRAY.DICTIONARIES.CREATE_AND_RESOLVE,
+      terraform: XRAY.TERRAFORM.DICTIONARY_MANUAL_RESOLVE,
+    },
+    tags: [TAGS.REGRESSION],
+    // Dictionaries land via the Automation API and the v4 transform-headers flow
+    // resolution path both ship in 4.12, for both provisioners.
+    since: { gko: "4.12", terraform: "4.12" },
+    // GKO provisions two CRs then polls the gateway; give it headroom over 30s.
+    timeoutMs: { gko: 60_000 },
+  },
+  async ({ provisioned }) => {
+    const baseUrl = await gatewayBaseUrl();
+    const ctx = await provisioned.contextPath();
+
+    // The shared invariant: the gateway resolves the dictionary value into the
+    // header the echo endpoint reflects back. Poll for eventual consistency
+    // (operator/provider apply -> APIM -> gateway sync). A non-200 throws with
+    // the status + body so that on timeout the failure says WHY the gateway
+    // never resolved, rather than a bare "received undefined". `poll` retries on
+    // throw, so a transient non-200 during gateway sync is not a hard failure.
+    await poll(
+      async () => {
+        const res = await fetch(`${baseUrl}${ctx}`);
+        if (res.status !== 200) {
+          const errorBody = await res.text().catch(() => "<no body>");
+          throw new Error(`gateway returned ${res.status} for ${ctx}: ${errorBody}`);
+        }
+        const body = (await res.json()) as { headers?: Record<string, string> };
+        const value = body.headers?.["X-Dict-Env"] ?? body.headers?.["x-dict-env"];
+        expect(value, "dictionary value resolved in the gateway response header").toBe("test");
+      },
+      { timeoutMs: 30_000, intervalMs: 2_000, description: "dictionary value resolves in the gateway response" },
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Grows the runner-agnostic **provisioner layer** (`test/platform-test/e2e/tests/scenarios/`) and documents the GKO ↔ Terraform parity effort, covering three tickets:

- **Terraform dictionary tests (GKO-2997)** 
Adds the Terraform arm for dictionaries (the GKO side already had coverage) as a shared cross-provisioner scenario, `tests/scenarios/dictionaries/dictionary.scenario.ts`. One intent runs against both provisioners: a MANUAL dictionary whose value is injected into a response header by a `transform-headers` flow and resolved at the gateway. New TF fixture `dictionaries/manual-resolve/main.tf` authors the `apim_dictionary` + `apim_apiv4` (the first inline `flows` block in a TF fixture). The duplicated GKO `CREATE_AND_RESOLVE` test is removed from the gko-only file; its `@GKO-2903` id moves to the scenario's GKO arm. Filed Xray Test **GKO-2998** for the Terraform arm (linked `is tested by` ← GKO-2997).
- **Parity analysis (GKO-2907)** 
Adds `test/platform-test/PARITY.md`: the GKO vs TF coverage inventory (GKO 310 / TF 20 / scenario-layer 22+7), a parity matrix, the intentionally-GKO-only and TF-only classifications, and a prioritised parity backlog.
- **Parity pattern (GKO-2918)** 
Documents "Adding a cross-provisioner parity scenario" in `AGENTS.md` (the de-dup rule + PARITY.md pointer). The broad parity migration stays deferred as the tracked backlog in PARITY.md.

### Verification

- `typecheck` + `typecheck:e2e` clean.
- The dictionary scenario passes on both arms, and the full scenarios suite (**31 tests**) is green, against a gck-provisioned cluster (APIM master in the `gravitee` namespace, GKO operator in `default`) — i.e. the CI setup.

See: 
- https://gravitee.atlassian.net/browse/GKO-2997
- https://gravitee.atlassian.net/browse/GKO-2907
- https://gravitee.atlassian.net/browse/GKO-2918
