### PR TITLE
test: add assign-categories-to-api GKO/TF parity journey

### DIFF
--- a/test/platform-test/PARITY.md
+++ b/test/platform-test/PARITY.md
@@ -15,9 +15,9 @@ GKO-only or have no TF provider resource (see the buckets below).
 
 | Bucket | Approx | Detail |
 |---|--:|---|
-| ✅ Done via journey | ~9 areas | api-key subscriptions, dictionaries, groups, applications, V4 lifecycle/visibility, plans (JWT/OAuth2), message APIs, labels |
+| ✅ Done via journey | ~10 areas | api-key subscriptions, dictionaries, groups, applications, V4 lifecycle/visibility, plans (JWT/OAuth2), message APIs, labels, categories |
 | ⛔ Pending (blocked) | 1 | SPG reuse — GKO-3001 (admission) + TF `cross_id` gap |
-| 🟡 Feasible, not yet done | ~50 | subscription plan-types (JWT/OAuth2/mTLS), plan/policy lifecycle, application members, group members, API metadata / categories-assign / inline pages, more V4 lifecycle |
+| 🟡 Feasible, not yet done | ~50 | subscription plan-types (JWT/OAuth2/mTLS), plan/policy lifecycle, application members, group members, API metadata / inline pages, more V4 lifecycle |
 | 🚫 Permanently GKO-only | ~150 | K8s/operator mechanics (~100: admission, status/reconcile, mTLS CRs, templating, import/export, mgmt-context) + TF-blocked APIM areas (~50: V2 lifecycle, pages/fetchers, notifications, category CRUD) |
 
 **Achievable parity: ~25–30% covered.** The foundation and pattern are in place, so
@@ -67,6 +67,7 @@ the scenario, its `gko/` + `terraform/` fixtures, and a README (the
 | reuse-shared-policy-group | `apim_shared_policy_group` | GKO-976/980 · TF GKO-3005 — ⛔ both arms pending (blockers below) |
 | consume-message-api | `apim_apiv4` (MESSAGE) | GKO-72/73 · TF new |
 | label-an-api | `apim_apiv4.labels` (inline) | GKO-1473 · TF new |
+| assign-categories-to-api | `apim_apiv4.categories` (inline) | GKO-267/270 · TF new (GKO-2918) |
 | subscribe-and-call (api-key) | `apim_subscription` | existing |
 | api-references-dictionary-property | `apim_dictionary` (MANUAL) | existing |
 | manage-dynamic-dictionary | `apim_dictionary` (DYNAMIC) | GKO-2904/2910/2911/2909 · TF new (GKO-2997) |
@@ -120,7 +121,7 @@ Everything else is per-driver (`tests/gko/`, `tests/terraform/`).
 | Message APIs (V4) | consume-message-api | 🟢 done via journey |
 | Groups + members | create-group-with-member | 🟡 TF-led; journey covers create |
 | Labels | label-an-api | 🟢 done via journey (inline `apim_apiv4.labels`) |
-| Categories (assign to API) | — | 🟡 expressible inline (`apim_apiv4.categories`); next journey |
+| Categories (assign to API) | assign-categories-to-api | 🟢 done via journey (inline `apim_apiv4.categories`) |
 | Pages — inline markdown | — | 🟡 expressible inline (`apim_apiv4.pages[]`); next journey |
 | Pages — standalone + fetchers | — | ⛔ no standalone `apim_page` |
 | Notifications | — | ⛔ no `apim_notification` (no inline path) |
@@ -158,9 +159,10 @@ resource AND no inline `apim_apiv4` attribute), so they stay GKO-only:
 | Category CRUD (create/rename a category) | ~6 | no `apim_category`; an API can only *reference* categories inline |
 
 Partially TF-expressible at the API level (assign-to-API only, no standalone
-CRUD) and good candidates for follow-up journeys: **categories**
-(`apim_apiv4.categories`), **inline markdown pages** (`apim_apiv4.pages[]`),
-**group association** (`apim_apiv4.groups`), **metadata** (`apim_apiv4.metadata`).
+CRUD). **Categories** (`apim_apiv4.categories`) is done via the
+assign-categories-to-api journey; remaining follow-up journeys: **inline markdown
+pages** (`apim_apiv4.pages[]`), **group association** (`apim_apiv4.groups`),
+**metadata** (`apim_apiv4.metadata`).
 
 ## Intentionally Terraform-only (no GKO parity expected)
 
