### PR TITLE
test: add add-inline-markdown-page-in-api GKO/TF parity journey (GKO-3025)

### DIFF
--- a/test/platform-test/PARITY.md
+++ b/test/platform-test/PARITY.md
@@ -15,10 +15,10 @@ GKO-only or have no TF provider resource (see the buckets below).
 
 | Bucket | Approx | Detail |
 |---|--:|---|
-| ✅ Done via journey | ~10 areas | api-key subscriptions, dictionaries, groups, applications, V4 lifecycle/visibility, plans (JWT/OAuth2), message APIs, labels, categories |
+| ✅ Done via journey | ~10 areas | api-key subscriptions, dictionaries, groups, applications, V4 lifecycle/visibility, plans (JWT/OAuth2), message APIs, labels, categories, inline pages |
 | ⛔ Pending (blocked) | 1 | SPG reuse — GKO-3001 (admission) + TF `cross_id` gap |
-| 🟡 Feasible, not yet done | ~50 | subscription plan-types (JWT/OAuth2/mTLS), plan/policy lifecycle, application members, group members, API metadata / inline pages, more V4 lifecycle |
-| 🚫 Permanently GKO-only | ~150 | K8s/operator mechanics (~100: admission, status/reconcile, mTLS CRs, templating, import/export, mgmt-context) + TF-blocked APIM areas (~50: V2 lifecycle, pages/fetchers, notifications, category CRUD) |
+| 🟡 Feasible, not yet done | ~50 | subscription plan-types (JWT/OAuth2/mTLS), plan/policy lifecycle, application members, group members, API metadata, more V4 lifecycle |
+| 🚫 Permanently GKO-only | ~150 | K8s/operator mechanics (~100: admission, status/reconcile, mTLS CRs, templating, import/export, mgmt-context) + TF-blocked APIM areas (~50: V2 lifecycle & V2 pages/fetchers, standalone pages, notifications, category CRUD) |
 
 **Achievable parity: ~25–30% covered.** The foundation and pattern are in place, so
 each remaining journey is incremental. Full 1:1 is a non-goal (GKO-2918).
@@ -45,11 +45,13 @@ parity-testable at the API level:
 | `categories` | assigning categories to an API (can't *create* a category) |
 | `groups` | associating existing groups with an API |
 | `metadata` | API metadata |
-| `pages[]` | inline markdown documentation (not standalone pages / fetchers) |
+| `pages[]` | inline markdown documentation **and inline fetchers** (`pages[].source`); not standalone pages |
 
 Genuinely impossible (no resource and no inline path): **V2 API lifecycle** (no
-`apim_apiv2` at all), standalone **page fetchers**, environment-level **category
-CRUD** and **notification configuration**.
+`apim_apiv2` at all, so V2 pages/fetchers too), standalone pages (no `apim_page`),
+environment-level **category CRUD** and **notification configuration**. Inline
+page **fetchers** on a V4 API are *not* in this list — `apim_apiv4.pages[].source`
+mirrors `spec.pages.<x>.source`, so they are parity-testable.
 
 ## Use-case journeys (where parity lives)
 
@@ -68,6 +70,7 @@ the scenario, its `gko/` + `terraform/` fixtures, and a README (the
 | consume-message-api | `apim_apiv4` (MESSAGE) | GKO-72/73 · TF new |
 | label-an-api | `apim_apiv4.labels` (inline) | GKO-1473 · TF new |
 | assign-categories-to-api | `apim_apiv4.categories` (inline) | GKO-267/270 · TF new (GKO-2918) |
+| add-inline-markdown-page-in-api | `apim_apiv4.pages[]` (inline) | GKO-1470 · TF GKO-3034 |
 | subscribe-and-call (api-key) | `apim_subscription` | existing |
 | api-references-dictionary-property | `apim_dictionary` (MANUAL) | existing |
 | manage-dynamic-dictionary | `apim_dictionary` (DYNAMIC) | GKO-2904/2910/2911/2909 · TF new (GKO-2997) |
@@ -122,8 +125,9 @@ Everything else is per-driver (`tests/gko/`, `tests/terraform/`).
 | Groups + members | create-group-with-member | 🟡 TF-led; journey covers create |
 | Labels | label-an-api | 🟢 done via journey (inline `apim_apiv4.labels`) |
 | Categories (assign to API) | assign-categories-to-api | 🟢 done via journey (inline `apim_apiv4.categories`) |
-| Pages — inline markdown | — | 🟡 expressible inline (`apim_apiv4.pages[]`); next journey |
-| Pages — standalone + fetchers | — | ⛔ no standalone `apim_page` |
+| Pages — inline markdown | add-inline-markdown-page-in-api | 🟢 done via journey (inline `apim_apiv4.pages[]`) |
+| Pages — inline fetchers (`pages[].source`) | — | 🟡 expressible on both drivers (TF `apim_apiv4.pages[].source`); journey pending |
+| Pages — standalone (no owning API) | — | ⛔ no standalone `apim_page` resource |
 | Notifications | — | ⛔ no `apim_notification` (no inline path) |
 | V2 API lifecycle | — | ⛔ no `apim_apiv2` (no inline path) |
 | Applications — members / OAuth | — | GKO-only (admission + member reconciliation) |
@@ -153,16 +157,20 @@ resource AND no inline `apim_apiv4` attribute), so they stay GKO-only:
 
 | Area | `tests/gko` | Why no TF path |
 |---|---:|---|
