### PR TITLE
feat: implement matching accross route

### DIFF
--- a/controllers/gateway-api/httproute/controller.go
+++ b/controllers/gateway-api/httproute/controller.go
@@ -46,7 +46,6 @@ type Reconciler struct {
 	Recorder record.EventRecorder
 }
 
-//nolint:gocognit // acceptable complexity
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	route := &gwAPIv1.HTTPRoute{}
 	if err := k8s.GetClient().Get(ctx, req.NamespacedName, route); err != nil {
@@ -73,43 +72,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			}
 
 			return events.Record(event.Update, route, func() error {
-				internal.Init(dc)
-
-				// Create a shared gateway cache to ensure both Resolve and Accept use the same gateway versions
-				cache := make(internal.GatewayCache)
-
-				if err := internal.ResolveWithCache(ctx, dc, cache); err != nil {
-					return err
-				}
-
-				if err := internal.AcceptWithCache(ctx, dc, cache); err != nil {
-					return err
-				}
-
-				// TODO: detect with merge conflict resolution
-				if err := internal.DetectConflicts(ctx, dc); err != nil {
-					return err
-				}
-
-				for i := range dc.Status.Parents {
-					parent := &dc.Status.Parents[i]
-					if k8s.IsConflicted(gateway.WrapRouteParentStatus(parent)) {
-						return nil
-					}
-				}
-
-				ctx = mapper.WithGatewayCache(ctx, mapper.GatewayCache(cache))
-
-				if env.Config.GatewayAPISkipAPIDefinition {
-					if err := internal.ProgramConfigMap(ctx, dc); err != nil {
-						return err
-					}
-				} else {
-					if err := internal.Program(ctx, dc); err != nil {
-						return err
-					}
-				}
-				return nil
+				return r.reconcileRoute(ctx, dc)
 			})
 		})
 	})
@@ -141,6 +104,48 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	log.InfoEndReconcile(ctx, route)
 	return ctrl.Result{}, nil
+}
+
+func (r *Reconciler) reconcileRoute(ctx context.Context, dc *gwAPIv1.HTTPRoute) error {
+	internal.Init(dc)
+
+	cache := make(internal.GatewayCache)
+
+	if err := internal.ResolveWithCache(ctx, dc, cache); err != nil {
+		return err
+	}
+
+	if err := internal.AcceptWithCache(ctx, dc, cache); err != nil {
+		return err
+	}
+
+	ctx = mapper.WithGatewayCache(ctx, mapper.GatewayCache(cache))
+
+	switch {
+	case env.Config.GatewayAPISkipAPIDefinition && env.Config.GatewayAPIMatchAcrossRoutes:
+		return internal.ProgramMergedConfigMaps(ctx, dc)
+	case env.Config.GatewayAPISkipAPIDefinition:
+		return internal.ProgramConfigMap(ctx, dc)
+	case env.Config.GatewayAPIMatchAcrossRoutes:
+		return internal.ProgramMergedAPIs(ctx, dc)
+	default:
+		return r.reconcileDefault(ctx, dc)
+	}
+}
+
+func (r *Reconciler) reconcileDefault(ctx context.Context, dc *gwAPIv1.HTTPRoute) error {
+	if err := internal.DetectConflicts(ctx, dc); err != nil {
+		return err
+	}
+
+	for i := range dc.Status.Parents {
+		parent := &dc.Status.Parents[i]
+		if k8s.IsConflicted(gateway.WrapRouteParentStatus(parent)) {
+			return nil
+		}
+	}
+
+	return internal.Program(ctx, dc)
 }
 
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/controllers/gateway-api/httproute/internal/mapper/endpoints.go
+++ b/controllers/gateway-api/httproute/internal/mapper/endpoints.go
@@ -33,7 +33,7 @@ var (
 	defaultEndpointWeight int32 = 1
 )
 
