### PR TITLE
fix: preserve AutomationAPIManaged condition on failed reconcile

### DIFF
--- a/internal/k8s/conditions.go
+++ b/internal/k8s/conditions.go
@@ -123,6 +123,11 @@ func ErrorToCondition(obj client.Object, err error) {
 		}
 	}
 	conditions := []metav1.Condition{*ac, *refs}
+	if ca, ok := obj.(core.ConditionAware); ok {
+		if toKeep := GetCondition(ca, AutomationAPIManaged); toKeep != nil {
+			conditions = append(conditions, *toKeep)
+		}
+	}
 	SetConditions(obj, conditions)
 }
 

--- a/internal/k8s/conditions_test.go
+++ b/internal/k8s/conditions_test.go
@@ -1,0 +1,95 @@
+// Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gravitee-io/gravitee-kubernetes-operator/api/v1alpha1"
+	gerrors "github.com/gravitee-io/gravitee-kubernetes-operator/internal/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestErrorToCondition_PreservesAutomationAPIManaged(t *testing.T) {
+	api := &v1alpha1.ApiV4Definition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-api",
+			Namespace:  "default",
+			Generation: 2,
+		},
+	}
+
+	api.Status.Conditions = []metav1.Condition{
+		{
+			Type:               AutomationAPIManaged,
+			Status:             metav1.ConditionTrue,
+			Reason:             AutomationAPIManaged,
+			ObservedGeneration: 1,
+		},
+	}
+
+	err := gerrors.NewControlPlaneError(fmt.Errorf("some transient APIM error"))
+	ErrorToCondition(api, err)
+
+	conditions := api.GetConditions()
+
+	if _, ok := conditions[AutomationAPIManaged]; !ok {
+		t.Fatal("AutomationAPIManaged condition was wiped by ErrorToCondition")
+	}
+	if conditions[AutomationAPIManaged].Status != metav1.ConditionTrue {
+		t.Fatalf("AutomationAPIManaged condition status changed to %s, want True",
+			conditions[AutomationAPIManaged].Status)
+	}
+
+	if _, ok := conditions[ConditionAccepted]; !ok {
+		t.Fatal("Accepted condition missing after ErrorToCondition")
+	}
+	if conditions[ConditionAccepted].Status != ConditionStatusFalse {
+		t.Fatalf("Accepted condition status is %s, want False", conditions[ConditionAccepted].Status)
+	}
+
+	if _, ok := conditions[ConditionResolvedRefs]; !ok {
+		t.Fatal("ResolvedRefs condition missing after ErrorToCondition")
+	}
+}
+
+func TestErrorToCondition_WithoutAutomationAPIManaged(t *testing.T) {
+	api := &v1alpha1.ApiV4Definition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-api",
+			Namespace:  "default",
+			Generation: 1,
+		},
+	}
+	api.Status.Conditions = []metav1.Condition{}
+
+	err := gerrors.NewControlPlaneError(fmt.Errorf("some error"))
+	ErrorToCondition(api, err)
+
+	conditions := api.GetConditions()
+
+	if _, ok := conditions[AutomationAPIManaged]; ok {
+		t.Fatal("AutomationAPIManaged condition should not appear when it was not previously set")
+	}
+
+	if _, ok := conditions[ConditionAccepted]; !ok {
+		t.Fatal("Accepted condition missing after ErrorToCondition")
+	}
+
+	if _, ok := conditions[ConditionResolvedRefs]; !ok {
+		t.Fatal("ResolvedRefs condition missing after ErrorToCondition")
+	}
+}

--- a/runbooks/upgrade-lifecycle/runbook.md
+++ b/runbooks/upgrade-lifecycle/runbook.md
@@ -394,6 +394,67 @@ curl -s -o /dev/null -w "---\nstatus %{http_code}\n---\n" http://localhost:30082
 
 ---
 
+## Troubleshooting: "Path/Host already exists" after upgrade
+
+### Symptom
+
+After upgrading from GKO 4.11.x to 4.12.x, reconciliation of an existing `ApiV4Definition` fails with:
+
+```
+request [PUT] .../automation/.../apis?dryRun=false failed with status 400
+(Unable to import because of errors [Path [/my-path/] already exists])
+```
+
+or the equivalent `Hosts [my-host] already exists` for native APIs.
+
+The GKO log line will show `"resourceID":""` — meaning `Status.ID` is empty.
+
+### Root cause
+
+GKO 4.12 syncs V4 APIs via the Automation API using HRIDs. When the CRD has no
+`Status.ID` (e.g. the CRD was deleted and recreated, or never successfully
+synced under 4.11), GKO cannot link it to the existing API in APIM and tries to
+create a new one, which collides on path/host uniqueness.
+
+### Recovery
+
+Set `spec.id` on the CRD to the UUID of the existing API in APIM. This routes
+GKO through the legacy path with `hridContainsUUID=true`, matching the existing
+API by UUID instead of trying to create a new one.
+
+1. Find the API UUID in the APIM Console (API > General Info > API ID), or via
+   the management API:
+   ```bash
+   curl -s "$APIM_URL/management/v2/environments/DEFAULT/apis?q=<api-name>" \
+     -H "Authorization: Bearer $TOKEN" | jq '.[0].id'
+   ```
+
+2. Add `spec.id` to the CRD:
+   ```yaml
+   apiVersion: gravitee.io/v1alpha1
+   kind: ApiV4Definition
+   metadata:
+     name: my-api
+   spec:
+     id: "<UUID-from-APIM>"
+     contextRef:
+       name: my-context
+     # ... rest of spec unchanged
+   ```
+
+3. Apply the updated CRD. The next reconcile will import with `hridContainsUUID=true`
+   and update the existing API in place. Once successful, `Status.ID` is
+   repopulated and the `spec.id` field can optionally be kept for clarity.
+
+### Prevention
+
+Avoid deleting and recreating `ApiV4Definition` CRDs that were previously
+synced under GKO 4.11. A standard `kubectl apply` (without delete) preserves
+the `status` subresource, which carries the `Status.ID` needed for the upgrade
+path. Helm upgrades and operator restarts also preserve status.
+
+---
+
 ## Resource Summary
 
 | Phase | Resource | File |


### PR DESCRIPTION
ErrorToCondition now retains the AutomationAPIManaged condition instead of wiping the entire condition slice, preventing HRID-managed resources from silently reverting to the legacy UUID path after a transient error — includes unit tests and upgrade runbook documentation for the spec.id manual recovery workaround.