-| V2 API lifecycle | ~12 | no `apim_apiv2` resource; provider is V4-only |
+| V2 API lifecycle (incl. V2 pages/fetchers) | ~12 | no `apim_apiv2` resource; provider is V4-only |
 | Notifications | ~11 | no `apim_notification` resource, no inline attribute |
-| Standalone pages / fetchers | ~20 | only inline `apim_apiv4.pages[]`; no `apim_page`, no fetcher support |
+| Standalone pages (no owning API) | few | no `apim_page` resource; V4 pages are always inline on the API |
 | Category CRUD (create/rename a category) | ~6 | no `apim_category`; an API can only *reference* categories inline |
 
+> V4 inline page **fetchers** (`apim_apiv4.pages[].source`) are **not** GKO-only —
+> the TF provider exposes the same `source` block, so they are a feasible parity
+> follow-up (see the parity matrix).
+
 Partially TF-expressible at the API level (assign-to-API only, no standalone
-CRUD). **Categories** (`apim_apiv4.categories`) is done via the
-assign-categories-to-api journey; remaining follow-up journeys: **inline markdown
-pages** (`apim_apiv4.pages[]`), **group association** (`apim_apiv4.groups`),
-**metadata** (`apim_apiv4.metadata`).
+CRUD). **Categories** (`apim_apiv4.categories`) and **inline markdown pages**
+(`apim_apiv4.pages[]`) are done via the assign-categories-to-api and
+add-inline-markdown-page-in-api journeys; remaining follow-up journeys: **group association**
+(`apim_apiv4.groups`), **metadata** (`apim_apiv4.metadata`).
 
 ## Intentionally Terraform-only (no GKO parity expected)
 
@@ -190,10 +198,11 @@ dictionary, groups). What remains:
 | 6 | Message APIs (V4) | ✅ done — consume-message-api |
 | 7 | Labels | ✅ done — label-an-api (inline `apim_apiv4.labels`) |
 | 8 | Categories (assign) | ✅ done: assign-categories-to-api (inline `apim_apiv4.categories`) |
-| 8b | Inline pages · group-assoc · metadata | ⏳ future journeys (inline `apim_apiv4` attrs, no standalone resource) |
+| 8b | Inline markdown pages | ✅ done: add-inline-markdown-page-in-api (inline `apim_apiv4.pages[]`) |
+| 8c | Inline page fetchers (`pages[].source`) · group-assoc · metadata | ⏳ future journeys (all inline `apim_apiv4` attrs; both drivers support them) |
 | 9 | mTLS plans, gateway JWT/OAuth2 enforcement | ⏳ future (subscription + token orchestration) |
 | 10 | SPG reuse end-to-end | GKO-3001 (admission resolves ref before dry-run) + TF: expose `cross_id` on `apim_shared_policy_group` |
-| 11 | Notifications · standalone pages/fetchers · category CRUD · V2 lifecycle | ⛔ no TF path — stay GKO-only |
+| 11 | Notifications · standalone pages · category CRUD · V2 lifecycle (& V2 pages/fetchers) | ⛔ no TF path — stay GKO-only |
 | 12 | Co-locate all journeys under `tests/user-journeys/` (incl. the 3 pre-existing) | ✅ done |
 
 When picking up a row, prefer **a use-case journey** (one intent, two arms) over a

