### PR TITLE
test: add non-HRID names upgrade survival scenario

### DIFF
--- a/test/platform-test/e2e/fixtures/upgrade/api-non-hrid-fresh.yaml
+++ b/test/platform-test/e2e/fixtures/upgrade/api-non-hrid-fresh.yaml
@@ -1,0 +1,77 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Same identifier shapes as api-non-hrid.yaml (spaced plan/page keys, lowercase
+# flow mode) but provisioned FRESH on the new line: proves the create path
+# maps them, not only the survival of carried-over resources. Distinct names
+# because re-creating a just-deleted application can hit its archived state.
+apiVersion: gravitee.io/v1alpha1
+kind: ApiV4Definition
+metadata:
+  name: non-hrid-fresh-api
+spec:
+  contextRef:
+    name: dev-ctx
+  definitionContext:
+    syncFrom: MANAGEMENT
+  name: non-hrid-fresh-api
+  version: "1.0"
+  type: PROXY
+  description: "API with non-HRID plan and page names, created after the upgrade"
+  listeners:
+    - type: HTTP
+      paths:
+        - path: "/non-hrid-fresh"
+      entrypoints:
+        - type: http-proxy
+          qos: AUTO
+  endpointGroups:
+    - name: "Default HTTP proxy group"
+      type: "http-proxy"
+      endpoints:
+        - name: "Default HTTP proxy"
+          type: "http-proxy"
+          configuration:
+            target: "https://api.gravitee.io/echo"
+          inheritConfiguration: false
+          secondary: false
+  flowExecution:
+    mode: default
+    matchRequired: false
+  pages:
+    Folder with spaces:
+      name: "non-hrid-folder"
+      type: FOLDER
+      published: true
+    Page with spaces:
+      name: "non-hrid-page"
+      type: MARKDOWN
+      parent: Folder with spaces
+      content: |
+        Documentation created after the upgrade.
+      visibility: PUBLIC
+      published: true
+  plans:
+    JWT Plan. With Spaces:
+      name: "JWT plan"
+      description: "Requires a JWT token"
+      security:
+        type: "JWT"
+        configuration:
+          signature: "RSA_RS256"
+          publicKeyResolver: "GIVEN_KEY"
+          resolverParameter: "[[ secret `jwt/public.key` ]]"
+          userClaim: "sub"
+          clientIdClaim: "client_id"
+      status: "PUBLISHED"

--- a/test/platform-test/e2e/fixtures/upgrade/api-non-hrid-updated.yaml
+++ b/test/platform-test/e2e/fixtures/upgrade/api-non-hrid-updated.yaml
@@ -1,0 +1,76 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# api-non-hrid.yaml with only the description changed. The spaced plan/page
+# keys and the lowercase flow mode stay untouched on purpose: updating a
+# carried-over resource must not require rewriting its identifiers.
+apiVersion: gravitee.io/v1alpha1
+kind: ApiV4Definition
+metadata:
+  name: non-hrid-api
+spec:
+  contextRef:
+    name: dev-ctx
+  definitionContext:
+    syncFrom: MANAGEMENT
+  name: non-hrid-api
+  version: "1.0"
+  type: PROXY
+  description: "API with non-HRID plan and page names (updated after upgrade)"
+  listeners:
+    - type: HTTP
+      paths:
+        - path: "/legacy-non-hrid"
+      entrypoints:
+        - type: http-proxy
+          qos: AUTO
+  endpointGroups:
+    - name: "Default HTTP proxy group"
+      type: "http-proxy"
+      endpoints:
+        - name: "Default HTTP proxy"
+          type: "http-proxy"
+          configuration:
+            target: "https://api.gravitee.io/echo"
+          inheritConfiguration: false
+          secondary: false
+  flowExecution:
+    mode: default
+    matchRequired: false
+  pages:
+    Folder with spaces:
+      name: "non-hrid-folder"
+      type: FOLDER
+      published: true
+    Page with spaces:
+      name: "non-hrid-page"
+      type: MARKDOWN
+      parent: Folder with spaces
+      content: |
+        Documentation created before the upgrade.
+      visibility: PUBLIC
+      published: true
+  plans:
+    JWT Plan. With Spaces:
+      name: "JWT plan"
+      description: "Requires a JWT token"
+      security:
+        type: "JWT"
+        configuration:
+          signature: "RSA_RS256"
+          publicKeyResolver: "GIVEN_KEY"
+          resolverParameter: "[[ secret `jwt/public.key` ]]"
+          userClaim: "sub"
+          clientIdClaim: "client_id"
+      status: "PUBLISHED"

--- a/test/platform-test/e2e/fixtures/upgrade/api-non-hrid.yaml
+++ b/test/platform-test/e2e/fixtures/upgrade/api-non-hrid.yaml
@@ -1,0 +1,78 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Carried across the upgrade with identifier shapes the old Management API
+# tolerated but the new control plane validates strictly: plan and page map
+# keys containing spaces and dots, a page parent referenced by such a key, and
+# a lowercase flowExecution.mode. The upgraded operator must map these to valid
+# HRIDs and normalised enums instead of failing the resource's sync.
+apiVersion: gravitee.io/v1alpha1
+kind: ApiV4Definition
+metadata:
+  name: non-hrid-api
+spec:
+  contextRef:
+    name: dev-ctx
+  definitionContext:
+    syncFrom: MANAGEMENT
+  name: non-hrid-api
+  version: "1.0"
+  type: PROXY
+  description: "API with non-HRID plan and page names"
+  listeners:
+    - type: HTTP
+      paths:
+        - path: "/legacy-non-hrid"
+      entrypoints:
+        - type: http-proxy
+          qos: AUTO
+  endpointGroups:
+    - name: "Default HTTP proxy group"
+      type: "http-proxy"
+      endpoints:
+        - name: "Default HTTP proxy"
+          type: "http-proxy"
+          configuration:
+            target: "https://api.gravitee.io/echo"
+          inheritConfiguration: false
+          secondary: false
+  flowExecution:
+    mode: default
+    matchRequired: false
+  pages:
+    Folder with spaces:
+      name: "non-hrid-folder"
+      type: FOLDER
+      published: true
+    Page with spaces:
+      name: "non-hrid-page"
+      type: MARKDOWN
+      parent: Folder with spaces
+      content: |
+        Documentation created before the upgrade.
+      visibility: PUBLIC
+      published: true
+  plans:
+    JWT Plan. With Spaces:
+      name: "JWT plan"
+      description: "Requires a JWT token"
+      security:
+        type: "JWT"
+        configuration:
+          signature: "RSA_RS256"
+          publicKeyResolver: "GIVEN_KEY"
+          resolverParameter: "[[ secret `jwt/public.key` ]]"
+          userClaim: "sub"
+          clientIdClaim: "client_id"
+      status: "PUBLISHED"

--- a/test/platform-test/e2e/fixtures/upgrade/app-non-hrid-fresh.yaml
+++ b/test/platform-test/e2e/fixtures/upgrade/app-non-hrid-fresh.yaml
@@ -1,0 +1,27 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: gravitee.io/v1alpha1
+kind: Application
+metadata:
+  name: non-hrid-fresh-app
+spec:
+  contextRef:
+    name: dev-ctx
+  name: non-hrid-fresh-app
+  description: "Application created after the upgrade"
+  settings:
+    app:
+      type: WEB
+      clientId: non-hrid-fresh-client

--- a/test/platform-test/e2e/fixtures/upgrade/app-non-hrid-updated.yaml
+++ b/test/platform-test/e2e/fixtures/upgrade/app-non-hrid-updated.yaml
@@ -1,0 +1,29 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# app-non-hrid.yaml with only the description changed, to exercise updating a
+# carried-over application on the new line.
+apiVersion: gravitee.io/v1alpha1
+kind: Application
+metadata:
+  name: non-hrid-app
+spec:
+  contextRef:
+    name: dev-ctx
+  name: non-hrid-app
+  description: "Application subscribed to a plan with a non-HRID name (updated after upgrade)"
+  settings:
+    app:
+      type: WEB
+      clientId: non-hrid-client

--- a/test/platform-test/e2e/fixtures/upgrade/app-non-hrid.yaml
+++ b/test/platform-test/e2e/fixtures/upgrade/app-non-hrid.yaml
@@ -1,0 +1,27 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: gravitee.io/v1alpha1
+kind: Application
+metadata:
+  name: non-hrid-app
+spec:
+  contextRef:
+    name: dev-ctx
+  name: non-hrid-app
+  description: "Application subscribed to a plan with a non-HRID name"
+  settings:
+    app:
+      type: WEB
+      clientId: non-hrid-client

--- a/test/platform-test/e2e/fixtures/upgrade/sub-non-hrid-fresh.yaml
+++ b/test/platform-test/e2e/fixtures/upgrade/sub-non-hrid-fresh.yaml
@@ -1,0 +1,24 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: gravitee.io/v1alpha1
+kind: Subscription
+metadata:
+  name: non-hrid-fresh-sub
+spec:
+  api:
+    name: non-hrid-fresh-api
+  application:
+    name: non-hrid-fresh-app
+  plan: "JWT Plan. With Spaces"

--- a/test/platform-test/e2e/fixtures/upgrade/sub-non-hrid-updated.yaml
+++ b/test/platform-test/e2e/fixtures/upgrade/sub-non-hrid-updated.yaml
@@ -1,0 +1,27 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# sub-non-hrid.yaml plus an end date: updating the subscription re-runs the
+# update path where the plan reference (a non-HRID map key) must be mapped.
+apiVersion: gravitee.io/v1alpha1
+kind: Subscription
+metadata:
+  name: non-hrid-sub
+spec:
+  api:
+    name: non-hrid-api
+  application:
+    name: non-hrid-app
+  plan: "JWT Plan. With Spaces"
+  endingAt: "2031-01-01T00:00:00Z"

--- a/test/platform-test/e2e/fixtures/upgrade/sub-non-hrid.yaml
+++ b/test/platform-test/e2e/fixtures/upgrade/sub-non-hrid.yaml
@@ -1,0 +1,26 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The plan is referenced by its raw map key, spaces and dot included, exactly
+# as a user's manifest would after subscribing on the old line.
+apiVersion: gravitee.io/v1alpha1
+kind: Subscription
+metadata:
+  name: non-hrid-sub
+spec:
+  api:
+    name: non-hrid-api
+  application:
+    name: non-hrid-app
+  plan: "JWT Plan. With Spaces"

--- a/test/platform-test/e2e/helpers/tags.ts
+++ b/test/platform-test/e2e/helpers/tags.ts
@@ -49,8 +49,7 @@ export const XRAY = {
     V4_SURVIVES_UPGRADE: "@GKO-1061",
     V2_SURVIVES_UPGRADE: "@GKO-1060",
     V4_RECONCILE_CYCLE_SURVIVES: "@GKO-2984",
-    // Placeholder - synced to a real Jira Test by /xray-sync-tests.
-    DATASTORE_SURVIVES_UPGRADE: "@GKO-TBD-datastore-survives-upgrade",
+    DATASTORE_SURVIVES_UPGRADE: "@GKO-3045",
     NON_HRID_SURVIVES_UPGRADE: "@GKO-3043",
     NON_HRID_FRESH_ON_NEW_LINE: "@GKO-3044",
     START_STOP_V2_V4_NATIVE: "@GKO-1464",

--- a/test/platform-test/e2e/helpers/tags.ts
+++ b/test/platform-test/e2e/helpers/tags.ts
@@ -51,6 +51,7 @@ export const XRAY = {
     V4_RECONCILE_CYCLE_SURVIVES: "@GKO-2984",
     // Placeholder - synced to a real Jira Test by /xray-sync-tests.
     DATASTORE_SURVIVES_UPGRADE: "@GKO-TBD-datastore-survives-upgrade",
+    NON_HRID_SURVIVES_UPGRADE: "@GKO-3043",
     START_STOP_V2_V4_NATIVE: "@GKO-1464",
     POLICY_ON_API_WITHOUT_PLANS: "@GKO-1465",
     ENTRYPOINT_POLICY_MATRIX: "@GKO-1474",

--- a/test/platform-test/e2e/helpers/tags.ts
+++ b/test/platform-test/e2e/helpers/tags.ts
@@ -52,6 +52,7 @@ export const XRAY = {
     // Placeholder - synced to a real Jira Test by /xray-sync-tests.
     DATASTORE_SURVIVES_UPGRADE: "@GKO-TBD-datastore-survives-upgrade",
     NON_HRID_SURVIVES_UPGRADE: "@GKO-3043",
+    NON_HRID_FRESH_ON_NEW_LINE: "@GKO-3044",
     START_STOP_V2_V4_NATIVE: "@GKO-1464",
     POLICY_ON_API_WITHOUT_PLANS: "@GKO-1465",
     ENTRYPOINT_POLICY_MATRIX: "@GKO-1474",

--- a/test/platform-test/e2e/tests/upgrade/survival-scenario.ts
+++ b/test/platform-test/e2e/tests/upgrade/survival-scenario.ts
@@ -119,6 +119,41 @@ export const survivalNonHridScenario = gkoScenario({
   },
 });
 
+/** Fixed identities for the non-HRID-names resources created on the NEW line. */
+export const SURVIVAL_NON_HRID_FRESH = {
+  apiName: "non-hrid-fresh-api",
+  appName: "non-hrid-fresh-app",
+  subName: "non-hrid-fresh-sub",
+  clientId: "non-hrid-fresh-client",
+  contextPath: "/non-hrid-fresh",
+  folderName: "non-hrid-folder",
+  pageName: "non-hrid-page",
+} as const;
+
+/**
+ * Same identifier shapes as {@link survivalNonHridScenario} but provisioned
+ * FRESH in the after-phase: proves the new line's create path handles them,
+ * not only the survival of carried-over resources. Distinct names because
+ * re-creating a just-deleted application can hit its archived state in APIM.
+ */
+export const survivalNonHridFreshScenario = gkoScenario({
+  manifests: [
+    "upgrade/jwt-secret.yaml",
+    "upgrade/api-non-hrid-fresh.yaml",
+    "upgrade/app-non-hrid-fresh.yaml",
+  ],
+  roles: {
+    api: { kind: "apiv4definition", name: SURVIVAL_NON_HRID_FRESH.apiName },
+    application: { kind: "application", name: SURVIVAL_NON_HRID_FRESH.appName },
+    subscription: { kind: "subscription", name: SURVIVAL_NON_HRID_FRESH.subName },
+  },
+  dynamicRoles: ["subscription"],
+  contextPath: SURVIVAL_NON_HRID_FRESH.contextPath,
+  applyParams: async (kubectl) => {
+    await kubectl.apply(fixture("upgrade/sub-non-hrid-fresh.yaml"));
+  },
+});
+
 /** Fixed identity for the V2 keyless survival API (GKO-1060). */
 export const SURVIVAL_V2 = {
   apiName: "legacy-v2-api",

--- a/test/platform-test/e2e/tests/upgrade/survival-scenario.ts
+++ b/test/platform-test/e2e/tests/upgrade/survival-scenario.ts
@@ -77,6 +77,48 @@ export const survivalScenario = gkoScenario({
   },
 });
 
+/**
+ * Fixed identities + expectations for the non-HRID-names survival check. The
+ * API carries identifier shapes the old (4.11) Management API tolerated but the
+ * new control plane validates strictly: plan and page map keys with spaces and
+ * dots, a page parent referenced by such a key, and a lowercase
+ * flowExecution.mode. The upgraded operator must keep syncing these resources
+ * (mapping the keys to valid HRIDs, normalising the enums) instead of marking
+ * them SyncFailed on their first reconcile after the upgrade.
+ */
+export const SURVIVAL_NON_HRID = {
+  apiName: "non-hrid-api",
+  appName: "non-hrid-app",
+  subName: "non-hrid-sub",
+  clientId: "non-hrid-client",
+  contextPath: "/legacy-non-hrid",
+  folderName: "non-hrid-folder",
+  pageName: "non-hrid-page",
+  updatedDescription: "API with non-HRID plan and page names (updated after upgrade)",
+  updatedAppDescription:
+    "Application subscribed to a plan with a non-HRID name (updated after upgrade)",
+} as const;
+
+/**
+ * GKO provisioner for the non-HRID-names API + app + JWT-plan subscription
+ * (the subscription references the plan by its raw spaced map key). Shares the
+ * `jwt` templating secret with the core scenario; listing it here too keeps
+ * this scenario self-sufficient (apply is idempotent).
+ */
+export const survivalNonHridScenario = gkoScenario({
+  manifests: ["upgrade/jwt-secret.yaml", "upgrade/api-non-hrid.yaml", "upgrade/app-non-hrid.yaml"],
+  roles: {
+    api: { kind: "apiv4definition", name: SURVIVAL_NON_HRID.apiName },
+    application: { kind: "application", name: SURVIVAL_NON_HRID.appName },
+    subscription: { kind: "subscription", name: SURVIVAL_NON_HRID.subName },
+  },
+  dynamicRoles: ["subscription"],
+  contextPath: SURVIVAL_NON_HRID.contextPath,
+  applyParams: async (kubectl) => {
+    await kubectl.apply(fixture("upgrade/sub-non-hrid.yaml"));
+  },
+});
+
 /** Fixed identity for the V2 keyless survival API (GKO-1060). */
 export const SURVIVAL_V2 = {
   apiName: "legacy-v2-api",

--- a/test/platform-test/e2e/tests/upgrade/survival.after.spec.ts
+++ b/test/platform-test/e2e/tests/upgrade/survival.after.spec.ts
@@ -43,6 +43,8 @@ import {
   SURVIVAL,
   survivalNonHridScenario,
   SURVIVAL_NON_HRID,
+  survivalNonHridFreshScenario,
+  SURVIVAL_NON_HRID_FRESH,
   survivalV2Scenario,
   SURVIVAL_V2,
   survivalV2SubScenario,
@@ -68,9 +70,9 @@ function targetAtLeast(version: string): boolean {
 test.afterAll(async () => {
   const order = [
     "v2-sub", "sub-legacy-weather", "sub-mobile-legacy", "sub-mobile-weather", "sub-legacy-mtls", "sub-legacy-legacy-jwt",
-    "sub-non-hrid",
-    "v2-sub-app", "app-mobile", "app-legacy", "app-non-hrid",
-    "v2-sub-api", "api-weather", "api-legacy", "api-non-hrid",
+    "sub-non-hrid", "sub-non-hrid-fresh",
+    "v2-sub-app", "app-mobile", "app-legacy", "app-non-hrid", "app-non-hrid-fresh",
+    "v2-sub-api", "api-weather", "api-legacy", "api-non-hrid", "api-non-hrid-fresh",
     "v2-legacy-api", "jwt-secret",
   ];
   for (const f of order) {
@@ -417,4 +419,41 @@ test(`upgrade survival (non-HRID names): reconcile, update, delete on the new li
     await mapi.assertApiHttpStatus(apiId, 404);
     await gateway.assertNotResponds(ctx, { notStatus: 200, headers: bearer() });
   });
+});
+
+test(`upgrade survival (non-HRID names): fresh resources provision on the new line ${XRAY.API_LIFECYCLE.NON_HRID_FRESH_ON_NEW_LINE} @upgrade @after`, async ({
+  mapi,
+  gateway,
+}) => {
+  // Create-path counterpart of the carried-over check: a brand-new API, app and
+  // subscription using the same spaced plan/page keys and lowercase flow mode
+  // must provision through the new control plane from scratch.
+  const provisioned = await survivalNonHridFreshScenario().provision({});
+
+  const apiId = await provisioned.apiId();
+  const subId = await provisioned.subscriptionId();
+  const ctx = await provisioned.contextPath();
+  const bearer = () => ({ Authorization: `Bearer ${signJwt(SURVIVAL_NON_HRID_FRESH.clientId)}` });
+
+  await mapi.waitForApiStarted(apiId, { timeoutMs: 30_000 });
+  await mapi.assertSubscriptionAccepted(apiId, subId);
+  await gateway.assertResponds(ctx, { status: 401 });
+  await gateway.assertResponds(ctx, { status: 200, headers: bearer() });
+
+  await expect
+    .poll(
+      async () => {
+        const pages = await mapi.listApiPages(apiId);
+        return {
+          folders: pages.filter((p) => p.name === SURVIVAL_NON_HRID_FRESH.folderName).length,
+          markdowns: pages.filter((p) => p.name === SURVIVAL_NON_HRID_FRESH.pageName).length,
+        };
+      },
+      { timeout: 30_000 },
+    )
+    .toEqual({ folders: 1, markdowns: 1 });
+
+  await provisioned.destroy();
+  await kubectl.waitForDeletion("apiv4definition", SURVIVAL_NON_HRID_FRESH.apiName);
+  await mapi.assertApiHttpStatus(apiId, 404);
 });

--- a/test/platform-test/e2e/tests/upgrade/survival.after.spec.ts
+++ b/test/platform-test/e2e/tests/upgrade/survival.after.spec.ts
@@ -41,6 +41,8 @@ import { XRAY } from "../../helpers/tags.js";
 import {
   survivalScenario,
   SURVIVAL,
+  survivalNonHridScenario,
+  SURVIVAL_NON_HRID,
   survivalV2Scenario,
   SURVIVAL_V2,
   survivalV2SubScenario,
@@ -66,8 +68,10 @@ function targetAtLeast(version: string): boolean {
 test.afterAll(async () => {
   const order = [
     "v2-sub", "sub-legacy-weather", "sub-mobile-legacy", "sub-mobile-weather", "sub-legacy-mtls", "sub-legacy-legacy-jwt",
-    "v2-sub-app", "app-mobile", "app-legacy",
-    "v2-sub-api", "api-weather", "api-legacy", "v2-legacy-api", "jwt-secret",
+    "sub-non-hrid",
+    "v2-sub-app", "app-mobile", "app-legacy", "app-non-hrid",
+    "v2-sub-api", "api-weather", "api-legacy", "api-non-hrid",
+    "v2-legacy-api", "jwt-secret",
   ];
   for (const f of order) {
     await kubectl.del(fixture(`upgrade/${f}.yaml`)).catch(() => {});
@@ -317,5 +321,100 @@ test(`upgrade survival (V2): keyless V2 API survives the upgrade ${XRAY.API_LIFE
     await provisioned.destroy();
     await kubectl.waitForDeletion("apidefinition", SURVIVAL_V2.apiName);
     await gateway.assertNotResponds(ctx, { notStatus: 200 });
+  });
+});
+
+test(`upgrade survival (non-HRID names): reconcile, update, delete on the new line ${XRAY.API_LIFECYCLE.NON_HRID_SURVIVES_UPGRADE} @upgrade @after`, async ({
+  mapi,
+  gateway,
+}) => {
+  const provisioner = survivalNonHridScenario();
+  if (!provisioner.attach) {
+    throw new Error("the GKO provisioner does not implement attach(); cannot run the after-phase");
+  }
+
+  // Rebuild a handle to the resources created before the upgrade (a missing CR
+  // here means it did not survive).
+  const provisioned = await provisioner.attach({
+    api: { hrid: SURVIVAL_NON_HRID.apiName },
+    application: { hrid: SURVIVAL_NON_HRID.appName },
+    subscription: { hrid: SURVIVAL_NON_HRID.subName },
+  });
+
+  const apiId = await provisioned.apiId();
+  const appId = await provisioned.applicationId();
+  const subId = await provisioned.subscriptionId();
+  const ctx = await provisioned.contextPath();
+  const bearer = () => ({ Authorization: `Bearer ${signJwt(SURVIVAL_NON_HRID.clientId)}` });
+
+  // The core-survival teardown deletes the shared JWT templating secret; the
+  // reconciles below re-resolve the plan's public key from it, so put it back.
+  await kubectl.apply(fixture("upgrade/jwt-secret.yaml"));
+
+  await test.step("resources survived the post-upgrade resync", async () => {
+    // The upgraded operator reconciles every carried-over CR on startup. That
+    // resync must accept the spaced plan/page keys and the lowercase flow mode
+    // instead of rejecting the resources (Accepted=False, ControlPlaneError)
+    // with no retry - the condition checks make that failure mode explicit.
+    await kubectl.waitForCondition("apiv4definition", SURVIVAL_NON_HRID.apiName, "Accepted");
+    await kubectl.waitForCondition("application", SURVIVAL_NON_HRID.appName, "Accepted");
+    await kubectl.waitForCondition("subscription", SURVIVAL_NON_HRID.subName, "Accepted");
+
+    await mapi.waitForApiStarted(apiId, { timeoutMs: 30_000 });
+    await mapi.assertSubscriptionAccepted(apiId, subId);
+    await gateway.assertResponds(ctx, { status: 401 });
+    await gateway.assertResponds(ctx, { status: 200, headers: bearer() });
+
+    // The pages declared under spaced map keys are still there, once each:
+    // remapping their identifiers must not drop or duplicate them.
+    await expect
+      .poll(
+        async () => {
+          const pages = await mapi.listApiPages(apiId);
+          return {
+            folders: pages.filter((p) => p.name === SURVIVAL_NON_HRID.folderName).length,
+            markdowns: pages.filter((p) => p.name === SURVIVAL_NON_HRID.pageName).length,
+          };
+        },
+        { timeout: 30_000 },
+      )
+      .toEqual({ folders: 1, markdowns: 1 });
+  });
+
+  await test.step("the new operator updates the carried-over resources", async () => {
+    // The identifiers stay spaced/lowercase in the updated manifests: a user
+    // must not have to rewrite them for updates to keep working. Each update
+    // pushes the full definition through the new control-plane path.
+    await kubectl.apply(fixture("upgrade/api-non-hrid-updated.yaml"));
+    await mapi.waitForApiMatches(
+      apiId,
+      { description: SURVIVAL_NON_HRID.updatedDescription },
+      { timeoutMs: 30_000 },
+    );
+
+    await kubectl.apply(fixture("upgrade/app-non-hrid-updated.yaml"));
+    await mapi.waitForApplicationMatches(
+      appId,
+      { description: SURVIVAL_NON_HRID.updatedAppDescription },
+      { timeoutMs: 30_000 },
+    );
+
+    await kubectl.apply(fixture("upgrade/sub-non-hrid-updated.yaml"));
+    await expect
+      .poll(async () => (await mapi.fetchSubscription(apiId, subId)).endingAt, {
+        timeout: 30_000,
+      })
+      .toBeTruthy();
+    await mapi.assertSubscriptionAccepted(apiId, subId);
+
+    // The updates did not break the data plane.
+    await gateway.assertResponds(ctx, { status: 200, headers: bearer() });
+  });
+
+  await test.step("clean teardown", async () => {
+    await provisioned.destroy();
+    await kubectl.waitForDeletion("apiv4definition", SURVIVAL_NON_HRID.apiName);
+    await mapi.assertApiHttpStatus(apiId, 404);
+    await gateway.assertNotResponds(ctx, { notStatus: 200, headers: bearer() });
   });
 });

--- a/test/platform-test/e2e/tests/upgrade/survival.before.spec.ts
+++ b/test/platform-test/e2e/tests/upgrade/survival.before.spec.ts
@@ -27,10 +27,16 @@
  * never collects it.
  */
 
-import { test } from "../../setup.js";
+import { test, expect } from "../../setup.js";
 import * as kubectl from "../../helpers/kubectl.js";
 import { signJwt } from "../../helpers/jwt.js";
-import { DATASTORE, survivalScenario, survivalV2Scenario } from "./survival-scenario.js";
+import {
+  DATASTORE,
+  SURVIVAL_NON_HRID,
+  survivalNonHridScenario,
+  survivalScenario,
+  survivalV2Scenario,
+} from "./survival-scenario.js";
 
 test("upgrade survival: provision and verify on the old line @upgrade @before", async ({
   mapi,
@@ -66,6 +72,47 @@ test("upgrade survival (V2): keyless V2 API reachable on the old line @upgrade @
   // provision() already waited for the V2 API CR to reconcile (Accepted); the
   // keyless plan means the gateway serves it without a token. Leave it running.
   await gateway.assertResponds(ctx, { status: 200 });
+});
+
+test("upgrade survival (non-HRID names): provision and verify on the old line @upgrade @before", async ({
+  mapi,
+  gateway,
+}) => {
+  const provisioned = await survivalNonHridScenario().provision({});
+
+  const apiId = await provisioned.apiId();
+  const subId = await provisioned.subscriptionId();
+  const ctx = await provisioned.contextPath();
+
+  // Healthy on the OLD line despite the spaced plan/page keys and the lowercase
+  // flow mode: the API is started and the subscription (which references the
+  // plan by its raw spaced key) is accepted.
+  await mapi.waitForApiStarted(apiId, { timeoutMs: 30_000 });
+  await mapi.assertSubscriptionAccepted(apiId, subId);
+
+  // Reachable through the gateway: rejected without a token, served with a
+  // valid JWT (client_id = the subscribed app's clientId).
+  await gateway.assertResponds(ctx, { status: 401 });
+  await gateway.assertResponds(ctx, {
+    status: 200,
+    headers: { Authorization: `Bearer ${signJwt(SURVIVAL_NON_HRID.clientId)}` },
+  });
+
+  // The pages declared under spaced map keys made it into APIM, once each.
+  await expect
+    .poll(
+      async () => {
+        const pages = await mapi.listApiPages(apiId);
+        return {
+          folders: pages.filter((p) => p.name === SURVIVAL_NON_HRID.folderName).length,
+          markdowns: pages.filter((p) => p.name === SURVIVAL_NON_HRID.pageName).length,
+        };
+      },
+      { timeout: 30_000 },
+    )
+    .toEqual({ folders: 1, markdowns: 1 });
+
+  // No teardown on purpose - the after-phase re-attaches to these resources.
 });
 
 test("upgrade survival: record the datastore identity before the upgrade @upgrade @before", async () => {


### PR DESCRIPTION
## Purpose

Add an upgrade survival scenario for resources whose plan and page map keys are not valid HRIDs (spaces, dots) and whose `flowExecution.mode` is lowercase, running in the existing two-phase upgrade lane (provisioned on GKO 4.11 + APIM 4.11, verified after the in-place upgrade).

## Summary of changes

- New fixtures under `e2e/fixtures/upgrade/`: core trio with plan key `JWT Plan. With Spaces`, spaced page keys and lowercase mode; updated variants (descriptions, subscription `endingAt`); a fresh trio for the create path
- `survival-scenario.ts`: `SURVIVAL_NON_HRID` / `SURVIVAL_NON_HRID_FRESH` constants and factories
- Before phase: provision + verify on the old line; after phase: carried-over resources reach Accepted after the post-upgrade resync, stay reachable, accept updates with unchanged identifiers, delete cleanly (@GKO-3043); same shapes provision fresh on the new line (@GKO-3044); safety-net teardown extended
- `tags.ts`: real Xray ids, including the outstanding datastore placeholder (@GKO-3045)

Verified on the full local lane twice: against master the after phase fails on GKO-3042 (found by this scenario); against #1721 all five after-phase tests pass. The master upgrade lane stays red until the GKO-3042 fix is cherry-picked to master.

## Out of scope

- The GKO-3042 fix itself (#1721) and its master cherry-pick
- Removing the temporary usecase integration test from #1718 (follow-up in GKO-3041 once the lane is stable)
- Version-pair parameterization of the upgrade lane (GKO-2985)

See: https://gravitee.atlassian.net/browse/GKO-3041