-func buildEndpointGroups(ctx context.Context, route *gwAPIv1.HTTPRoute) ([]*v4.EndpointGroup, error) {
+func buildEndpointGroupsWithPrefix(ctx context.Context, route *gwAPIv1.HTTPRoute, prefix string) ([]*v4.EndpointGroup, error) {
 	groups := []*v4.EndpointGroup{}
 	for ruleIndex, rule := range route.Spec.Rules {
 		for matchIndex, match := range rule.Matches {
@@ -44,6 +44,7 @@ func buildEndpointGroups(ctx context.Context, route *gwAPIv1.HTTPRoute) ([]*v4.E
 				ruleIndex,
 				match,
 				matchIndex,
+				prefix,
 			)
 			if err != nil {
 				return nil, err
@@ -61,9 +62,10 @@ func buildEndpointGroup(
 	ruleIndex int,
 	match gwAPIv1.HTTPRouteMatch,
 	matchIndex int,
+	prefix string,
 ) (*v4.EndpointGroup, error) {
 	endpointGroup := v4.NewHttpEndpointGroup(
-		buildEndpointGroupName(ruleIndex, matchIndex),
+		buildEndpointGroupName(ruleIndex, matchIndex, prefix),
 	)
 
 	backendRefs := getActiveBackendRefs(rule.BackendRefs)
@@ -80,8 +82,8 @@ func buildEndpointGroup(
 	return endpointGroup, nil
 }
 
-func buildEndpointGroupName(ruleIndex, matchIndex int) string {
-	return fmt.Sprintf("endpoints-%d-%d", ruleIndex, matchIndex)
+func buildEndpointGroupName(ruleIndex, matchIndex int, prefix string) string {
+	return fmt.Sprintf("%sendpoints-%d-%d", prefix, ruleIndex, matchIndex)
 }
 
 func buildEndpoints(

--- a/controllers/gateway-api/httproute/internal/mapper/flows.go
+++ b/controllers/gateway-api/httproute/internal/mapper/flows.go
@@ -49,7 +49,7 @@ type weightedFlow struct {
 	Weight int
 }
 
-func buildFlows(ctx context.Context, route *gwAPIv1.HTTPRoute) ([]*v4.Flow, error) {
+func buildFlowsWithPrefix(ctx context.Context, route *gwAPIv1.HTTPRoute, prefix string) ([]*v4.Flow, error) {
 	weightedFlows := make([]weightedFlow, 0)
 
 	for ruleIndex, rule := range route.Spec.Rules {
@@ -57,7 +57,7 @@ func buildFlows(ctx context.Context, route *gwAPIv1.HTTPRoute) ([]*v4.Flow, erro
 			conditionsExpressions := buildFlowConditionExpressions(match)
 
 			if flow, err := createRuleMatchFlow(
-				ctx, route, rule, ruleIndex, match, matchIndex, conditionsExpressions,
+				ctx, route, rule, ruleIndex, match, matchIndex, conditionsExpressions, prefix,
 			); err != nil {
 				return nil, err
 			} else {
@@ -101,6 +101,7 @@ func createRuleMatchFlow(
 	match gwAPIv1.HTTPRouteMatch,
 	matchIndex int,
 	conditionsExpressions []el.Expression,
+	prefix string,
 ) (*v4.Flow, error) {
 	hasUnresolvedBackend, err := hasUnresolvedBackendForRule(ctx, route, rule)
 	if err != nil {
@@ -119,7 +120,7 @@ func createRuleMatchFlow(
 	case hasInvalidGrants:
 		return buildRuleErrorFlow("Invalid reference grant", match, conditionsExpressions), nil
 	default:
-		return buildRoutingFlow(ctx, route, rule, ruleIndex, match, matchIndex, conditionsExpressions), nil
+		return buildRoutingFlow(ctx, route, rule, ruleIndex, match, matchIndex, conditionsExpressions, prefix), nil
 	}
 }
 
@@ -131,11 +132,12 @@ func buildRoutingFlow(
 	match gwAPIv1.HTTPRouteMatch,
 	matchIndex int,
 	conditionsExpressions []el.Expression,
+	prefix string,
 ) *v4.Flow {
-	flowName := fmt.Sprintf("rule-%d-match%d", ruleIndex, matchIndex)
+	flowName := fmt.Sprintf("%srule-%d-match%d", prefix, ruleIndex, matchIndex)
 	return &v4.Flow{
 		Name:      &flowName,
-		Request:   buildRequestFlow(ctx, route, rule, ruleIndex, matchIndex),
+		Request:   buildRequestFlow(ctx, route, rule, ruleIndex, matchIndex, prefix),
 		Response:  buildResponseFlow(rule),
 		Enabled:   true,
 		Selectors: buildFlowSelectors(match, conditionsExpressions),
@@ -214,11 +216,12 @@ func buildRequestFlow(
 	route *gwAPIv1.HTTPRoute,
 	rule gwAPIv1.HTTPRouteRule,
 	ruleIndex, matchIndex int,
+	prefix string,
 ) []*v4.FlowStep {
 	steps := []*v4.FlowStep{}
 	if len(rule.BackendRefs) > 0 {
 		rewrite := extractURLRewriteFilter(rule.Filters)
-		steps = append(steps, buildRoutingStep(ruleIndex, matchIndex, rewrite))
+		steps = append(steps, buildRoutingStep(ruleIndex, matchIndex, rewrite, prefix))
 	}
 	return append(steps, buildRequestFilters(ctx, route, rule)...)
 }
@@ -227,27 +230,27 @@ func buildResponseFlow(rule gwAPIv1.HTTPRouteRule) []*v4.FlowStep {
 	return buildResponseFilters(rule)
 }
 
-func buildRoutingStep(ruleIndex, matchIndex int, rewrite *gwAPIv1.HTTPURLRewriteFilter) *v4.FlowStep {
+func buildRoutingStep(ruleIndex, matchIndex int, rewrite *gwAPIv1.HTTPURLRewriteFilter, prefix string) *v4.FlowStep {
 	policyName := routingPolicyName
 	return v4.NewFlowStep(base.FlowStep{
 		Policy:  &policyName,
 		Enabled: true,
 		Configuration: utils.NewGenericStringMap().
-			Put(routingRulesKey, buildRoutingRule(ruleIndex, matchIndex, rewrite)),
+			Put(routingRulesKey, buildRoutingRule(ruleIndex, matchIndex, rewrite, prefix)),
 	})
 }
 
-func buildRoutingRule(ruleIndex, matchIndex int, rewrite *gwAPIv1.HTTPURLRewriteFilter) []interface{} {
+func buildRoutingRule(ruleIndex, matchIndex int, rewrite *gwAPIv1.HTTPURLRewriteFilter, prefix string) []interface{} {
 	return []interface{}{
 		map[string]interface{}{
 			routingPatternKey: routingPattern,
-			routingURLKey:     buildRoutingTarget(ruleIndex, matchIndex, rewrite),
+			routingURLKey:     buildRoutingTarget(ruleIndex, matchIndex, rewrite, prefix),
 		},
 	}
 }
 
-func buildRoutingTarget(ruleIndex, matchIndex int, rewrite *gwAPIv1.HTTPURLRewriteFilter) string {
-	endpointGroup := buildEndpointGroupName(ruleIndex, matchIndex)
+func buildRoutingTarget(ruleIndex, matchIndex int, rewrite *gwAPIv1.HTTPURLRewriteFilter, prefix string) string {
+	endpointGroup := buildEndpointGroupName(ruleIndex, matchIndex, prefix)
 
 	if rewrite == nil || rewrite.Path == nil {
 		return fmt.Sprintf(endpointMatcherPattern, endpointGroup)

--- a/controllers/gateway-api/httproute/internal/mapper/mapper.go
+++ b/controllers/gateway-api/httproute/internal/mapper/mapper.go
@@ -16,6 +16,8 @@ package mapper
 
 import (
 	"context"
+	"sort"
+	"strings"
 
 	"github.com/gravitee-io/gravitee-kubernetes-operator/api/model/api/base"
 	v4 "github.com/gravitee-io/gravitee-kubernetes-operator/api/model/api/v4"
@@ -47,24 +49,103 @@ func Map(ctx context.Context, route *gwAPIv1.HTTPRoute) (*v1alpha1.ApiV4Definiti
 }
 
 func MapSpec(ctx context.Context, route *gwAPIv1.HTTPRoute) (v1alpha1.ApiV4DefinitionSpec, error) {
+	return MapSpecWithPrefix(ctx, route, "")
+}
+
+func MapSpecWithPrefix(ctx context.Context, route *gwAPIv1.HTTPRoute, prefix string) (v1alpha1.ApiV4DefinitionSpec, error) {
 	spec := newAPISpec(route)
 	listeners, err := buildListeners(ctx, route)
 	if err != nil {
 		return v1alpha1.ApiV4DefinitionSpec{}, err
 	}
 	spec.Listeners = listeners
-	endpointGroups, err := buildEndpointGroups(ctx, route)
+	endpointGroups, err := buildEndpointGroupsWithPrefix(ctx, route, prefix)
 	if err != nil {
 		return v1alpha1.ApiV4DefinitionSpec{}, err
 	}
 	spec.EndpointGroups = endpointGroups
-	flows, err := buildFlows(ctx, route)
+	flows, err := buildFlowsWithPrefix(ctx, route, prefix)
 	if err != nil {
 		return v1alpha1.ApiV4DefinitionSpec{}, err
 	}
 	spec.Flows = flows
 	spec.Tags = buildTags(route)
 	return spec, nil
+}
+
+func MergeSpecs(specs []v1alpha1.ApiV4DefinitionSpec) v1alpha1.ApiV4DefinitionSpec {
+	if len(specs) == 0 {
+		return v1alpha1.ApiV4DefinitionSpec{}
+	}
+
+	merged := specs[0]
+
+	for i := 1; i < len(specs); i++ {
+		spec := specs[i]
+		merged.Flows = append(merged.Flows, spec.Flows...)
+		merged.EndpointGroups = append(merged.EndpointGroups, spec.EndpointGroups...)
+		merged.Tags = mergeTags(merged.Tags, spec.Tags)
+		if len(spec.Listeners) > 0 && len(merged.Listeners) > 0 {
+			mergeListenerPaths(merged.Listeners[0], spec.Listeners[0])
+		}
+	}
+
+	sortFlowsByWeight(merged.Flows)
+
+	return merged
+}
+
+func sortFlowsByWeight(flows []*v4.Flow) {
+	sort.SliceStable(flows, func(i, j int) bool {
+		return flowWeight(flows[i]) > flowWeight(flows[j])
+	})
+}
+
+func flowWeight(flow *v4.Flow) int {
+	if flow == nil || len(flow.Selectors) < 2 {
+		return 0
+	}
+	cond := flow.Selectors[1].GetString("condition")
+	if cond == "" {
+		return 0
+	}
+	return strings.Count(cond, " and ") + 1
+}
+
+func mergeTags(a, b []string) []string {
+	seen := make(map[string]struct{}, len(a))
+	for _, t := range a {
+		seen[t] = struct{}{}
+	}
+	for _, t := range b {
+		if _, ok := seen[t]; !ok {
+			a = append(a, t)
+			seen[t] = struct{}{}
+		}
+	}
+	return a
+}
+
+func mergeListenerPaths(dst, src *v4.GenericListener) {
+	dstListener := dst.ToListener()
+	srcListener := src.ToListener()
+	httpDst, ok1 := dstListener.(*v4.HttpListener)
+	httpSrc, ok2 := srcListener.(*v4.HttpListener)
+	if !ok1 || !ok2 {
+		return
+	}
+	existing := make(map[string]struct{})
+	for _, p := range httpDst.Paths {
+		existing[p.Host+"|"+p.Path] = struct{}{}
+	}
+	for _, p := range httpSrc.Paths {
+		key := p.Host + "|" + p.Path
+		if _, ok := existing[key]; !ok {
+			httpDst.Paths = append(httpDst.Paths, p)
+			existing[key] = struct{}{}
+		}
+	}
+	*dst = *v4.ToGenericListener(httpDst)
 }
 
 func newAPI(route *gwAPIv1.HTTPRoute) *v1alpha1.ApiV4Definition {
@@ -113,6 +194,10 @@ func newKeyLessPlan() *v4.Plan {
 func buildTags(route *gwAPIv1.HTTPRoute) []string {
 	tags := []string{}
 	for i, ref := range route.Spec.ParentRefs {
+		if i >= len(route.Status.Parents) {
+			tags = append(tags, buildTag(route, ref))
+			continue
+		}
 		routeParentStatus := gateway.WrapRouteParentStatus(&route.Status.Parents[i])
 		if k8s.IsAccepted(routeParentStatus) {
 			tags = append(tags, buildTag(route, ref))

--- a/controllers/gateway-api/httproute/internal/program.go
+++ b/controllers/gateway-api/httproute/internal/program.go
@@ -20,7 +20,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strings"
 
+	"github.com/gravitee-io/gravitee-kubernetes-operator/api/model/gateway"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/api/v1alpha1"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/controllers/gateway-api/httproute/internal/mapper"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/core"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/k8s"
@@ -28,25 +32,34 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwAPIv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 const (
-	configMapPrefix    = "httproute-"
-	maxK8sNameLength   = 253
-	hashSuffixLength   = 8
-	definitionKey      = "definition"
-	apiDefVersionKey   = "apiDefinitionVersion"
-	apiDefVersionValue = "4.0.0"
-	orgKey             = "organizationId"
-	envKey             = "environmentId"
-	defaultOrgID       = "DEFAULT"
-	defaultEnvID       = "DEFAULT"
-	managedByKey       = "managed-by"
-	gioTypeKey         = "gio-type"
+	configMapPrefix     = "httproute-"
+	gatewayConfigMapPfx = "gw-route-"
+	gatewayAPIPfx       = "gw-route-"
+	maxK8sNameLength    = 253
+	hashSuffixLength    = 8
+	definitionKey       = "definition"
+	apiDefVersionKey    = "apiDefinitionVersion"
+	apiDefVersionValue  = "4.0.0"
+	orgKey              = "organizationId"
+	envKey              = "environmentId"
+	defaultOrgID        = "DEFAULT"
+	defaultEnvID        = "DEFAULT"
+	managedByKey        = "managed-by"
+	gioTypeKey          = "gio-type"
+	gatewayOwnerKey     = "gateway-owner"
+	routeLabelPrefix    = "httproute.gravitee.io/"
 )
+
+// ---------------------------------------------------------------------------
+// Program creates one ApiV4Definition CR per HTTPRoute (default path).
+// ---------------------------------------------------------------------------
 
 func Program(ctx context.Context, route *gwAPIv1.HTTPRoute) error {
 	api, err := mapper.Map(ctx, route)
@@ -60,6 +73,12 @@ func Program(ctx context.Context, route *gwAPIv1.HTTPRoute) error {
 
 		return k8s.CreateOrUpdate(ctx, api, func() error {
 			api.SetOwnerReferences(getOwnerReferences(route))
+			if api.Labels == nil {
+				api.Labels = make(map[string]string)
+			}
+			for k, v := range routeLabels(route) {
+				api.Labels[k] = v
+			}
 			spec, err := mapper.MapSpec(ctx, route)
 			if err != nil {
 				return err
@@ -70,9 +89,12 @@ func Program(ctx context.Context, route *gwAPIv1.HTTPRoute) error {
 	})
 }
 
-// ProgramConfigMap creates a ConfigMap directly from the HTTPRoute, bypassing
-// the intermediate ApiV4Definition CR. This frees the CR name so a user-managed
-// ApiV4Definition with the same name can coexist.
+// ---------------------------------------------------------------------------
+// ProgramConfigMap creates one ConfigMap per HTTPRoute (skipAPIDefinition
+// without matchAcrossRoutes). This is the original per-route behaviour that
+// preserves backward-compatible naming and API IDs.
+// ---------------------------------------------------------------------------
+
 func ProgramConfigMap(ctx context.Context, route *gwAPIv1.HTTPRoute) error {
 	api, err := mapper.Map(ctx, route)
 	if err != nil {
@@ -94,15 +116,20 @@ func ProgramConfigMap(ctx context.Context, route *gwAPIv1.HTTPRoute) error {
 		return err
 	}
 
+	cmLabels := map[string]string{
+		managedByKey: core.CRDGroup,
+		gioTypeKey:   core.CRDApiDefinitionResource + "." + core.CRDGroup,
+	}
+	for k, v := range routeLabels(route) {
+		cmLabels[k] = v
+	}
+
 	cm := &v1.ConfigMap{
 		ObjectMeta: metaV1.ObjectMeta{
 			Name:            buildConfigMapName(route),
 			Namespace:       route.Namespace,
 			OwnerReferences: getOwnerReferences(route),
-			Labels: map[string]string{
-				managedByKey: core.CRDGroup,
-				gioTypeKey:   core.CRDApiDefinitionResource + "." + core.CRDGroup,
-			},
+			Labels:          cmLabels,
 		},
 		Data: map[string]string{
 			definitionKey:    string(jsonSpec),
@@ -128,6 +155,506 @@ func ProgramConfigMap(ctx context.Context, route *gwAPIv1.HTTPRoute) error {
 	})
 }
 
+// ---------------------------------------------------------------------------
+// ProgramMergedConfigMaps merges HTTPRoutes with overlapping context paths
+// into a single ConfigMap per group (skipAPIDefinition + matchAcrossRoutes).
+// ---------------------------------------------------------------------------
+
+func ProgramMergedConfigMaps(ctx context.Context, route *gwAPIv1.HTTPRoute) error {
+	for _, gw := range resolveAcceptedParentGateways(ctx, route) {
+		if err := programGatewayMergedConfigMaps(ctx, gw); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func programGatewayMergedConfigMaps(ctx context.Context, gw *gwAPIv1.Gateway) error {
+	allRoutes, err := listRoutesForGateway(ctx, gw)
+	if err != nil {
+		return err
+	}
+
+	if len(allRoutes) == 0 {
+		return deleteAllMergedConfigMaps(ctx, gw)
+	}
+
+	mapped, err := mapAllRoutes(ctx, allRoutes)
+	if err != nil {
+		return err
+	}
+	groups := groupByOverlappingPaths(mapped)
+
+	activeNames := make(map[string]bool)
+	for _, group := range groups {
+		cmName, err := programGroupConfigMap(ctx, gw, group)
+		if err != nil {
+			return err
+		}
+		activeNames[cmName] = true
+	}
+
+	return cleanupStaleMergedConfigMaps(ctx, gw, activeNames)
+}
+
+func programGroupConfigMap(ctx context.Context, gw *gwAPIv1.Gateway, group []mappedRoute) (string, error) {
+	merged, err := mergeGroupSpecs(ctx, group)
+	if err != nil {
+		return "", err
+	}
+
+	groupKey := buildGroupKey(group)
+	merged.ID = uuid.FromStrings(string(gw.UID), groupKey)
+	merged.CrossID = uuid.FromStrings(gw.Namespace, gw.Name, groupKey)
+	populatePlanIDs(&merged)
+	ownerRefs := buildGroupOwnerRefs(group, gw.Namespace)
+
+	gwDef := merged.Api.ToGatewayDefinition()
+	jsonSpec, err := json.Marshal(gwDef)
+	if err != nil {
+		return "", err
+	}
+
+	cmName := buildGroupConfigMapName(gw, groupKey)
+	cmLabels := map[string]string{
+		managedByKey:    core.CRDGroup,
+		gioTypeKey:      core.CRDApiDefinitionResource + "." + core.CRDGroup,
+		gatewayOwnerKey: gatewayHash(gw),
+	}
+	for k, v := range groupRouteLabels(group) {
+		cmLabels[k] = v
+	}
+
+	cm := &v1.ConfigMap{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:            cmName,
+			Namespace:       gw.Namespace,
+			OwnerReferences: ownerRefs,
+			Labels:          cmLabels,
+		},
+		Data: map[string]string{
+			definitionKey:    string(jsonSpec),
+			apiDefVersionKey: apiDefVersionValue,
+			orgKey:           defaultOrgID,
+			envKey:           defaultEnvID,
+		},
+	}
+
+	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		existing := &v1.ConfigMap{}
+		getErr := k8s.GetClient().Get(ctx, client.ObjectKeyFromObject(cm), existing)
+		if errors.IsNotFound(getErr) {
+			return k8s.GetClient().Create(ctx, cm)
+		}
+		if getErr != nil {
+			return getErr
+		}
+		existing.Labels = cm.Labels
+		existing.Data = cm.Data
+		existing.SetOwnerReferences(cm.GetOwnerReferences())
+		return k8s.GetClient().Update(ctx, existing)
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return cmName, nil
+}
+
+// ---------------------------------------------------------------------------
+// ProgramMergedAPIs merges HTTPRoutes with overlapping context paths into a
+// single ApiV4Definition CR per group (matchAcrossRoutes without
+// skipAPIDefinition).
+// ---------------------------------------------------------------------------
+
+func ProgramMergedAPIs(ctx context.Context, route *gwAPIv1.HTTPRoute) error {
+	for _, gw := range resolveAcceptedParentGateways(ctx, route) {
+		if err := programGatewayMergedAPIs(ctx, gw); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func programGatewayMergedAPIs(ctx context.Context, gw *gwAPIv1.Gateway) error {
+	allRoutes, err := listRoutesForGateway(ctx, gw)
+	if err != nil {
+		return err
+	}
+
+	if len(allRoutes) == 0 {
+		return deleteAllMergedAPIs(ctx, gw)
+	}
+
+	mapped, err := mapAllRoutes(ctx, allRoutes)
+	if err != nil {
+		return err
+	}
+	groups := groupByOverlappingPaths(mapped)
+
+	activeNames := make(map[string]bool)
+	for _, group := range groups {
+		apiName, err := programGroupAPI(ctx, gw, group)
+		if err != nil {
+			return err
+		}
+		activeNames[apiName] = true
+	}
+
+	return cleanupStaleMergedAPIs(ctx, gw, activeNames)
+}
+
+func programGroupAPI(ctx context.Context, gw *gwAPIv1.Gateway, group []mappedRoute) (string, error) {
+	merged, err := mergeGroupSpecs(ctx, group)
+	if err != nil {
+		return "", err
+	}
+
+	groupKey := buildGroupKey(group)
+	merged.ID = uuid.FromStrings(string(gw.UID), groupKey)
+	merged.CrossID = uuid.FromStrings(gw.Namespace, gw.Name, groupKey)
+	populatePlanIDs(&merged)
+
+	apiName := buildGroupAPIName(gw, groupKey)
+	ownerRefs := buildGroupOwnerRefs(group, gw.Namespace)
+	newHash := merged.Hash()
+
+	api := &v1alpha1.ApiV4Definition{}
+	api.Name = apiName
+	api.Namespace = gw.Namespace
+
+	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		if err := k8s.GetClient().Get(ctx, client.ObjectKeyFromObject(api), api); client.IgnoreNotFound(err) != nil {
+			return err
+		}
+
+		return k8s.CreateOrUpdate(ctx, api, func() error {
+			api.SetOwnerReferences(ownerRefs)
+			if api.Labels == nil {
+				api.Labels = make(map[string]string)
+			}
+			api.Labels[managedByKey] = core.CRDGroup
+			api.Labels[gatewayOwnerKey] = gatewayHash(gw)
+			for k, v := range groupRouteLabels(group) {
+				api.Labels[k] = v
+			}
+
+			if api.Annotations != nil && api.Annotations[core.LastSpecHashAnnotation] == newHash {
+				return nil
+			}
+			api.Spec = merged
+			return nil
+		})
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return apiName, nil
+}
+
+func mergeGroupSpecs(ctx context.Context, group []mappedRoute) (v1alpha1.ApiV4DefinitionSpec, error) {
+	specs := make([]v1alpha1.ApiV4DefinitionSpec, len(group))
+	for i, mr := range group {
+		if len(group) == 1 {
+			spec, err := mapper.MapSpec(ctx, mr.route)
+			if err != nil {
+				return v1alpha1.ApiV4DefinitionSpec{}, err
+			}
+			specs[i] = spec
+		} else {
+			specs[i] = mr.spec
+		}
+	}
+	return mapper.MergeSpecs(specs), nil
+}
+
+func populatePlanIDs(spec *v1alpha1.ApiV4DefinitionSpec) {
+	if spec.Plans != nil {
+		for key, plan := range *spec.Plans {
+			plan.ID = uuid.FromStrings(spec.ID, key)
+		}
+	}
+}
+
+func buildGroupOwnerRefs(group []mappedRoute, gwNamespace string) []metaV1.OwnerReference {
+	var refs []metaV1.OwnerReference
+	for _, mr := range group {
+		if mr.route.Namespace == gwNamespace {
+			refs = append(refs, metaV1.OwnerReference{
+				Kind:       "HTTPRoute",
+				APIVersion: gwAPIv1.GroupVersion.String(),
+				Name:       mr.route.GetName(),
+				UID:        mr.route.GetUID(),
+			})
+		}
+	}
+	return refs
+}
+
+func buildGroupAPIName(gw *gwAPIv1.Gateway, groupKey string) string {
+	gwH := gatewayHash(gw)
+	grpH := sha256.Sum256([]byte(groupKey))
+	grpSuffix := hex.EncodeToString(grpH[:])[:hashSuffixLength]
+	return fmt.Sprintf("%s%s-%s", gatewayAPIPfx, gwH, grpSuffix)
+}
+
+func deleteAllMergedAPIs(ctx context.Context, gw *gwAPIv1.Gateway) error {
+	return cleanupStaleMergedAPIs(ctx, gw, nil)
+}
+
+func cleanupStaleMergedAPIs(ctx context.Context, gw *gwAPIv1.Gateway, activeNames map[string]bool) error {
+	apiList := &v1alpha1.ApiV4DefinitionList{}
+	labelSelector := labels.SelectorFromSet(map[string]string{
+		managedByKey:    core.CRDGroup,
+		gatewayOwnerKey: gatewayHash(gw),
+	})
+	if err := k8s.GetClient().List(ctx, apiList,
+		&client.ListOptions{
+			Namespace:     gw.Namespace,
+			LabelSelector: labelSelector,
+		},
+	); err != nil {
+		return err
+	}
+
+	for i := range apiList.Items {
+		api := &apiList.Items[i]
+		if activeNames != nil && activeNames[api.Name] {
+			continue
+		}
+		if err := k8s.GetClient().Delete(ctx, api); client.IgnoreNotFound(err) != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+type mappedRoute struct {
+	route *gwAPIv1.HTTPRoute
+	spec  v1alpha1.ApiV4DefinitionSpec
+}
+
+func resolveAcceptedParentGateways(ctx context.Context, route *gwAPIv1.HTTPRoute) []*gwAPIv1.Gateway {
+	seen := make(map[string]bool)
+	var gateways []*gwAPIv1.Gateway
+
+	for _, ref := range route.Spec.ParentRefs {
+		if !k8s.IsGatewayKind(ref) {
+			continue
+		}
+		if ps := findParentStatus(route, ref); ps != nil {
+			if !k8s.IsAccepted(gateway.WrapRouteParentStatus(ps)) {
+				continue
+			}
+		}
+		gw, err := k8s.ResolveGateway(ctx, route.ObjectMeta, ref)
+		if err != nil {
+			continue
+		}
+		key := gw.Namespace + "/" + gw.Name
+		if !seen[key] {
+			seen[key] = true
+			gateways = append(gateways, gw)
+		}
+	}
+
+	return gateways
+}
+
+func findParentStatus(route *gwAPIv1.HTTPRoute, ref gwAPIv1.ParentReference) *gwAPIv1.RouteParentStatus {
+	refNS := route.Namespace
+	if ref.Namespace != nil {
+		refNS = string(*ref.Namespace)
+	}
+	for i := range route.Status.Parents {
+		p := &route.Status.Parents[i]
+		pNS := route.Namespace
+		if p.ParentRef.Namespace != nil {
+			pNS = string(*p.ParentRef.Namespace)
+		}
+		if p.ParentRef.Name == ref.Name && pNS == refNS && sectionNameEquals(p.ParentRef.SectionName, ref.SectionName) {
+			return p
+		}
+	}
+	return nil
+}
+
+func sectionNameEquals(a, b *gwAPIv1.SectionName) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+func mapAllRoutes(ctx context.Context, allRoutes []gwAPIv1.HTTPRoute) ([]mappedRoute, error) {
+	sort.Slice(allRoutes, func(i, j int) bool {
+		return allRoutes[i].Name < allRoutes[j].Name
+	})
+
+	mapped := make([]mappedRoute, 0, len(allRoutes))
+	for i := range allRoutes {
+		r := &allRoutes[i]
+		prefix := r.Name + "-"
+		spec, err := mapper.MapSpecWithPrefix(ctx, r, prefix)
+		if err != nil {
+			return nil, err
+		}
+		mapped = append(mapped, mappedRoute{route: r, spec: spec})
+	}
+	return mapped, nil
+}
+
+func groupByOverlappingPaths(mapped []mappedRoute) [][]mappedRoute {
+	n := len(mapped)
+	if n == 0 {
+		return nil
+	}
+
+	parent := make([]int, n)
+	for i := range parent {
+		parent[i] = i
+	}
+
+	var find = func(i int) int {
+		for parent[i] != i {
+			parent[i] = parent[parent[i]]
+			i = parent[i]
+		}
+		return i
+	}
+
+	union := func(i, j int) {
+		ri, rj := find(i), find(j)
+		if ri != rj {
+			parent[ri] = rj
+		}
+	}
+
+	pathOwners := make(map[string][]int)
+	for i, mr := range mapped {
+		for _, p := range mr.spec.GetContextPaths() {
+			pathOwners[p] = append(pathOwners[p], i)
+		}
+	}
+
+	for _, indices := range pathOwners {
+		for j := 1; j < len(indices); j++ {
+			union(indices[0], indices[j])
+		}
+	}
+
+	groupMap := make(map[int][]mappedRoute)
+	for i, mr := range mapped {
+		root := find(i)
+		groupMap[root] = append(groupMap[root], mr)
+	}
+
+	groups := make([][]mappedRoute, 0, len(groupMap))
+	for _, g := range groupMap {
+		groups = append(groups, g)
+	}
+
+	return groups
+}
+
+func buildGroupKey(group []mappedRoute) string {
+	names := make([]string, len(group))
+	for i, mr := range group {
+		names[i] = mr.route.Name
+	}
+	sort.Strings(names)
+	return strings.Join(names, "+")
+}
+
+func gatewayHash(gw *gwAPIv1.Gateway) string {
+	h := sha256.Sum256([]byte(gw.Namespace + "/" + gw.Name))
+	return hex.EncodeToString(h[:])[:hashSuffixLength]
+}
+
+func buildGroupConfigMapName(gw *gwAPIv1.Gateway, groupKey string) string {
+	gwH := gatewayHash(gw)
+	grpH := sha256.Sum256([]byte(groupKey))
+	grpSuffix := hex.EncodeToString(grpH[:])[:hashSuffixLength]
+	return fmt.Sprintf("%s%s-%s", gatewayConfigMapPfx, gwH, grpSuffix)
+}
+
+func listRoutesForGateway(ctx context.Context, gw *gwAPIv1.Gateway) ([]gwAPIv1.HTTPRoute, error) {
+	list := &gwAPIv1.HTTPRouteList{}
+	if err := k8s.GetClient().List(ctx, list); err != nil {
+		return nil, err
+	}
+
+	var attached []gwAPIv1.HTTPRoute
+	for i := range list.Items {
+		if referencesGatewayByNameNs(&list.Items[i], gw) {
+			attached = append(attached, list.Items[i])
+		}
+	}
+	return attached, nil
+}
+
+func referencesGatewayByNameNs(route *gwAPIv1.HTTPRoute, gw *gwAPIv1.Gateway) bool {
+	for _, ref := range route.Spec.ParentRefs {
+		if !k8s.IsGatewayKind(ref) {
+			continue
+		}
+		if string(ref.Name) != gw.Name {
+			continue
+		}
+		refNS := ref.Namespace
+		if refNS == nil {
+			if route.Namespace == gw.Namespace {
+				return true
+			}
+		} else if string(*refNS) == gw.Namespace {
+			return true
+		}
+	}
+	return false
+}
+
+func deleteAllMergedConfigMaps(ctx context.Context, gw *gwAPIv1.Gateway) error {
+	return cleanupStaleMergedConfigMaps(ctx, gw, nil)
+}
+
+func cleanupStaleMergedConfigMaps(ctx context.Context, gw *gwAPIv1.Gateway, activeNames map[string]bool) error {
+	cmList := &v1.ConfigMapList{}
+	labelSelector := labels.SelectorFromSet(map[string]string{
+		managedByKey:    core.CRDGroup,
+		gioTypeKey:      core.CRDApiDefinitionResource + "." + core.CRDGroup,
+		gatewayOwnerKey: gatewayHash(gw),
+	})
+	if err := k8s.GetClient().List(ctx, cmList,
+		&client.ListOptions{
+			Namespace:     gw.Namespace,
+			LabelSelector: labelSelector,
+		},
+	); err != nil {
+		return err
+	}
+
+	for i := range cmList.Items {
+		cm := &cmList.Items[i]
+		if activeNames != nil && activeNames[cm.Name] {
+			continue
+		}
+		if err := k8s.GetClient().Delete(ctx, cm); client.IgnoreNotFound(err) != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func buildConfigMapName(route *gwAPIv1.HTTPRoute) string {
 	name := configMapPrefix + route.Name
 	if len(name) <= maxK8sNameLength {
@@ -139,13 +666,27 @@ func buildConfigMapName(route *gwAPIv1.HTTPRoute) string {
 	return fmt.Sprintf("%s%s-%s", configMapPrefix, route.Name[:truncateAt], suffix)
 }
 
+func routeLabels(routes ...*gwAPIv1.HTTPRoute) map[string]string {
+	rl := make(map[string]string, len(routes))
+	for _, r := range routes {
+		rl[routeLabelPrefix+r.Name] = r.Namespace
+	}
+	return rl
+}
+
+func groupRouteLabels(group []mappedRoute) map[string]string {
+	rl := make(map[string]string, len(group))
+	for _, mr := range group {
+		rl[routeLabelPrefix+mr.route.Name] = mr.route.Namespace
+	}
+	return rl
+}
+
 func getOwnerReferences(httpRoute *gwAPIv1.HTTPRoute) []metaV1.OwnerReference {
-	kind := httpRoute.GetObjectKind().GroupVersionKind().Kind
-	version := httpRoute.GetObjectKind().GroupVersionKind().GroupVersion().String()
 	return []metaV1.OwnerReference{
 		{
-			Kind:       kind,
-			APIVersion: version,
+			Kind:       "HTTPRoute",
+			APIVersion: gwAPIv1.GroupVersion.String(),
 			Name:       httpRoute.GetName(),
 			UID:        httpRoute.GetUID(),
 		},

--- a/hack/scripts/rebase-operatorhub-prs.mjs
+++ b/hack/scripts/rebase-operatorhub-prs.mjs
@@ -25,8 +25,7 @@ process.env.GH_TOKEN = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
 
 LOG.blue("Searching for open GKO PRs on OperatorHub ...");
 
-const prsRaw =
-  await $`gh search prs --repo ${UPSTREAM_REPO} ${OPERATOR_NAME} \
+const prsRaw = await $`gh search prs --repo ${UPSTREAM_REPO} ${OPERATOR_NAME} \
     --author graviteeio --state open \
     --json number,title,headRefName --limit 20`;
 
@@ -41,8 +40,7 @@ LOG.blue(`Found ${prs.length} open PR(s). Checking CI status ...`);
 
 const stale = [];
 for (const pr of prs) {
-  const checksRaw =
-    await $`gh pr view ${pr.number} --repo ${UPSTREAM_REPO} \
+  const checksRaw = await $`gh pr view ${pr.number} --repo ${UPSTREAM_REPO} \
       --json statusCheckRollup \
       --jq ${`[.statusCheckRollup[] | select(.name == "operator-ci")] | map({conclusion}) | first`}`;
 

--- a/helm/gko/README.md
+++ b/helm/gko/README.md
@@ -132,11 +132,12 @@ When storing templates stored in config maps, the config map should contain a co
 Configure Kubernetes Gateway API support.
 
 
-| Name                                      | Description                                                                                                                                                         | Value   |
-| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `gatewayAPI.applyCRDs`                    | If true, the manager will apply Gateway API CRDs on startup.                                                                                                        | `true`  |
-| `gatewayAPI.controller.enabled`           | Set to true to enable experimental gateway api support.                                                                                                             | `false` |
-| `gatewayAPI.controller.skipAPIDefinition` | If true, the HTTPRoute reconciler creates a ConfigMap directly instead of an intermediate ApiV4Definition CR, freeing the CR name for user-managed API definitions. | `false` |
+| Name                                      | Description                                                                                                                                                                                                                                          | Value   |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `gatewayAPI.applyCRDs`                    | If true, the manager will apply Gateway API CRDs on startup.                                                                                                                                                                                         | `true`  |
+| `gatewayAPI.controller.enabled`           | Set to true to enable experimental gateway api support.                                                                                                                                                                                              | `false` |
+| `gatewayAPI.controller.skipAPIDefinition` | If true, the HTTPRoute reconciler creates a ConfigMap directly instead of an intermediate ApiV4Definition CR, freeing the CR name for user-managed API definitions.                                                                                  | `false` |
+| `gatewayAPI.controller.matchAcrossRoutes` | If true, HTTPRoutes with overlapping context paths on the same Gateway are merged into a single API definition. Enables full Gateway API conformance for cross-route matching at the cost of changing API identity (IDs, names) for affected routes. | `false` |
 
 ### HTTP Client
 

--- a/helm/gko/templates/manager/config.yaml
+++ b/helm/gko/templates/manager/config.yaml
@@ -74,6 +74,9 @@ data:
   {{- if .Values.gatewayAPI.controller.skipAPIDefinition }}
   GATEWAY_API_SKIP_API_DEFINITION: "true"
   {{- end }}
+  {{- if .Values.gatewayAPI.controller.matchAcrossRoutes }}
+  GATEWAY_API_MATCH_ACROSS_ROUTES: "true"
+  {{- end }}
   {{- if .Values.gatewayAPI.applyCRDs }}
   APPLY_GATEWAY_API_CRDS: "true"
   {{- end }}

--- a/helm/gko/templates/rbac/manager-cluster-role.yaml
+++ b/helm/gko/templates/rbac/manager-cluster-role.yaml
@@ -94,6 +94,9 @@ rules:
 {{- if .Values.gatewayAPI.controller.enabled }}
       - create
 {{- end }}
+{{- if .Values.gatewayAPI.controller.matchAcrossRoutes }}
+      - delete
+{{- end }}
       - get
       - list
       - update

--- a/helm/gko/values.yaml
+++ b/helm/gko/values.yaml
@@ -236,6 +236,8 @@ gatewayAPI:
     enabled: false
     ## @param gatewayAPI.controller.skipAPIDefinition If true, the HTTPRoute reconciler creates a ConfigMap directly instead of an intermediate ApiV4Definition CR, freeing the CR name for user-managed API definitions.
     skipAPIDefinition: false
+    ## @param gatewayAPI.controller.matchAcrossRoutes If true, HTTPRoutes with overlapping context paths on the same Gateway are merged into a single API definition. Enables full Gateway API conformance for cross-route matching at the cost of changing API identity (IDs, names) for affected routes.
+    matchAcrossRoutes: false
 
 ## @section HTTP Client
 ## @descriptionStart

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -39,6 +39,7 @@ const (
 	EnableWebhook                        = "ENABLE_WEBHOOK"
 	EnableGatewayAPI                     = "ENABLE_GATEWAY_API"
 	GatewayAPISkipAPIDefinition          = "GATEWAY_API_SKIP_API_DEFINITION"
+	GatewayAPIMatchAcrossRoutes          = "GATEWAY_API_MATCH_ACROSS_ROUTES"
 	ApplyGatewayAPICRDs                  = "APPLY_GATEWAY_API_CRDS"
 	WebhookNS                            = "WEBHOOK_NAMESPACE"
 	WebhookServiceName                   = "WEBHOOK_SERVICE_NAME"
@@ -95,6 +96,7 @@ var Config = struct {
 	EnableWebhook                        bool
 	EnableGatewayAPI                     bool
 	GatewayAPISkipAPIDefinition          bool
+	GatewayAPIMatchAcrossRoutes          bool
 	ApplyGatewayAPICRDs                  bool
 	WebhookNS                            string
 	WebhookService                       string
@@ -155,6 +157,7 @@ func init() {
 	Config.EnableWebhook = os.Getenv(EnableWebhook) == TrueString
 	Config.EnableGatewayAPI = os.Getenv(EnableGatewayAPI) == TrueString
 	Config.GatewayAPISkipAPIDefinition = os.Getenv(GatewayAPISkipAPIDefinition) == TrueString
+	Config.GatewayAPIMatchAcrossRoutes = os.Getenv(GatewayAPIMatchAcrossRoutes) == TrueString
 	Config.ApplyGatewayAPICRDs = os.Getenv(ApplyGatewayAPICRDs) == TrueString
 	Config.WebhookNS = os.Getenv(WebhookNS)
 	Config.WebhookService = os.Getenv(WebhookServiceName)

--- a/internal/k8s/resolve.go
+++ b/internal/k8s/resolve.go
@@ -43,9 +43,7 @@ func ResolveGateway(
 
 func ResolveRouteHostnames(ctx context.Context, route *gwAPIv1.HTTPRoute) []string {
 	hostnames := []string{}
-	for i := range route.Spec.ParentRefs {
-		refStatus := route.Status.Parents[i]
-		ref := refStatus.ParentRef
+	for _, ref := range route.Spec.ParentRefs {
 		gw, err := ResolveGateway(ctx, route.ObjectMeta, ref)
 		if err != nil {
 			continue

--- a/test/conformance/kubernetes.io/gateway-api/report/standard-4.12.0-default-report.yaml
+++ b/test/conformance/kubernetes.io/gateway-api/report/standard-4.12.0-default-report.yaml
@@ -1,0 +1,57 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2026-07-18T15:54:51+02:00"
+gatewayAPIChannel: standard
+gatewayAPIVersion: v1.4.1
+implementation:
+  contact:
+  - team-devex@graviteesource.com
+  organization: gravitee.io
+  project: gravitee-kubernetes-operator
+  url: https://github.com/gravitee-io/gravitee-kubernetes-operator
+  version: 4.12.0
+kind: ConformanceReport
+mode: default
+profiles:
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 33
+      Skipped: 0
+  extended:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 7
+      Skipped: 0
+    supportedFeatures:
+    - GatewayPort8080
+    - HTTPRoutePathRedirect
+    - HTTPRoutePathRewrite
+    - HTTPRoutePortRedirect
+    - HTTPRouteResponseHeaderModification
+    - HTTPRouteSchemeRedirect
+    unsupportedFeatures:
+    - BackendTLSPolicy
+    - BackendTLSPolicySANValidation
+    - GatewayAddressEmpty
+    - GatewayHTTPListenerIsolation
+    - GatewayInfrastructurePropagation
+    - GatewayStaticAddresses
+    - HTTPRouteBackendProtocolH2C
+    - HTTPRouteBackendProtocolWebSocket
+    - HTTPRouteBackendRequestHeaderModification
+    - HTTPRouteBackendTimeout
+    - HTTPRouteCORS
+    - HTTPRouteDestinationPortMatching
+    - HTTPRouteHostRewrite
+    - HTTPRouteMethodMatching
+    - HTTPRouteNamedRouteRule
+    - HTTPRouteParentRefPort
+    - HTTPRouteQueryParamMatching
+    - HTTPRouteRequestMirror
+    - HTTPRouteRequestMultipleMirrors
+    - HTTPRouteRequestPercentageMirror
+    - HTTPRouteRequestTimeout
+  name: GATEWAY-HTTP
+  summary: Core tests succeeded. Extended tests succeeded.

--- a/test/conformance/kubernetes.io/gateway-api/standard/conformance_test.go
+++ b/test/conformance/kubernetes.io/gateway-api/standard/conformance_test.go
@@ -78,11 +78,9 @@ func TestGatewayAPIConformance(t *testing.T) {
 
 	opts.SkipTests = []string{}
 
-	// We skip this test because right now we cannot accept different
-	// routes with the same host and path.
-	// For that reason the second route will get Accepted but not Programmed
-	// because of the conflict.
-	opts.SkipTests = append(opts.SkipTests, "HTTPRouteMatchingAcrossRoutes")
+	if os.Getenv(env.GatewayAPIMatchAcrossRoutes) != env.TrueString {
+		opts.SkipTests = append(opts.SkipTests, "HTTPRouteMatchingAcrossRoutes")
+	}
 
 	// We skip this test in circle ci because for some reason
 	// threads get blocked on the gatway side when

--- a/test/conformance/operator.values.yaml
+++ b/test/conformance/operator.values.yaml
@@ -16,6 +16,7 @@ gatewayAPI:
   controller:
     enabled: true
     skipAPIDefinition: true
+    matchAcrossRoutes: true
 
 manager:
   image:


### PR DESCRIPTION
This gives us [full conformance](https://github.com/gravitee-io/gravitee-kubernetes-operator/pull/1735/changes#diff-55daa2cd4901d5b425f5ce68a459a04faf1101270f0f7a1f7827967b7cb751cd) for HTTP by making `HTTPRouteMatchingAcrossRoutes` pass.

The code change is feature flagged as an opt-in, because with this method we merge conflicting routes in one API, which leads to applying a different naming strategy for APIDefinition / config maps, and could be seen as a breaking change by users.

To opt-in, the helm value to apply is `gatewayAPI.controller.matchAcrossRoutes=true `