--- a/test/platform-test/e2e/helpers/tags.ts
+++ b/test/platform-test/e2e/helpers/tags.ts
@@ -480,6 +480,9 @@ export const XRAY = {
     // ── GKO-3024: categories-assign parity journey (assign-categories-to-api) ──
     // @parent: GKO-3024
     API_CATEGORIES_TF: "@GKO-3031",
+    // ── GKO-3025: inline-pages parity journey (add-inline-markdown-page-in-api) ──
+    // @parent: GKO-3025
+    API_INLINE_PAGES_TF: "@GKO-3034",
   },
   PAGES: {
     MARKDOWN_PAGE_CRUD_V4: "@GKO-277",

--- a/test/platform-test/e2e/tests/gko/pages/v4-documentation.test.ts
+++ b/test/platform-test/e2e/tests/gko/pages/v4-documentation.test.ts
@@ -21,7 +21,9 @@
  *   GKO-236:  CRUD on existing V4 API operations (documentation context)
  *   GKO-280:  Documentation created by GKO is read-only when re-imported
  *   GKO-282:  Inline documentation with PUBLIC visibility
- *   GKO-1470: Documentation managed by GKO is reconciled end-to-end
+ *
+ * GKO-1470 (inline page reconciled end-to-end: lands on create, removed on strip)
+ * moved to the add-inline-markdown-page-in-api cross-provisioner journey.
  *
  * Skipped tests:
  *   GKO-283 (V4 spec.visibility PUBLIC-only) — GKO product bug
@@ -148,34 +150,4 @@ test.describe("V4 API Documentation — Extended", () => {
 
   // GKO-283 (V4 spec.visibility only accepts PUBLIC) was skipped due to a
   // GKO product bug.
-
-  // ── GKO-1470: Documentation is fully reconciled by the operator ─
-
-  test(`Documentation is reconciled end-to-end ${XRAY.PAGES.V4_DOC_RECONCILED} ${TAGS.REGRESSION}`, async ({
-    kubectl,
-    mapi,
-  }) => {
-    const API_NAME = "e2e-v4-markdown-page";
-    const WITH_PAGE = fixture("pages/v4-api-with-page-markdown/crd.yaml");
-    const WITHOUT_PAGE = fixture("pages/v4-api-without-page-markdown/crd.yaml");
-
-    await kubectl.apply(WITH_PAGE);
-    await kubectl.waitForCondition("apiv4definition", API_NAME, "Accepted");
-    const apiId = (await kubectl.getStatus<{ id: string }>("apiv4definition", API_NAME)).id;
-
-    await test.step("Page present after create", async () => {
-      const crd = YAML.parse(await mapi.exportApiCrd(apiId)) as ExportedCrd;
-      expect(crd.spec?.pages?.["markdown-page"]).toBeDefined();
-    });
-
-    await kubectl.apply(WITHOUT_PAGE);
-    await kubectl.waitForCondition("apiv4definition", API_NAME, "Accepted");
-
-    await test.step("Page removed after without-page re-apply", async () => {
-      const crd = YAML.parse(await mapi.exportApiCrd(apiId)) as ExportedCrd;
-      expect(crd.spec?.pages?.["markdown-page"]).toBeUndefined();
-    });
-
-    await kubectl.del(WITHOUT_PAGE);
-  });
 });

--- a/test/platform-test/e2e/tests/user-journeys/README.md
+++ b/test/platform-test/e2e/tests/user-journeys/README.md
@@ -28,6 +28,7 @@ up by `terraform destroy`.
 | [`consume-message-api`](./consume-message-api/) | Stand up a V4 MESSAGE (event) API | GKO-72/73 · TF GKO-3006 |
 | [`label-an-api`](./label-an-api/) | Label a V4 API (inline `apim_apiv4.labels`) | GKO-1473 · TF GKO-3007 |
 | [`assign-categories-to-api`](./assign-categories-to-api/) | Assign a portal category to a V4 API (inline `apim_apiv4.categories`; category pre-created via mAPI) | GKO-267/270 · TF GKO-3031 |
+| [`add-inline-markdown-page-in-api`](./add-inline-markdown-page-in-api/) | Add an inline markdown documentation page to a V4 API (inline `apim_apiv4.pages[]`; inline fetchers are a feasible follow-up, V2 pages stay GKO-only) | GKO-1470 · TF GKO-3034 |
 | [`reuse-shared-policy-group`](./reuse-shared-policy-group/) | Reuse a Shared Policy Group across an API — ⛔ pending (GKO-3001 + TF crossId gap) | GKO-976/980 · TF GKO-3005 |
 
 Run any journey by its Xray tag (both arms), or pin a driver:

--- a/test/platform-test/e2e/tests/user-journeys/add-inline-markdown-page-in-api/README.md
+++ b/test/platform-test/e2e/tests/user-journeys/add-inline-markdown-page-in-api/README.md
@@ -1,0 +1,32 @@
+# Journey: add an inline markdown page to an API
+
+**As an API producer, I ship documentation alongside my API definition.**
+
+Add an inline markdown page to a V4 API, then strip it. A page is an **inline
+attribute** of the API (`apim_apiv4.pages[]` / `spec.pages`) — there is no
+standalone Page resource, but the journey is still fully expressible through both
+provisioners.
+
+| Driver | Fixture | Notes |
+|---|---|---|
+| GKO | [`gko/api-with-page.yaml`](./gko/api-with-page.yaml) + [`gko/api-without-page.yaml`](./gko/api-without-page.yaml) | `ApiV4Definition.spec.pages` (map keyed by hrid); strip = re-apply without it. |
+| Terraform | [`terraform/main.tf`](./terraform/main.tf) | `apim_apiv4.pages`; `with_page = false` empties the list. |
+
+**What it proves:** an inline markdown page set through either driver lands in
+APIM (`GET /apis/{id}/pages`); stripping it removes it. The payload is a nested
+object, so the fixtures and the assertion compare a page object
+(`{ name, type, content, published }`), not a plain string.
+
+**Adjacent, not covered here:** inline page **fetchers** (`pages[].source`, e.g.
+an `http-fetcher` pulling a Swagger spec) are also expressible on **both** drivers
+(the TF `apim_apiv4.pages[].source` block mirrors `spec.pages.<x>.source`), so a
+fetcher-parity journey is a feasible follow-up. Only **V2** documentation has no
+Terraform path (there is no `apim_apiv2` resource) and stays GKO-only under
+[`tests/gko/pages/`](../../gko/pages/).
+
+Run it:
+
+```sh
+npm --prefix test/platform-test run e2e -- --grep @GKO-1470
+npm --prefix test/platform-test run e2e -- --grep @GKO-1470 --provision-with terraform
+```

--- a/test/platform-test/e2e/tests/user-journeys/add-inline-markdown-page-in-api/add-inline-markdown-page-in-api.scenario.ts
+++ b/test/platform-test/e2e/tests/user-journeys/add-inline-markdown-page-in-api/add-inline-markdown-page-in-api.scenario.ts
@@ -1,0 +1,119 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Journey: add an inline markdown page to an API.
+ *
+ * As an API producer, I ship API documentation alongside the API definition. An
+ * inline markdown page is an attribute of apim_apiv4 (spec.pages / pages[]) — there
+ * is no standalone Page Terraform resource — yet the journey is fully expressible
+ * through both provisioners: a page set through either driver lands in APIM and is
+ * removed when stripped. Inline page fetchers (pages[].source) are also expressible
+ * on both drivers and are a feasible follow-up; only V2 documentation has no
+ * Terraform path (no apim_apiv2) and stays GKO-only.
+ *
+ * This is the same inline-attribute pattern as label-an-api, except the payload is
+ * a nested object list, so the with/without fixtures and the assertion compare a
+ * page object ({ name, type, content, published }) rather than a plain string.
+ *
+ * Fixtures are co-located in this folder.
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test, expect } from "../../../setup.js";
+import { XRAY, TAGS } from "../../../helpers/tags.js";
+import { forEachProvisioner } from "../../../helpers/for-each-provisioner.js";
+import { gkoScenario, tfScenario } from "../../../helpers/provisioner-env.js";
+import type { Page } from "../../../../src/types/apim.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+// The inline page both fixtures attach. Content is compared trimmed because the
+// two drivers' block-scalar / heredoc syntaxes differ on the trailing newline.
+const PAGE = {
+  name: "Getting started",
+  type: "MARKDOWN",
+  content: "# Getting started\n\nCall `GET /` to reach the upstream echo endpoint.",
+  published: true,
+};
+
+/** Project a fetched page to the fields under test (content normalised). */
+function project(p: Page) {
+  return {
+    name: p.name,
+    type: p.type,
+    content: (p.content ?? "").trim(),
+    published: p.published ?? false,
+  };
+}
+
+/** The single knob: whether the API carries the inline page. */
+interface PageParams {
+  withPage: boolean;
+}
+
+forEachProvisioner<PageParams>(
+  {
+    title: "Add an inline markdown page to a V4 API",
+    provisioners: {
+      gko: gkoScenario<PageParams>({
+        manifests: [],
+        roles: { api: "documented-api" },
+        dynamicRoles: ["api"],
+        applyParams: async (k, params) => {
+          await k.apply(path.join(here, params.withPage ? "gko/api-with-page.yaml" : "gko/api-without-page.yaml"));
+        },
+      }),
+      terraform: tfScenario<PageParams>({
+        fixture: path.join(here, "terraform"),
+        toVars: (params) => ({ with_page: params.withPage }),
+      }),
+    },
+    xray: {
+      // The GKO arm reuses the end-to-end documentation-reconcile test (page lands
+      // on create, removed on strip); this journey is its sole coverage.
+      gko: XRAY.PAGES.V4_DOC_RECONCILED,
+      terraform: XRAY.TERRAFORM.API_INLINE_PAGES_TF,
+    },
+    tags: [TAGS.REGRESSION],
+    since: { gko: "4.12", terraform: "4.12" },
+    timeoutMs: { gko: 60_000 },
+  },
+  async ({ provisioned, mapi }) => {
+    const apiId = await provisioned.apiId();
+
+    await test.step("Page attached through the provisioner lands in APIM", async () => {
+      await expect
+        .poll(async () => (await mapi.listApiPages(apiId)).map(project), {
+          timeout: 30_000,
+          message: "API documentation page reaches APIM",
+        })
+        .toEqual([{ ...PAGE, content: PAGE.content.trim() }]);
+    });
+
+    await test.step("Stripping the page removes it in APIM", async () => {
+      await provisioned.update({ withPage: false });
+      await expect
+        .poll(async () => (await mapi.listApiPages(apiId)).length, {
+          timeout: 30_000,
+          message: "API documentation page removed",
+        })
+        .toBe(0);
+    });
+  },
+  { withPage: true },
+);