@@ -187,7 +189,8 @@ dictionary, groups). What remains:
 | 5 | Shared Policy Groups | ⛔ pending — journey authored (correct form), blocked by GKO-3001 (admission) + TF crossId gap |
 | 6 | Message APIs (V4) | ✅ done — consume-message-api |
 | 7 | Labels | ✅ done — label-an-api (inline `apim_apiv4.labels`) |
-| 8 | Categories (assign) · inline pages · group-assoc · metadata | ⏳ future journeys (inline `apim_apiv4` attrs, no standalone resource) |
+| 8 | Categories (assign) | ✅ done: assign-categories-to-api (inline `apim_apiv4.categories`) |
+| 8b | Inline pages · group-assoc · metadata | ⏳ future journeys (inline `apim_apiv4` attrs, no standalone resource) |
 | 9 | mTLS plans, gateway JWT/OAuth2 enforcement | ⏳ future (subscription + token orchestration) |
 | 10 | SPG reuse end-to-end | GKO-3001 (admission resolves ref before dry-run) + TF: expose `cross_id` on `apim_shared_policy_group` |
 | 11 | Notifications · standalone pages/fetchers · category CRUD · V2 lifecycle | ⛔ no TF path — stay GKO-only |

--- a/test/platform-test/e2e/helpers/tags.ts
+++ b/test/platform-test/e2e/helpers/tags.ts
@@ -477,6 +477,9 @@ export const XRAY = {
     SPG_REUSE_TF: "@GKO-3005",
     MESSAGE_API_TF: "@GKO-3006",
     API_LABELS_TF: "@GKO-3007",
+    // ── GKO-3024: categories-assign parity journey (assign-categories-to-api) ──
+    // @parent: GKO-3024
+    API_CATEGORIES_TF: "@GKO-3031",
   },
   PAGES: {
     MARKDOWN_PAGE_CRUD_V4: "@GKO-277",

--- a/test/platform-test/e2e/tests/gko/policies/policy-lifecycle.test.ts
+++ b/test/platform-test/e2e/tests/gko/policies/policy-lifecycle.test.ts
@@ -147,28 +147,11 @@ test.describe("Policies — Lifecycle", () => {
     await kubectl.del(updatedPolicy);
   });
 
-  // ── GKO-267: V4 API with valid category ──────────────────────
-
-  test(`Create V4 API with valid category ${XRAY.CATEGORIES.VALID_CATEGORY_V4} ${TAGS.REGRESSION}`, async ({
-    kubectl,
-    mapi,
-  }) => {
-    const API_NAME = "e2e-v4-labels-cats";
-    const fixturePath = fixture("categories/v4-with-labels/crd.yaml");
-
-    await kubectl.apply(fixturePath);
-    await kubectl.waitForCondition("apiv4definition", API_NAME, "Accepted");
-
-    const status = await kubectl.getStatus<{ id: string }>("apiv4definition", API_NAME);
-    const api = await mapi.fetchApi(status.id);
-
-    // Verify labels are applied (categories require pre-existing category in APIM)
-    expect(api.labels).toBeTruthy();
-
-    await kubectl.del(fixturePath);
-  });
-
   // ── GKO-269: Non-existing category ───────────────────────────
+  // Assigning and removing a valid category (@GKO-267 / @GKO-270) is covered by
+  // the cross-provisioner journey tests/user-journeys/assign-categories-to-api/.
+  // This case covers the GKO-only behaviour that an unknown category reference is
+  // tolerated: the API still deploys.
 
   test(`Non-existing category is ignored ${XRAY.CATEGORIES.NON_EXISTING_CATEGORY_V4} ${TAGS.REGRESSION}`, async ({
     kubectl,
@@ -181,26 +164,6 @@ test.describe("Policies — Lifecycle", () => {
     await kubectl.apply(fixturePath);
     await kubectl.waitForCondition("apiv4definition", API_NAME, "Accepted");
 
-    const status = await kubectl.getStatus<{ id: string }>("apiv4definition", API_NAME);
-    await mapi.assertApiStarted(status.id);
-
-    await kubectl.del(fixturePath);
-  });
-
-  // ── GKO-270: Remove a category ───────────────────────────────
-
-  test(`Remove a category from V4 API ${XRAY.CATEGORIES.REMOVE_CATEGORY_V4} ${TAGS.REGRESSION}`, async ({
-    kubectl,
-    mapi,
-  }) => {
-    const API_NAME = "e2e-v4-labels-cats";
-    const fixturePath = fixture("categories/v4-with-labels/crd.yaml");
-
-    await kubectl.apply(fixturePath);
-    await kubectl.waitForCondition("apiv4definition", API_NAME, "Accepted");
-
-    // Re-apply without categories — they should be removed
-    // (labels-cats fixture has labels but categories are managed at APIM level)
     const status = await kubectl.getStatus<{ id: string }>("apiv4definition", API_NAME);
     await mapi.assertApiStarted(status.id);
 

--- a/test/platform-test/e2e/tests/user-journeys/README.md
+++ b/test/platform-test/e2e/tests/user-journeys/README.md
@@ -27,6 +27,7 @@ up by `terraform destroy`.
 | [`secure-api-with-plan`](./secure-api-with-plan/) | Secure an API with a JWT plan and an OAuth2 plan | GKO-162/163 · TF GKO-3004 |
 | [`consume-message-api`](./consume-message-api/) | Stand up a V4 MESSAGE (event) API | GKO-72/73 · TF GKO-3006 |
 | [`label-an-api`](./label-an-api/) | Label a V4 API (inline `apim_apiv4.labels`) | GKO-1473 · TF GKO-3007 |
+| [`assign-categories-to-api`](./assign-categories-to-api/) | Assign a portal category to a V4 API (inline `apim_apiv4.categories`; category pre-created via mAPI) | GKO-267/270 · TF GKO-3031 |
 | [`reuse-shared-policy-group`](./reuse-shared-policy-group/) | Reuse a Shared Policy Group across an API — ⛔ pending (GKO-3001 + TF crossId gap) | GKO-976/980 · TF GKO-3005 |
 
 Run any journey by its Xray tag (both arms), or pin a driver:

--- a/test/platform-test/e2e/tests/user-journeys/assign-categories-to-api/README.md
+++ b/test/platform-test/e2e/tests/user-journeys/assign-categories-to-api/README.md
@@ -1,0 +1,34 @@
+# Journey: assign a category to an API
+
+**As an API producer, I organise my API in the portal by assigning it to a category.**
+
+Assign a pre-existing portal category to a V4 API, then strip it. Categories are
+an **inline attribute** of the API (`apim_apiv4.categories`): there is no
+standalone Terraform resource and no GKO Category CRD, and an API can only
+*reference* a category that already exists in the environment (**APIM silently
+drops references to unknown categories**). The category itself is therefore
+created once as a provisioner-agnostic precondition via mAPI
+(`POST /configuration/categories`), and both drivers assign it by key.
+
+| Driver | Fixture | Notes |
+|---|---|---|
+| GKO | [`gko/api-with-categories.yaml`](./gko/api-with-categories.yaml) + [`gko/api-without-categories.yaml`](./gko/api-without-categories.yaml) | `ApiV4Definition.spec.categories`; strip = re-apply without them. |
+| Terraform | [`terraform/main.tf`](./terraform/main.tf) | `apim_apiv4.categories`; `with_categories = false` empties the list. |
+
+**Precondition:** the scenario `beforeEach` creates the referenced category
+(`e2e-portal-category`) via mAPI and deletes it in `afterEach`. Neither GKO nor
+Terraform can create a category; they can only assign an existing one.
+
+**What it proves:** a category assigned through either driver lands on the API in
+APIM; stripping it removes the assignment. This is the same inline-attribute
+pattern as [`label-an-api`](../label-an-api/) and the template for the other
+inline `apim_apiv4` attributes (`groups`, `metadata`, inline `pages[]`).
+
+Run it:
+
+```sh
+# GKO arm (title carries @GKO-267 + @GKO-270)
+npm --prefix test/platform-test run e2e -- --grep @GKO-267
+# Terraform arm
+npm --prefix test/platform-test run e2e -- --grep @GKO-3031
+```

--- a/test/platform-test/e2e/tests/user-journeys/assign-categories-to-api/assign-categories-to-api.scenario.ts
+++ b/test/platform-test/e2e/tests/user-journeys/assign-categories-to-api/assign-categories-to-api.scenario.ts
@@ -1,0 +1,138 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Journey: assign a category to an API.
+ *
+ * As an API producer, I organise my API in the portal by assigning it to a
+ * category. Categories are an inline attribute of apim_apiv4 (no standalone
+ * Terraform resource and no GKO Category CRD): an API can only *reference* a
+ * category that already exists in the environment, and APIM silently drops
+ * references to unknown categories. So the category is created ONCE as a
+ * provisioner-agnostic precondition via mAPI, and both drivers then assign it by
+ * key (spec.categories / apim_apiv4.categories) and remove it when stripped.
+ *
+ * This is the same inline-attribute pattern as label-an-api (the reference
+ * journey), with the added category precondition.
+ *
+ * Fixtures are co-located in this folder.
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test, expect } from "../../../setup.js";
+import { XRAY, TAGS } from "../../../helpers/tags.js";
+import { forEachProvisioner } from "../../../helpers/for-each-provisioner.js";
+import { gkoScenario, tfScenario } from "../../../helpers/provisioner-env.js";
+import type { Category } from "../../../../src/types/apim.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+// Category slug. e2e-prefixed for isolation in the shared APIM env, matching the
+// e2e-sa-* / e2e-v4-* convention for test-created resources. Passed as both name
+// and key; the beforeEach guard asserts APIM kept this exact key, and both static
+// fixtures reference it verbatim.
+const CATEGORY_KEY = "e2e-portal-category";
+
+/** The single knob: whether the API carries the category. */
+interface CategoryParams {
+  withCategories: boolean;
+}
+
+// The precondition category, created once per test in beforeEach (mapi is a
+// test-scoped fixture, so it is unreachable from beforeAll). Module scope is safe
+// because the suite runs serially (workers: 1).
+let category: Category | undefined;
+
+// Create the referenced category BEFORE the test body provisions the API: for
+// both drivers the API (and its category-ref resolution) is created inside the
+// body's provision() call, and APIM drops references to categories that do not
+// yet exist. A top-level beforeEach always runs before the test body.
+test.beforeEach(async ({ mapi }) => {
+  category = await mapi.createCategory({ key: CATEGORY_KEY, name: CATEGORY_KEY });
+  // Fail fast (instead of with a confusing "category never lands" timeout) if
+  // APIM's slugification produced a key other than the one the fixtures use.
+  expect(category.key, "APIM category key must match the fixtures").toBe(CATEGORY_KEY);
+});
+
+// Registered BEFORE forEachProvisioner so it runs AFTER the generator's own
+// teardown (Playwright runs afterEach in reverse registration order): the API is
+// destroyed first, then its category precondition is removed.
+test.afterEach(async ({ mapi }) => {
+  if (category) await mapi.deleteCategory(category.id).catch(() => {});
+  category = undefined;
+});
+
+forEachProvisioner<CategoryParams>(
+  {
+    title: "Assign a category to a V4 API",
+    provisioners: {
+      gko: gkoScenario<CategoryParams>({
+        manifests: [],
+        roles: { api: "categorized-api" },
+        dynamicRoles: ["api"],
+        applyParams: async (k, params) => {
+          await k.apply(
+            path.join(here, params.withCategories ? "gko/api-with-categories.yaml" : "gko/api-without-categories.yaml"),
+          );
+        },
+      }),
+      terraform: tfScenario<CategoryParams>({
+        fixture: path.join(here, "terraform"),
+        toVars: (params) => ({ with_categories: params.withCategories }),
+      }),
+    },
+    xray: {
+      // The GKO arm covers both the assign (@GKO-267) and remove (@GKO-270)
+      // category cases; this journey is their sole coverage.
+      gko: [XRAY.CATEGORIES.VALID_CATEGORY_V4, XRAY.CATEGORIES.REMOVE_CATEGORY_V4],
+      terraform: XRAY.TERRAFORM.API_CATEGORIES_TF,
+    },
+    tags: [TAGS.REGRESSION],
+    since: { gko: "4.12", terraform: "4.12" },
+    timeoutMs: { gko: 60_000 },
+  },
+  async ({ provisioned, mapi }) => {
+    const apiId = await provisioned.apiId();
+    const cat = category!;
+
+    await test.step("Category assigned through the provisioner lands in APIM", async () => {
+      await expect
+        .poll(
+          async () => {
+            const assigned = (await mapi.fetchApi(apiId)).categories ?? [];
+            // APIM may echo the reference by key or by UUID depending on version;
+            // normalise a UUID back to the key so the expectation is
+            // representation-independent.
+            return assigned.map((c) => (c === cat.id ? cat.key : c)).slice().sort();
+          },
+          { timeout: 30_000, message: "API category reaches APIM" },
+        )
+        .toEqual([cat.key].sort());
+    });
+
+    await test.step("Stripping the category removes it in APIM", async () => {
+      await provisioned.update({ withCategories: false });
+      await expect
+        .poll(async () => (await mapi.fetchApi(apiId)).categories ?? [], {
+          timeout: 30_000,
+          message: "API category removed",
+        })
+        .toEqual([]);
+    });
+  },
+  { withCategories: true },
+);

--- a/test/platform-test/e2e/tests/user-journeys/assign-categories-to-api/gko/api-with-categories.yaml
+++ b/test/platform-test/e2e/tests/user-journeys/assign-categories-to-api/gko/api-with-categories.yaml
@@ -1,0 +1,64 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Assign a portal category to a V4 API, through GKO. Categories are an inline
+# attribute of the API (no standalone resource) and must reference a category
+# that already exists in the environment (created as a precondition via mAPI in
+# the scenario); APIM silently drops references to unknown categories.
+# Re-applying api-without-categories.yaml strips the reference. (metadata.labels
+# carries the e2e sweep marker; spec.categories is the portal category under test.)
+apiVersion: gravitee.io/v1alpha1
+kind: ApiV4Definition
+metadata:
+  name: categorized-api
+  labels:
+    gravitee.io/e2e: "true"
+spec:
+  contextRef:
+    name: "dev-ctx"
+    namespace: "default"
+  name: "categorized-api"
+  description: "V4 proxy API organised with a portal category"
+  version: "1.0.0"
+  type: PROXY
+  state: STARTED
+  categories:
+    - "e2e-portal-category"
+  definitionContext:
+    origin: KUBERNETES
+    syncFrom: MANAGEMENT
+  listeners:
+    - type: HTTP
+      paths:
+        - path: "/categorized-api"
+      entrypoints:
+        - type: http-proxy
+          qos: AUTO
+  endpointGroups:
+    - name: Default HTTP proxy group
+      type: http-proxy
+      endpoints:
+        - name: Default HTTP proxy
+          type: http-proxy
+          inheritConfiguration: false
+          configuration:
+            target: https://api.gravitee.io/echo
+  flowExecution:
+    mode: DEFAULT
+    matchRequired: false
+  plans:
+    KeyLess:
+      name: "Free plan"
+      security:
+        type: "KEY_LESS"

--- a/test/platform-test/e2e/tests/user-journeys/assign-categories-to-api/gko/api-without-categories.yaml
+++ b/test/platform-test/e2e/tests/user-journeys/assign-categories-to-api/gko/api-without-categories.yaml
@@ -1,0 +1,58 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The same API as api-with-categories.yaml with the portal category reference
+# stripped; re-applied to verify APIM removes the assignment (sync-down).
+apiVersion: gravitee.io/v1alpha1
+kind: ApiV4Definition
+metadata:
+  name: categorized-api
+  labels:
+    gravitee.io/e2e: "true"
+spec:
+  contextRef:
+    name: "dev-ctx"
+    namespace: "default"
+  name: "categorized-api"
+  description: "V4 proxy API organised with a portal category"
+  version: "1.0.0"
+  type: PROXY
+  state: STARTED
+  definitionContext:
+    origin: KUBERNETES
+    syncFrom: MANAGEMENT
+  listeners:
+    - type: HTTP
+      paths:
+        - path: "/categorized-api"
+      entrypoints:
+        - type: http-proxy
+          qos: AUTO
+  endpointGroups:
+    - name: Default HTTP proxy group
+      type: http-proxy
+      endpoints:
+        - name: Default HTTP proxy
+          type: http-proxy
+          inheritConfiguration: false
+          configuration:
+            target: https://api.gravitee.io/echo
+  flowExecution:
+    mode: DEFAULT
+    matchRequired: false
+  plans:
+    KeyLess:
+      name: "Free plan"
+      security:
+        type: "KEY_LESS"

--- a/test/platform-test/e2e/tests/user-journeys/assign-categories-to-api/terraform/main.tf
+++ b/test/platform-test/e2e/tests/user-journeys/assign-categories-to-api/terraform/main.tf
@@ -1,0 +1,110 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Assign a portal category to a V4 API, through the Terraform APIM provider.
+# Categories are an inline attribute of apim_apiv4 (no standalone resource) and
+# reference a category that must already exist in the environment (created as a
+# precondition via mAPI in the scenario); APIM silently drops unknown refs.
+# with_categories = false re-applies with an empty list to strip the reference.
+terraform {
+  required_providers {
+    apim = {
+      source = "gravitee-io/apim"
+    }
+  }
+}
+
+provider "apim" {}
+
+variable "environment_id" {
+  type    = string
+  default = "DEFAULT"
+}
+
+variable "organization_id" {
+  type    = string
+  default = "DEFAULT"
+}
+
+variable "with_categories" {
+  type    = bool
+  default = true
+}
+
+resource "apim_apiv4" "api" {
+  environment_id  = var.environment_id
+  organization_id = var.organization_id
+  hrid            = "categorized-api-tf"
+  name            = "categorized-api-tf"
+  description     = "V4 proxy API organised with a portal category"
+  version         = "1"
+  type            = "PROXY"
+  state           = "STARTED"
+  lifecycle_state = "PUBLISHED"
+  visibility      = "PRIVATE"
+  categories      = var.with_categories ? ["e2e-portal-category"] : []
+
+  listeners = [
+    {
+      http = {
+        type = "HTTP"
+        paths = [
+          { path = "/categorized-api-tf/" }
+        ]
+        entrypoints = [
+          { type = "http-proxy" }
+        ]
+      }
+    }
+  ]
+
+  endpoint_groups = [
+    {
+      name = "Default HTTP proxy group"
+      type = "http-proxy"
+      endpoints = [
+        {
+          name                  = "default-endpoint"
+          type                  = "http-proxy"
+          inherit_configuration = false
+          configuration         = jsonencode({ target = "https://api.gravitee.io/echo" })
+        }
+      ]
+    }
+  ]
+
+  flow_execution = {
+    mode           = "DEFAULT"
+    match_required = false
+  }
+
+  plans = [
+    {
+      hrid     = "keyless"
+      name     = "Free plan"
+      type     = "API"
+      mode     = "STANDARD"
+      status   = "PUBLISHED"
+      security = { type = "KEY_LESS" }
+    }
+  ]
+}
+
+output "api_id" {
+  value = apim_apiv4.api.id
+}
+
+output "api_context_path" {
+  value = "/categorized-api-tf"
+}

--- a/test/platform-test/src/assertions/apim/mapi.ts
+++ b/test/platform-test/src/assertions/apim/mapi.ts
@@ -23,7 +23,7 @@ import type { FetchFn } from "../../types/http.js";
 import type { DeepPartial, AssertionReport, PollOptions } from "../../types/match.js";
 import type { MapiConfig } from "../../types/mapi.js";
 import type { GatewayConfig } from "../../types/gateway.js";
-import type { Api, Application, Plan, PaginatedResult, Subscription, SubscriptionApiKey, NotificationSetting, Group, GroupMember } from "../../types/apim.js";
+import type { Api, Application, Plan, PaginatedResult, Subscription, SubscriptionApiKey, NotificationSetting, Group, GroupMember, Category } from "../../types/apim.js";
 import { Gateway } from "./gateway.js";
 
 /**
@@ -507,6 +507,68 @@ export class Mapi {
     });
     if (![200, 201, 400, 409].includes(res.status)) {
       throw new Error(`Failed to create service account ${name}: ${res.status} ${res.statusText}`);
+    }
+  }
+
+  // ── Categories ─────────────────────────────────────────────
+
+  /**
+   * List all portal categories in the environment (v1 management API).
+   *
+   * Categories are an environment-level entity with no standalone GKO CRD and no
+   * `apim_category` Terraform resource — an API can only *reference* them by key.
+   * These helpers let a journey create the referenced category as a
+   * provisioner-agnostic precondition, mirroring `createServiceAccount` for the
+   * group-member tests.
+   */
+  async listCategories(): Promise<Category[]> {
+    const path = this.http.managementV1Path("/configuration/categories");
+    const res = await this.http.get<Category[]>(path);
+    if (res.status !== 200) {
+      throw new Error(`Failed to list categories: ${res.status} ${res.statusText}\n${JSON.stringify(res.body, null, 2)}`);
+    }
+    return res.body;
+  }
+
+  /** Fetch a single category by its key. @throws if not found. */
+  async fetchCategoryByKey(key: string): Promise<Category> {
+    const categories = await this.listCategories();
+    const category = categories.find((c) => c.key === key);
+    if (!category) {
+      throw new Error(
+        `Category with key "${key}" not found. Known keys: ${categories.map((c) => c.key).join(", ")}`,
+      );
+    }
+    return category;
+  }
+
+  /**
+   * Idempotently create a portal category and return it (with its
+   * server-assigned id + key). `key` is passed explicitly so it is deterministic
+   * across runs (APIM otherwise derives it from `name`). A 400/409 is treated as
+   * "already exists" (categories persist in Mongo across runs); the existing one
+   * is then fetched by key.
+   */
+  async createCategory(input: { key: string; name: string; description?: string }): Promise<Category> {
+    const path = this.http.managementV1Path("/configuration/categories");
+    const res = await this.http.post<Category>(path, {
+      key: input.key,
+      name: input.name,
+      description: input.description,
+    });
+    if (res.status === 200 || res.status === 201) return res.body;
+    if (res.status === 400 || res.status === 409) return this.fetchCategoryByKey(input.key);
+    throw new Error(
+      `Failed to create category "${input.name}": ${res.status} ${res.statusText} - ${JSON.stringify(res.body)}`,
+    );
+  }
+
+  /** Delete a category by its id (teardown of the precondition). */
+  async deleteCategory(categoryId: string): Promise<void> {
+    const path = this.http.managementV1Path(`/configuration/categories/${categoryId}`);
+    const res = await this.http.delete(path);
+    if (res.status !== 204 && res.status !== 200) {
+      throw new Error(`Failed to delete category ${categoryId}: ${res.status} ${res.statusText}\n${JSON.stringify(res.body, null, 2)}`);
     }
   }
 }

--- a/test/platform-test/src/types/apim.ts
+++ b/test/platform-test/src/types/apim.ts
@@ -887,3 +887,25 @@ export interface GroupMember {
   displayName?: string;
   roles?: Record<string, string>;
 }
+
+// ── Category Types ────────────────────────────────────────────
+
+/**
+ * A portal category as returned by the v1 management API
+ * (`/configuration/categories`).
+ *
+ * An environment-level entity that APIs reference by `key`. There is no
+ * standalone GKO Category CRD and no `apim_category` Terraform resource, so an
+ * API can only *reference* an existing category through its inline `categories`
+ * attribute (APIM silently drops references to unknown categories). APIM derives
+ * `key` from `name` when it is not supplied.
+ */
+export interface Category {
+  id: string;
+  key: string;
+  name: string;
+  description?: string;
+  order?: number;
+  hidden?: boolean;
+  totalApis?: number;
+}

--- a/test/platform-test/src/types/index.ts
+++ b/test/platform-test/src/types/index.ts
@@ -23,7 +23,7 @@ export type {
   Listener, HttpListener, SubscriptionListener, TcpListener, KafkaListener,
   Entrypoint, EndpointGroupV4, EndpointV4,
   Application, NotificationSetting,
-  Group, GroupMember,
+  Group, GroupMember, Category,
 } from "./apim.js";
 
 // ── HTTP ─────────────────────────────────────────────────────


### PR DESCRIPTION
### What
Adds a cross-provisioner (GKO + Terraform) user-journey
`assign-categories-to-api` verifying that assigning an APIM category to a V4 API
works identically through both drivers (GKO `spec.categories`, Terraform
`apim_apiv4.categories`) and that stripping it removes the assignment.

### Why
Categories are the remaining half of the GKO-2918 "Categories, Labels" parity
bullet (labels were already covered by `label-an-api`). They are an inline
`apim_apiv4` attribute with no standalone resource, so they are parity-testable
through both drivers.

### Notes
- The referenced category must pre-exist (APIM silently drops unknown refs) and
  neither driver can create one, so the journey creates it via mAPI as a
  provisioner-agnostic precondition (new `Category` type + category helpers on
  the mAPI client); both arms reference it by key.
- De-dups the two weak standalone GKO tests (`@GKO-267` / `@GKO-270` only
  asserted labels/started); their ids move onto the journey's GKO arm. The
  Terraform arm is filed as Xray Test GKO-3031.
- Verified green on the local e2e cluster (both arms + surviving `@GKO-269`) and
  `npm run typecheck`.

See: https://gravitee.atlassian.net/browse/GKO-3024