--- a/test/platform-test/e2e/tests/user-journeys/add-inline-markdown-page-in-api/gko/api-with-page.yaml
+++ b/test/platform-test/e2e/tests/user-journeys/add-inline-markdown-page-in-api/gko/api-with-page.yaml
@@ -1,0 +1,70 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Document a V4 API with an inline markdown page, through GKO. Pages are an inline
+# attribute of the API (spec.pages, keyed by hrid) — there is no standalone Page
+# resource; re-applying api-without-page.yaml strips the page. (metadata.labels
+# carries the e2e sweep marker; spec.pages is the documentation under test.)
+apiVersion: gravitee.io/v1alpha1
+kind: ApiV4Definition
+metadata:
+  name: documented-api
+  labels:
+    gravitee.io/e2e: "true"
+spec:
+  contextRef:
+    name: "dev-ctx"
+    namespace: "default"
+  name: "documented-api"
+  description: "V4 proxy API documented with an inline markdown page"
+  version: "1.0.0"
+  type: PROXY
+  state: STARTED
+  definitionContext:
+    origin: KUBERNETES
+    syncFrom: MANAGEMENT
+  listeners:
+    - type: HTTP
+      paths:
+        - path: "/documented-api"
+      entrypoints:
+        - type: http-proxy
+          qos: AUTO
+  endpointGroups:
+    - name: Default HTTP proxy group
+      type: http-proxy
+      endpoints:
+        - name: Default HTTP proxy
+          type: http-proxy
+          inheritConfiguration: false
+          configuration:
+            target: https://api.gravitee.io/echo
+  flowExecution:
+    mode: DEFAULT
+    matchRequired: false
+  plans:
+    KeyLess:
+      name: "Free plan"
+      security:
+        type: "KEY_LESS"
+  pages:
+    getting-started:
+      name: "Getting started"
+      type: MARKDOWN
+      content: |-
+        # Getting started
+
+        Call `GET /` to reach the upstream echo endpoint.
+      published: true
+      visibility: PUBLIC

--- a/test/platform-test/e2e/tests/user-journeys/add-inline-markdown-page-in-api/gko/api-without-page.yaml
+++ b/test/platform-test/e2e/tests/user-journeys/add-inline-markdown-page-in-api/gko/api-without-page.yaml
@@ -1,0 +1,58 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The same API as api-with-page.yaml with the inline markdown page stripped;
+# re-applying this proves GKO removes the page in APIM (sync-down).
+apiVersion: gravitee.io/v1alpha1
+kind: ApiV4Definition
+metadata:
+  name: documented-api
+  labels:
+    gravitee.io/e2e: "true"
+spec:
+  contextRef:
+    name: "dev-ctx"
+    namespace: "default"
+  name: "documented-api"
+  description: "V4 proxy API documented with an inline markdown page"
+  version: "1.0.0"
+  type: PROXY
+  state: STARTED
+  definitionContext:
+    origin: KUBERNETES
+    syncFrom: MANAGEMENT
+  listeners:
+    - type: HTTP
+      paths:
+        - path: "/documented-api"
+      entrypoints:
+        - type: http-proxy
+          qos: AUTO
+  endpointGroups:
+    - name: Default HTTP proxy group
+      type: http-proxy
+      endpoints:
+        - name: Default HTTP proxy
+          type: http-proxy
+          inheritConfiguration: false
+          configuration:
+            target: https://api.gravitee.io/echo
+  flowExecution:
+    mode: DEFAULT
+    matchRequired: false
+  plans:
+    KeyLess:
+      name: "Free plan"
+      security:
+        type: "KEY_LESS"

--- a/test/platform-test/e2e/tests/user-journeys/add-inline-markdown-page-in-api/terraform/main.tf
+++ b/test/platform-test/e2e/tests/user-journeys/add-inline-markdown-page-in-api/terraform/main.tf
@@ -1,0 +1,122 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Document a V4 API with an inline markdown page, through the Terraform APIM
+# provider. Pages are an inline attribute of apim_apiv4 (no standalone apim_page
+# resource). with_page = false re-applies with an empty list to strip the page.
+terraform {
+  required_providers {
+    apim = {
+      source = "gravitee-io/apim"
+    }
+  }
+}
+
+provider "apim" {}
+
+variable "environment_id" {
+  type    = string
+  default = "DEFAULT"
+}
+
+variable "organization_id" {
+  type    = string
+  default = "DEFAULT"
+}
+
+variable "with_page" {
+  type    = bool
+  default = true
+}
+
+resource "apim_apiv4" "api" {
+  environment_id  = var.environment_id
+  organization_id = var.organization_id
+  hrid            = "documented-api-tf"
+  name            = "documented-api-tf"
+  description     = "V4 proxy API documented with an inline markdown page"
+  version         = "1"
+  type            = "PROXY"
+  state           = "STARTED"
+  lifecycle_state = "PUBLISHED"
+  visibility      = "PRIVATE"
+
+  pages = var.with_page ? [
+    {
+      hrid    = "getting-started"
+      name    = "Getting started"
+      type    = "MARKDOWN"
+      content = <<-EOT
+        # Getting started
+
+        Call `GET /` to reach the upstream echo endpoint.
+      EOT
+      published  = true
+      visibility = "PUBLIC"
+    }
+  ] : []
+
+  listeners = [
+    {
+      http = {
+        type = "HTTP"
+        paths = [
+          { path = "/documented-api-tf/" }
+        ]
+        entrypoints = [
+          { type = "http-proxy" }
+        ]
+      }
+    }
+  ]
+
+  endpoint_groups = [
+    {
+      name = "Default HTTP proxy group"
+      type = "http-proxy"
+      endpoints = [
+        {
+          name                  = "default-endpoint"
+          type                  = "http-proxy"
+          inherit_configuration = false
+          configuration         = jsonencode({ target = "https://api.gravitee.io/echo" })
+        }
+      ]
+    }
+  ]
+
+  flow_execution = {
+    mode           = "DEFAULT"
+    match_required = false
+  }
+
+  plans = [
+    {
+      hrid     = "keyless"
+      name     = "Free plan"
+      type     = "API"
+      mode     = "STANDARD"
+      status   = "PUBLISHED"
+      security = { type = "KEY_LESS" }
+    }
+  ]
+}
+
+output "api_id" {
+  value = apim_apiv4.api.id
+}
+
+output "api_context_path" {
+  value = "/documented-api-tf"
+}

--- a/test/platform-test/src/assertions/apim/mapi.ts
+++ b/test/platform-test/src/assertions/apim/mapi.ts
@@ -23,7 +23,7 @@ import type { FetchFn } from "../../types/http.js";
 import type { DeepPartial, AssertionReport, PollOptions } from "../../types/match.js";
 import type { MapiConfig } from "../../types/mapi.js";
 import type { GatewayConfig } from "../../types/gateway.js";
-import type { Api, Application, Plan, PaginatedResult, Subscription, SubscriptionApiKey, NotificationSetting, Group, GroupMember, Category } from "../../types/apim.js";
+import type { Api, Application, Plan, PaginatedResult, Subscription, SubscriptionApiKey, NotificationSetting, Group, GroupMember, Category, Page, PageTree } from "../../types/apim.js";
 import { Gateway } from "./gateway.js";
 
 /**
@@ -570,6 +570,24 @@ export class Mapi {
     if (res.status !== 204 && res.status !== 200) {
       throw new Error(`Failed to delete category ${categoryId}: ${res.status} ${res.statusText}\n${JSON.stringify(res.body, null, 2)}`);
     }
+  }
+
+  // ── Documentation Pages ────────────────────────────────────
+
+  /**
+   * List an API's documentation pages (v2 management API).
+   *
+   * Inline pages have no standalone resource on either driver, so a journey
+   * asserts them at the API level here. The endpoint returns a `{ pages }`
+   * envelope; the bare page list is returned.
+   */
+  async listApiPages(apiId: string): Promise<Page[]> {
+    const path = this.http.managementV2Path(`/apis/${apiId}/pages`);
+    const res = await this.http.get<PageTree>(path);
+    if (res.status !== 200) {
+      throw new Error(`Failed to list pages for API ${apiId}: ${res.status} ${res.statusText}\n${JSON.stringify(res.body, null, 2)}`);
+    }
+    return res.body.pages ?? [];
   }
 }
 

--- a/test/platform-test/src/types/apim.ts
+++ b/test/platform-test/src/types/apim.ts
@@ -909,3 +909,34 @@ export interface Category {
   hidden?: boolean;
   totalApis?: number;
 }
+
+// ── Documentation Page Types ──────────────────────────────────
+
+/**
+ * An API documentation page as returned by the v2 management API
+ * (`GET /apis/{apiId}/pages` → `{ pages, breadcrumb }`).
+ *
+ * Inline pages are an attribute of the API (`ApiV4Definition.spec.pages` /
+ * `apim_apiv4.pages[]`); there is no standalone `apim_page` Terraform resource,
+ * so inline is the only cross-provisioner path (standalone pages and page
+ * fetchers stay GKO-only). The `hrid` used by the provisioners is not echoed
+ * back here; APIM returns its own `id`/`crossId`.
+ */
+export interface Page {
+  id: string;
+  crossId?: string;
+  name: string;
+  type: string;
+  content?: string;
+  order?: number;
+  published?: boolean;
+  visibility?: string;
+  homepage?: boolean;
+  parentId?: string;
+}
+
+/** Envelope returned by `GET /apis/{apiId}/pages`. */
+export interface PageTree {
+  pages: Page[];
+  breadcrumb: unknown[];
+}


### PR DESCRIPTION
### Purpose

Extend GKO ↔ Terraform e2e parity (GKO-2918) to inline API documentation pages.
`apim_apiv4.pages[]` / `spec.pages` is the only cross-provisioner path for pages,
so this closes the "Pages — inline markdown" parity row.

### Summary of changes

- New user-journey `add-inline-markdown-page-in-api`: add an inline markdown page
  to a V4 API through GKO and Terraform, assert it reaches APIM
  (`GET /apis/{id}/pages`), strip it, assert it is removed. The payload is a nested
  object, so the fixtures and the assertion compare a page object, not a plain string.
- New `Page` / `PageTree` type + `mapi.listApiPages` helper.
- De-dup: the standalone V4 doc-reconcile test (GKO-1470) is folded into the
  journey's GKO arm; GKO-236/280/282 stay.
- PARITY.md + catalog README updated. Corrected an earlier claim: inline page
  fetchers (`pages[].source`) ARE Terraform-expressible.
- Xray: GKO arm = GKO-1470, TF arm = GKO-3034.

### Out of scope

- Inline page **fetchers** (`pages[].source`, http/github) — expressible on both
  drivers; a feasible follow-up journey, not built here.
- Standalone pages (no `apim_page` resource) and **V2** pages/fetchers (no
  `apim_apiv2`) — no Terraform path, stay GKO-only.

See: https://gravitee.atlassian.net/browse/GKO-3025