### PR TITLE
test: provisioner registry consolidation + ProvisionerView (GKO, Terraform)

### DIFF
--- a/test/platform-test/e2e/helpers/for-each-provisioner.ts
+++ b/test/platform-test/e2e/helpers/for-each-provisioner.ts
@@ -27,9 +27,8 @@
 import { test } from "../setup.js";
 import type { Mapi, Gateway } from "../../src/index.js";
 import type { ProvisionerId, Provisioned, Provisioner } from "../../src/provisioners/index.js";
+import { PROVISIONER_ORDER } from "../../src/provisioners/index.js";
 import { TF_WORKSPACE_TIMEOUT_MS } from "../../src/provisioners/engines/terraform-core.js";
-
-const PROVISIONER_ORDER: readonly ProvisionerId[] = ["gko", "terraform"] as const;
 
 type ProvisionerFactory<P> = () => Provisioner<P> | Promise<Provisioner<P>>;
 

--- a/test/platform-test/e2e/helpers/tags.ts
+++ b/test/platform-test/e2e/helpers/tags.ts
@@ -420,6 +420,8 @@ export const XRAY = {
     CREATE_APP_AND_SUBSCRIPTION: "@GKO-1379",
     VALID_AND_MALFORMED_HCL: "@GKO-1453",
     GENERAL_CONDITIONS_PAGE: "@GKO-1930",
+    // Awaiting a real Xray ticket — run /xray-sync-tests to file it.
+    VIEW_DETECTS_TAINTED_RESOURCE: "@GKO-TBD-tf-view-tainted",
     // error handling in TF + delete-via-TF lifecycle.
     // GKO-1381 (Role-specific access for managing Apps and subscriptions
     // via Terraform) is not covered: the test harness has no

--- a/test/platform-test/e2e/playwright.config.ts
+++ b/test/platform-test/e2e/playwright.config.ts
@@ -17,31 +17,38 @@
 import { defineConfig } from "@playwright/test";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
+import { PROVISIONER_LANES } from "../src/provisioners/registry.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Optional provisioner-lane filter, set by `scripts/e2e.mjs` from
 // `--provision-with <p>` (or directly via the env var in CI).
 //
-// A lane = that provisioner's OWN tests + the matching arm of every shared
-// scenario. Legacy single-provisioner tests live under `tests/gko/` or
-// `tests/terraform/`; shared `*.scenario.ts` files emit one arm per provisioner,
-// each tagged `@gko` / `@terraform`. So we select a lane by (1) IGNORING the other
-// provisioner's folder and (2) DROPPING the other arm from shared scenarios via a
-// case-sensitive grepInvert (case-sensitive on purpose: Playwright's --grep CLI
-// flag is case-insensitive, so a bare `@gko` there would also match every
-// `@GKO-1234` Xray tag). This makes `--provision-with gko` run the FULL GKO suite,
-// not just the migrated scenarios.
+// A lane = that provisioner's OWN tests (if any) + the matching arm of every
+// shared scenario. Legacy single-provisioner tests live under `tests/<segment>/`
+// per `PROVISIONER_LANES[].testDirSegment`; shared `*.scenario.ts` files emit
+// one arm per provisioner, each tagged with `PROVISIONER_LANES[].tag`. So we
+// select a lane by (1) IGNORING every OTHER lane's legacy folder and (2)
+// DROPPING every other lane's arm from shared scenarios via a case-sensitive
+// grepInvert (case-sensitive on purpose: Playwright's --grep CLI flag is
+// case-insensitive, so a bare `@gko` there would also match every `@GKO-1234`
+// Xray tag). This makes `--provision-with gko` run the FULL GKO suite, not
+// just the migrated scenarios. A lane with no `testDirSegment` (e.g. a
+// provisioner that only ever appears via shared scenarios) simply contributes
+// no ignore pattern for its own folder.
 const provisioner = process.env["E2E_PROVISIONER"]?.trim().toLowerCase();
-let laneTestIgnore: RegExp | undefined;
-let laneGrepInvert: RegExp | undefined;
-if (provisioner === "gko") {
-  laneTestIgnore = /[/\\]tests[/\\]terraform[/\\]/;
-  laneGrepInvert = /@terraform\b/;
-} else if (provisioner === "terraform") {
-  laneTestIgnore = /[/\\]tests[/\\]gko[/\\]/;
-  laneGrepInvert = /@gko\b/;
-}
+const lane = PROVISIONER_LANES.find((l) => l.id === provisioner);
+const otherLanes = lane ? PROVISIONER_LANES.filter((l) => l.id !== lane.id) : [];
+const otherTestDirSegments = otherLanes
+  .map((l) => l.testDirSegment)
+  .filter((segment): segment is string => Boolean(segment));
+const laneTestIgnore: RegExp | undefined = otherTestDirSegments.length
+  ? new RegExp(String.raw`[/\\]tests[/\\](${otherTestDirSegments.join("|")})[/\\]`)
+  : undefined;
+const otherTags = otherLanes.map((l) => l.tag).join("|");
+const laneGrepInvert: RegExp | undefined = otherTags
+  ? new RegExp(otherTags + String.raw`\b`)
+  : undefined;
 if (provisioner) {
   console.log(`[e2e] provisioner lane: ${provisioner}`);
 }

--- a/test/platform-test/e2e/tests/terraform/provisioner-view.test.ts
+++ b/test/platform-test/e2e/tests/terraform/provisioner-view.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Terraform / HCL: `ProvisionerView` detects a tainted resource.
+ *
+ * This is the permanent record of the empirical spike behind
+ * `buildTerraformView` (src/provisioners/terraform/terraform-provisioner.ts):
+ * `terraform show -json`'s STATE representation (no plan needed) exposes a
+ * `tainted: true` field directly on a tainted resource, and the field is
+ * simply absent otherwise. Confirmed live against `terraform taint`/`untaint`
+ * with Terraform 1.14.8; the pinned CI version is 1.12.1 — if that pin moves,
+ * re-run this test to confirm the field is still exposed the same way.
+ *
+ * Xray tests:
+ *   GKO-TBD-tf-view-tainted: Terraform ProvisionerView reports "failed" for a tainted resource
+ *     WHEN a resource is provisioned and then `terraform taint`ed
+ *     THEN `assertProvisioner(provisioned, "api", "failed")` passes
+ *     AND untainting it makes `assertProvisioner(provisioned, "api", "applied")` pass again
+ *
+ * Preconditions:
+ *   - APIM and Gateway are running
+ *   - terraform CLI is installed
+ */
+
+import { test } from "../../setup.js";
+import { XRAY, TAGS } from "../../helpers/tags.js";
+import { fixture } from "../../setup.js";
+import { terraformEnv } from "../../helpers/terraform.js";
+import {
+  TerraformProvisioner,
+  assertProvisioner,
+  isTerraform,
+  type Provisioned,
+} from "../../../src/provisioners/index.js";
+import * as terraform from "../../helpers/terraform.js";
+
+let provisioned: Provisioned<void>;
+
+test.describe("Terraform — ProvisionerView", () => {
+  test.beforeAll(async () => {
+    test.setTimeout(terraform.TF_WORKSPACE_TIMEOUT_MS);
+    const provisioner = new TerraformProvisioner<void>({
+      fixtureDir: fixture("subscriptions/v4-full-stack"),
+      env: await terraformEnv(),
+      addresses: { api: "apim_apiv4.e2e_tf_test" },
+    });
+    provisioned = await provisioner.provision();
+  });
+
+  test.afterAll(async () => {
+    test.setTimeout(terraform.TF_WORKSPACE_TIMEOUT_MS);
+    if (provisioned) await provisioned.destroy();
+  });
+
+  test(`terraform view reports failed for a tainted resource ${XRAY.TERRAFORM.VIEW_DETECTS_TAINTED_RESOURCE} ${TAGS.REGRESSION}`, async () => {
+    await assertProvisioner(provisioned, "api", "applied");
+
+    if (!isTerraform(provisioned.checks)) {
+      throw new Error("expected a Terraform-provisioned handle");
+    }
+    await provisioned.checks.taint("api");
+    await assertProvisioner(provisioned, "api", "failed");
+
+    // Restore to a clean state so the afterAll destroy() is a normal teardown.
+    await provisioned.checks.untaint("api");
+    await assertProvisioner(provisioned, "api", "applied");
+  });
+});

--- a/test/platform-test/scripts/e2e.mjs
+++ b/test/platform-test/scripts/e2e.mjs
@@ -22,8 +22,10 @@
  *
  *   npm run e2e -- --provision-with gko --run-up-to-version 4.12.0 [playwright args]
  *
- *   --provision-with <gko|terraform>  Run only one provisioner lane.
- *                                     -> E2E_PROVISIONER (case-sensitive @tag grep).
+ *   --provision-with <id>             Run only one provisioner lane (see
+ *                                     src/provisioners/registry.ts for the
+ *                                     known ids). -> E2E_PROVISIONER
+ *                                     (case-sensitive @tag grep).
  *   --run-up-to-version <semver>      Run only features available at that version,
  *                                     i.e. skip tests tagged @since-<newer>.
  *                                     -> E2E_MAX_VERSION (enforced in e2e/setup.ts).
@@ -37,10 +39,11 @@
 import { spawn } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { PROVISIONER_ORDER } from "../dist/provisioners/registry.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONFIG = path.resolve(__dirname, "../e2e/playwright.config.ts");
-const PROVISIONERS = ["gko", "terraform"];
+const PROVISIONERS = PROVISIONER_ORDER;
 
 function die(message) {
   console.error(`[e2e] ${message}`);

--- a/test/platform-test/src/provisioners/base.ts
+++ b/test/platform-test/src/provisioners/base.ts
@@ -15,6 +15,7 @@
  */
 
 import type { Provisioned, ProvisionerChecks, ProvisionerId, Role } from "./types.js";
+import type { ProvisionerView } from "./view.js";
 
 /** Build the internal role string from a kind + optional disambiguating label. */
 function roleFor(kind: string, label?: string): Role {
@@ -31,6 +32,7 @@ function roleFor(kind: string, label?: string): Role {
 export abstract class BaseProvisioned<P = unknown> implements Provisioned<P> {
   abstract readonly provisionerId: ProvisionerId;
   abstract readonly checks: ProvisionerChecks;
+  abstract readonly view: ProvisionerView;
 
   /** Resolve a logical role to its APIM id (UUID). Resolved once, then cached. */
   protected abstract resolveId(role: Role): Promise<string>;

--- a/test/platform-test/src/provisioners/engines/kubectl.ts
+++ b/test/platform-test/src/provisioners/engines/kubectl.ts
@@ -99,6 +99,33 @@ export async function getStatus<T = unknown>(
   return resource.status;
 }
 
+/** A single entry of a Kubernetes `status.conditions[]` list-map. */
+export interface K8sCondition {
+  type: string;
+  status: "True" | "False" | "Unknown";
+  reason: string;
+  message: string;
+  lastTransitionTime: string;
+  observedGeneration?: number;
+}
+
+/**
+ * Read one condition (e.g. "Accepted") off a resource's `.status.conditions[]`,
+ * or undefined if that condition hasn't been reported yet. Unlike
+ * {@link waitForCondition} (which delegates entirely to `kubectl wait` and never
+ * inspects the condition value), this returns the condition itself so a caller
+ * can distinguish True/False/Unknown and read its reason/message.
+ */
+export async function getCondition(
+  kind: string,
+  name: string,
+  type: string,
+  namespace = NAMESPACE,
+): Promise<K8sCondition | undefined> {
+  const status = await getStatus<{ conditions?: K8sCondition[] }>(kind, name, namespace);
+  return status?.conditions?.find((c) => c.type === type);
+}
+
 /** Assert that a Kubernetes event for the given resource contains a message substring. */
 export async function assertEventContains(
   kind: string,

--- a/test/platform-test/src/provisioners/engines/terraform-core.ts
+++ b/test/platform-test/src/provisioners/engines/terraform-core.ts
@@ -204,6 +204,38 @@ export async function output(ws: TfWorkspace, name: string): Promise<string> {
   return stdout.trim();
 }
 
+/** One resource instance as reported by `terraform show -json`'s state representation. */
+export interface TfStateResource {
+  address: string;
+  /** Present (true) only when the resource is tainted; absent otherwise. Confirmed via `terraform show -json` against a live `terraform taint`/`untaint` cycle — not documented as a stable field name upstream, so re-verify if the pinned CLI version changes. */
+  tainted?: boolean;
+}
+
+/** Run `terraform taint <address>`, marking the resource for replacement on next apply. */
+export async function taint(ws: TfWorkspace, address: string): Promise<void> {
+  await tf(ws, ["taint", address]);
+}
+
+/** Run `terraform untaint <address>`, clearing a previous {@link taint}. */
+export async function untaint(ws: TfWorkspace, address: string): Promise<void> {
+  await tf(ws, ["untaint", address]);
+}
+
+/**
+ * Read the CURRENT STATE (no plan, no refresh) via `terraform show -json`,
+ * returning each resource's address and whether it is tainted. Deliberately
+ * state-only, not a `plan`-based signal: a plan would re-read the platform via
+ * the provider, turning a provisioner-internal check into a platform check —
+ * that's `mapi`'s job, not this one's. See {@link TfStateResource.tainted}.
+ */
+export async function showState(ws: TfWorkspace): Promise<{ resources: TfStateResource[] }> {
+  const { stdout } = await tf(ws, ["show", "-json"]);
+  const parsed = JSON.parse(stdout) as {
+    values?: { root_module?: { resources?: TfStateResource[] } };
+  };
+  return { resources: parsed.values?.root_module?.resources ?? [] };
+}
+
 /** Run `terraform destroy -auto-approve`. */
 export async function destroy(ws: TfWorkspace): Promise<void> {
   await tf(ws, ["destroy", "-auto-approve", "-no-color"]);

--- a/test/platform-test/src/provisioners/gko/gko-provisioner.ts
+++ b/test/platform-test/src/provisioners/gko/gko-provisioner.ts
@@ -18,6 +18,7 @@ import * as kubectl from "../engines/kubectl.js";
 import type { Provisioned, Provisioner, Role } from "../types.js";
 import { BaseProvisioned } from "../base.js";
 import type { GkoChecks } from "./checks.js";
+import type { GkoView } from "./view.js";
 
 /** The kubectl engine surface a parameterized apply step receives. */
 export type KubectlEngine = typeof kubectl;
@@ -105,6 +106,49 @@ function resolveBinding<P>(spec: ResolvedGkoSpec<P>, role: Role): GkoRoleBinding
   return binding;
 }
 
+/**
+ * Builds the GKO `ProvisionerView`: "did MY layer land this role?", answered
+ * purely from the CR's own condition/status — never from mAPI (that's what
+ * `mapi` assertions are for). MUST throw when it cannot yet tell (no CR
+ * resource yet observed the condition type at all), rather than return an
+ * ambiguous state — see {@link ProvisionerView}.
+ */
+/** @internal exported only for unit testing; not part of the package's public surface. */
+export function buildGkoView<P>(spec: ResolvedGkoSpec<P>): GkoView {
+  return {
+    async read(role: Role) {
+      const b = resolveBinding(spec, role);
+      if (!(await kubectl.exists(b.kind, b.name, spec.namespace))) {
+        return { state: "gone", detail: { reason: "NotFound" } };
+      }
+      const conditionType = b.readyCondition ?? "Accepted";
+      const condition = await kubectl.getCondition(b.kind, b.name, conditionType, spec.namespace);
+      if (!condition) {
+        throw new Error(
+          `GKO ${b.kind}/${b.name} has no "${conditionType}" condition yet; cannot determine state`,
+        );
+      }
+      if (condition.status === "Unknown") {
+        throw new Error(
+          `GKO ${b.kind}/${b.name} condition "${conditionType}" is Unknown; cannot determine state`,
+        );
+      }
+      if (condition.status === "True") {
+        return { state: "applied", detail: { reason: condition.reason, condition } };
+      }
+      const status = await kubectl.getStatus<{ errors?: { severe?: string[] } }>(
+        b.kind,
+        b.name,
+        spec.namespace,
+      );
+      return {
+        state: "failed",
+        detail: { reason: condition.reason, condition, severeErrors: status?.errors?.severe },
+      };
+    },
+  };
+}
+
 function buildGkoChecks<P>(spec: ResolvedGkoSpec<P>): GkoChecks {
   return {
     provisionerId: "gko",
@@ -145,11 +189,13 @@ async function teardownGko<P>(spec: ResolvedGkoSpec<P>): Promise<void> {
 class GkoProvisioned<P> extends BaseProvisioned<P> {
   readonly provisionerId = "gko" as const;
   readonly checks: GkoChecks;
+  readonly view: GkoView;
   private readonly idCache = new Map<string, string>();
 
   constructor(private readonly spec: ResolvedGkoSpec<P>) {
     super();
     this.checks = buildGkoChecks(spec);
+    this.view = buildGkoView(spec);
   }
 
   protected async resolveId(role: Role): Promise<string> {

--- a/test/platform-test/src/provisioners/gko/view.ts
+++ b/test/platform-test/src/provisioners/gko/view.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { K8sCondition } from "../engines/kubectl.js";
+import type { ProvisionerView } from "../view.js";
+
+/** Evidence GKO's `view.read()` reports: the condition it inspected, plus severe errors on failure. */
+export interface GkoViewDetail {
+  reason: string;
+  condition?: K8sCondition;
+  severeErrors?: string[];
+}
+
+/**
+ * GKO's `ProvisionerView`, reachable from a provisioned handle via
+ * `provision.view` — no narrowing needed (unlike `checks`), `view` is meant to
+ * be called from shared, provisioner-agnostic scenario bodies directly.
+ */
+export type GkoView = ProvisionerView<GkoViewDetail>;

--- a/test/platform-test/src/provisioners/index.ts
+++ b/test/platform-test/src/provisioners/index.ts
@@ -50,3 +50,4 @@ export { TerraformProvisioner } from "./terraform/terraform-provisioner.js";
 export type { TfScenarioSpec } from "./terraform/terraform-provisioner.js";
 export { isTerraform } from "./terraform/checks.js";
 export type { TerraformChecks } from "./terraform/checks.js";
+export type { TerraformView, TerraformViewDetail } from "./terraform/view.js";

--- a/test/platform-test/src/provisioners/index.ts
+++ b/test/platform-test/src/provisioners/index.ts
@@ -16,6 +16,10 @@
 
 /** Public surface of the provisioner layer. */
 
+// ── Registry ──────────────────────────────────────────────────
+export { PROVISIONER_ORDER, PROVISIONER_LANES } from "./registry.js";
+export type { ProvisionerLane } from "./registry.js";
+
 // ── Core abstraction ──────────────────────────────────────────
 export type {
   ProvisionerId,

--- a/test/platform-test/src/provisioners/index.ts
+++ b/test/platform-test/src/provisioners/index.ts
@@ -28,6 +28,8 @@ export type {
   Provisioner,
   ProvisionerChecks,
 } from "./types.js";
+export { assertProvisioner } from "./view.js";
+export type { ProvisionerState, ProvisionerViewResult, ProvisionerView } from "./view.js";
 
 // ── GKO ───────────────────────────────────────────────────────
 export { GkoProvisioner } from "./gko/gko-provisioner.js";
@@ -39,6 +41,7 @@ export type {
 } from "./gko/gko-provisioner.js";
 export { isGko } from "./gko/checks.js";
 export type { GkoChecks } from "./gko/checks.js";
+export type { GkoView, GkoViewDetail } from "./gko/view.js";
 export { subscriptionYaml, apiKeySecretYaml } from "./gko/subscription-yaml.js";
 export type { SubscriptionYamlOptions, ApiKeyEntry } from "./gko/subscription-yaml.js";
 

--- a/test/platform-test/src/provisioners/registry.ts
+++ b/test/platform-test/src/provisioners/registry.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Single source of truth for the set of provisioners the suite knows about.
+ * Everything that needs to enumerate provisioners (the `ProvisionerId` type,
+ * `forEachProvisioner`'s test-generation order, the `--provision-with` CLI
+ * flag, and Playwright's per-lane file/tag filtering) derives from this
+ * module instead of repeating its own hardcoded list.
+ */
+
+/** The provisioners the suite can run a scenario through, in generation order. */
+export const PROVISIONER_ORDER = ["gko", "terraform"] as const;
+
+/** Which provisioner created a resource. */
+export type ProvisionerId = (typeof PROVISIONER_ORDER)[number];
+
+/** Per-provisioner metadata needed to select a Playwright "lane". */
+export interface ProvisionerLane {
+  readonly id: ProvisionerId;
+  /**
+   * Legacy single-provisioner test folder (`e2e/tests/<segment>/`) to ignore
+   * when running a DIFFERENT provisioner's lane. Absent when the provisioner
+   * has no such legacy folder (e.g. a provisioner that only ever appears via
+   * shared `*.scenario.ts` files).
+   */
+  readonly testDirSegment?: string;
+  /** Case-sensitive title tag appended to generated test titles, e.g. "@gko". */
+  readonly tag: string;
+}
+
+export const PROVISIONER_LANES: readonly ProvisionerLane[] = [
+  { id: "gko", testDirSegment: "gko", tag: "@gko" },
+  { id: "terraform", testDirSegment: "terraform", tag: "@terraform" },
+];

--- a/test/platform-test/src/provisioners/terraform/checks.ts
+++ b/test/platform-test/src/provisioners/terraform/checks.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ProvisionerChecks } from "../types.js";
+import type { ProvisionerChecks, Role } from "../types.js";
 
 /**
  * Terraform-specific assertions, reachable from a provisioned handle via
@@ -37,6 +37,12 @@ export interface TerraformChecks extends ProvisionerChecks {
 
   /** Raw `terraform plan` result, for bespoke drift/idempotency assertions. */
   plan(): Promise<{ stdout: string; hasChanges: boolean }>;
+
+  /** `terraform taint` the resource address mapped to `role` (requires `addresses` in the scenario spec). */
+  taint(role: Role): Promise<void>;
+
+  /** `terraform untaint` the resource address mapped to `role` (requires `addresses` in the scenario spec). */
+  untaint(role: Role): Promise<void>;
 }
 
 /** Narrow a provisioner-checks surface to the Terraform one. */

--- a/test/platform-test/src/provisioners/terraform/terraform-provisioner.ts
+++ b/test/platform-test/src/provisioners/terraform/terraform-provisioner.ts
@@ -19,6 +19,7 @@ import type { TfWorkspace } from "../engines/terraform-core.js";
 import type { Provisioned, Provisioner, Role } from "../types.js";
 import { BaseProvisioned } from "../base.js";
 import type { TerraformChecks } from "./checks.js";
+import type { TerraformView } from "./view.js";
 
 /** Convention mapping a role to a default `terraform output` name. */
 const DEFAULT_OUTPUT_BY_ROLE: Record<string, string> = {
@@ -36,6 +37,15 @@ export interface TfScenarioSpec<P = unknown> {
   env: Record<string, string>;
   /** role -> terraform output name. Defaults: api->api_id, subscription->sub_id, application->app_id. */
   outputs?: Partial<Record<Role, string>>;
+  /**
+   * role -> terraform resource address (e.g. "apim_apiv4.test"), for
+   * `view.read()`. No default: unlike outputs, resource LOCAL NAMES are not
+   * standardized across fixtures (confirmed: existing fixtures use "test",
+   * "app", "dict", "group", "spg" ...), so guessing one would silently point
+   * `view.read()` at the wrong resource instead of failing loudly. Declare it
+   * per scenario for any role that needs `view`/`assertProvisioner`.
+   */
+  addresses?: Partial<Record<Role, string>>;
   /** Output name for the gateway context path. Default "api_context_path". */
   contextPathOutput?: string;
   /** Map params -> tfvars written before each apply (provision + update). */
@@ -60,9 +70,53 @@ function outputNameFor<P>(spec: TfScenarioSpec<P>, role: Role): string {
   return name;
 }
 
-function buildTerraformChecks(ws: TfWorkspace): TerraformChecks {
+function addressFor<P>(spec: TfScenarioSpec<P>, role: Role): string {
+  const address = spec.addresses?.[role];
+  if (!address) {
+    throw new Error(
+      `Terraform scenario has no resource address mapped for role "${role}"; ` +
+        `cannot determine view state. Add it to the scenario's \`addresses\` map ` +
+        `(e.g. { ${role}: "apim_apiv4.test" }).`,
+    );
+  }
+  return address;
+}
+
+/**
+ * Builds the Terraform `ProvisionerView`: "did MY layer land this role?",
+ * answered purely from the workspace's OWN state (`terraform show -json`),
+ * never from mAPI. Deliberately reads STATE, not a fresh `plan` — a plan
+ * re-reads the platform via the provider, which would make this a platform
+ * check (that's `mapi`'s job). MUST throw when it cannot tell (no address
+ * declared for the role) rather than return an ambiguous state.
+ */
+/** @internal exported only for unit testing; not part of the package's public surface. */
+export function buildTerraformView<P>(ws: TfWorkspace, spec: TfScenarioSpec<P>): TerraformView {
+  return {
+    async read(role: Role) {
+      const address = addressFor(spec, role);
+      const { resources } = await tfCore.showState(ws);
+      const resource = resources.find((r) => r.address === address);
+      if (!resource) {
+        return { state: "gone", detail: { reason: "not in state", address } };
+      }
+      if (resource.tainted) {
+        return { state: "failed", detail: { reason: "tainted", address } };
+      }
+      return { state: "applied", detail: { reason: "in state, not tainted", address } };
+    },
+  };
+}
+
+function buildTerraformChecks<P>(ws: TfWorkspace, spec: TfScenarioSpec<P>): TerraformChecks {
   return {
     provisionerId: "terraform",
+    async taint(role: Role) {
+      await tfCore.taint(ws, addressFor(spec, role));
+    },
+    async untaint(role: Role) {
+      await tfCore.untaint(ws, addressFor(spec, role));
+    },
     async assertNoDrift() {
       const { hasChanges, stdout } = await tfCore.plan(ws);
       if (hasChanges) {
@@ -90,6 +144,7 @@ function buildTerraformChecks(ws: TfWorkspace): TerraformChecks {
 class TerraformProvisioned<P> extends BaseProvisioned<P> {
   readonly provisionerId = "terraform" as const;
   readonly checks: TerraformChecks;
+  readonly view: TerraformView;
   private readonly idCache = new Map<string, string>();
   private contextPathCache?: string;
 
@@ -99,7 +154,8 @@ class TerraformProvisioned<P> extends BaseProvisioned<P> {
     private lastVars: Record<string, unknown>,
   ) {
     super();
-    this.checks = buildTerraformChecks(ws);
+    this.checks = buildTerraformChecks(ws, spec);
+    this.view = buildTerraformView(ws, spec);
   }
 
   protected async resolveId(role: Role): Promise<string> {

--- a/test/platform-test/src/provisioners/terraform/view.ts
+++ b/test/platform-test/src/provisioners/terraform/view.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ProvisionerView } from "../view.js";
+
+/** Evidence Terraform's `view.read()` reports: the resource address it inspected. */
+export interface TerraformViewDetail {
+  reason: string;
+  address?: string;
+}
+
+/**
+ * Terraform's `ProvisionerView`, reachable from a provisioned handle via
+ * `provision.view` — no narrowing needed (unlike `checks`), `view` is meant to
+ * be called from shared, provisioner-agnostic scenario bodies directly.
+ */
+export type TerraformView = ProvisionerView<TerraformViewDetail>;

--- a/test/platform-test/src/provisioners/types.ts
+++ b/test/platform-test/src/provisioners/types.ts
@@ -24,8 +24,10 @@
  * resolves to an APIM id. Add a provisioner by implementing this interface.
  */
 
-/** Which provisioner created a resource. */
-export type ProvisionerId = "gko" | "terraform";
+import type { ProvisionerId } from "./registry.js";
+
+/** Which provisioner created a resource. Re-exported for existing importers. */
+export type { ProvisionerId };
 
 /**
  * A logical role within a scenario, mapped per-provisioner to a concrete resource.
@@ -102,9 +104,10 @@ export interface Provisioner<P = unknown> {
   cleanup?(): Promise<void>;
 
   /**
-   * Reserved seam for upgrade testing (provision -> upgrade cluster ->
-   * re-assert): rebuild a handle from stable HRIDs after the original in-memory
-   * state is gone. Not implemented yet; throws if called.
+   * Seam for upgrade testing (provision -> upgrade cluster -> re-assert):
+   * rebuild a handle from stable HRIDs after the original in-memory state is
+   * gone. Optional because not every provisioner implements it (GKO does;
+   * Terraform does not yet).
    */
   attach?(refs: Partial<Record<Role, { hrid: string }>>): Promise<Provisioned<P>>;
 }

--- a/test/platform-test/src/provisioners/types.ts
+++ b/test/platform-test/src/provisioners/types.ts
@@ -25,6 +25,7 @@
  */
 
 import type { ProvisionerId } from "./registry.js";
+import type { ProvisionerView } from "./view.js";
 
 /** Which provisioner created a resource. Re-exported for existing importers. */
 export type { ProvisionerId };
@@ -83,6 +84,12 @@ export interface Provisioned<P = unknown> {
 
   /** Provisioner-specific assertions (narrow with `isGko`/`isTerraform`). */
   readonly checks: ProvisionerChecks;
+
+  /**
+   * Provisioner-internal, agnostic readout ("did MY layer land this role?").
+   * Usable from shared scenario bodies without narrowing, unlike `checks`.
+   */
+  readonly view: ProvisionerView;
 }
 
 /**

--- a/test/platform-test/src/provisioners/view.ts
+++ b/test/platform-test/src/provisioners/view.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Provisioned, Role } from "./types.js";
+
+/**
+ * What a provisioner's OWN record says about a role. Deliberately three
+ * outcomes and no fourth: there is no "unknown" state. A provisioner that
+ * cannot yet tell what happened MUST throw rather than return an ambiguous
+ * result — an "unknown" outcome would let a half-implemented `read()` pass
+ * silently instead of failing loudly.
+ */
+export type ProvisionerState = "applied" | "failed" | "gone";
+
+export interface ProvisionerViewResult<Detail = unknown> {
+  readonly state: ProvisionerState;
+  /** Provisioner-specific evidence for `state` (a condition, a plan diff, an HTTP error body, ...). */
+  readonly detail: Detail;
+}
+
+/**
+ * Provisioner-internal, agnostic readout: "did MY layer land this role?" — as
+ * opposed to `mapi`, which answers "is the resource actually right?" and is
+ * identical across provisioners. Reached via `Provisioned.view`, usable from
+ * shared scenario bodies without narrowing to a concrete provisioner (unlike
+ * `Provisioned.checks`, which requires `isGko`/`isTerraform`/... first).
+ */
+export interface ProvisionerView<Detail = unknown> {
+  /** MUST throw if it cannot yet tell what happened — never returns an "unknown" state. */
+  read(role: Role): Promise<ProvisionerViewResult<Detail>>;
+}
+
+/** The provisioner's record for `role` matches `expected`, or throws with the observed detail. */
+export async function assertProvisioner(
+  provisioned: Provisioned<unknown>,
+  role: Role,
+  expected: ProvisionerState,
+): Promise<void> {
+  const result = await provisioned.view.read(role);
+  if (result.state !== expected) {
+    throw new Error(
+      `expected provisioner state "${expected}" for role "${role}" ` +
+        `(${provisioned.provisionerId}), got "${result.state}": ${JSON.stringify(result.detail)}`,
+    );
+  }
+}

--- a/test/platform-test/test/provisioners/gko/view.test.ts
+++ b/test/platform-test/test/provisioners/gko/view.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { K8sCondition } from "../../../src/provisioners/engines/kubectl.js";
+
+const kubectlMocks = vi.hoisted(() => ({
+  exists: vi.fn(),
+  getCondition: vi.fn(),
+  getStatus: vi.fn(),
+}));
+
+vi.mock("../../../src/provisioners/engines/kubectl.js", () => kubectlMocks);
+
+const { buildGkoView } = await import("../../../src/provisioners/gko/gko-provisioner.js");
+
+function spec() {
+  return {
+    manifests: [],
+    roles: { api: { kind: "apiv4definition", name: "my-api" } },
+    dynamicRoles: [],
+  };
+}
+
+function condition(overrides: Partial<K8sCondition> = {}): K8sCondition {
+  return {
+    type: "Accepted",
+    status: "True",
+    reason: "Ready",
+    message: "",
+    lastTransitionTime: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("buildGkoView", () => {
+  beforeEach(() => {
+    kubectlMocks.exists.mockReset();
+    kubectlMocks.getCondition.mockReset();
+    kubectlMocks.getStatus.mockReset();
+  });
+
+  it("returns gone when the CR does not exist", async () => {
+    kubectlMocks.exists.mockResolvedValue(false);
+    const result = await buildGkoView(spec()).read("api");
+    expect(result.state).toBe("gone");
+    expect(kubectlMocks.getCondition).not.toHaveBeenCalled();
+  });
+
+  it("returns applied when the condition is True", async () => {
+    kubectlMocks.exists.mockResolvedValue(true);
+    kubectlMocks.getCondition.mockResolvedValue(condition({ status: "True" }));
+    const result = await buildGkoView(spec()).read("api");
+    expect(result.state).toBe("applied");
+  });
+
+  it("returns failed with severe errors when the condition is False", async () => {
+    kubectlMocks.exists.mockResolvedValue(true);
+    kubectlMocks.getCondition.mockResolvedValue(
+      condition({ status: "False", reason: "ValidationFailed" }),
+    );
+    kubectlMocks.getStatus.mockResolvedValue({ errors: { severe: ["endpoint target is invalid"] } });
+    const result = await buildGkoView(spec()).read("api");
+    expect(result.state).toBe("failed");
+    expect((result.detail as { severeErrors?: string[] }).severeErrors).toEqual([
+      "endpoint target is invalid",
+    ]);
+  });
+
+  it("throws (never returns an unknown state) when the condition has not been reported yet", async () => {
+    kubectlMocks.exists.mockResolvedValue(true);
+    kubectlMocks.getCondition.mockResolvedValue(undefined);
+    await expect(buildGkoView(spec()).read("api")).rejects.toThrow(/cannot determine state/);
+  });
+
+  it("throws (never returns an unknown state) when the condition is Unknown", async () => {
+    kubectlMocks.exists.mockResolvedValue(true);
+    kubectlMocks.getCondition.mockResolvedValue(condition({ status: "Unknown" }));
+    await expect(buildGkoView(spec()).read("api")).rejects.toThrow(/cannot determine state/);
+  });
+});

--- a/test/platform-test/test/provisioners/registry.test.ts
+++ b/test/platform-test/test/provisioners/registry.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect } from "vitest";
+import { PROVISIONER_ORDER, PROVISIONER_LANES } from "../../src/provisioners/registry.js";
+
+describe("provisioner registry", () => {
+  it("has exactly one lane per provisioner in PROVISIONER_ORDER", () => {
+    const laneIds = PROVISIONER_LANES.map((lane) => lane.id);
+    expect(new Set(laneIds)).toEqual(new Set(PROVISIONER_ORDER));
+    expect(laneIds).toHaveLength(PROVISIONER_ORDER.length);
+  });
+
+  it("gives every lane a non-empty, unique tag", () => {
+    const tags = PROVISIONER_LANES.map((lane) => lane.tag);
+    expect(tags.every((tag) => tag.startsWith("@"))).toBe(true);
+    expect(new Set(tags).size).toBe(tags.length);
+  });
+
+  it("does not require testDirSegment (a lane may only appear via shared scenarios)", () => {
+    // Structural check, not a behavioral one: absence must be a valid, typed
+    // state (undefined), not an empty string or another falsy sentinel that
+    // would silently match every path.
+    for (const lane of PROVISIONER_LANES) {
+      expect(lane.testDirSegment === undefined || lane.testDirSegment.length > 0).toBe(true);
+    }
+  });
+});

--- a/test/platform-test/test/provisioners/terraform/view.test.ts
+++ b/test/platform-test/test/provisioners/terraform/view.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const tfCoreMocks = vi.hoisted(() => ({
+  showState: vi.fn(),
+}));
+
+vi.mock("../../../src/provisioners/engines/terraform-core.js", () => tfCoreMocks);
+
+const { buildTerraformView } = await import(
+  "../../../src/provisioners/terraform/terraform-provisioner.js"
+);
+
+const ws = { dir: "/tmp/does-not-matter", env: {} };
+
+function spec() {
+  return { fixtureDir: "/tmp/fixture", env: {}, addresses: { api: "apim_apiv4.test" } };
+}
+
+describe("buildTerraformView", () => {
+  beforeEach(() => {
+    tfCoreMocks.showState.mockReset();
+  });
+
+  it("returns gone when the address is absent from state", async () => {
+    tfCoreMocks.showState.mockResolvedValue({ resources: [] });
+    const result = await buildTerraformView(ws, spec()).read("api");
+    expect(result.state).toBe("gone");
+  });
+
+  it("returns applied when the resource is present and not tainted", async () => {
+    tfCoreMocks.showState.mockResolvedValue({
+      resources: [{ address: "apim_apiv4.test" }],
+    });
+    const result = await buildTerraformView(ws, spec()).read("api");
+    expect(result.state).toBe("applied");
+  });
+
+  it("returns failed when the resource is present and tainted", async () => {
+    tfCoreMocks.showState.mockResolvedValue({
+      resources: [{ address: "apim_apiv4.test", tainted: true }],
+    });
+    const result = await buildTerraformView(ws, spec()).read("api");
+    expect(result.state).toBe("failed");
+  });
+
+  it("throws (never returns an unknown state) when no address is declared for the role", async () => {
+    tfCoreMocks.showState.mockResolvedValue({ resources: [] });
+    await expect(buildTerraformView(ws, { fixtureDir: "/tmp/fixture", env: {} }).read("api")).rejects.toThrow(
+      /no resource address mapped/,
+    );
+    expect(tfCoreMocks.showState).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Purpose

The e2e provisioner layer (test/platform-test) has two gaps described in the
"spike-provisioners" design doc: the provisioner set is hardcoded in four
separate places, and there is no provisioner-agnostic way to ask "did my
provisioning layer actually land this resource?" - that assertion currently
only exists behind Provisioned.checks, which requires narrowing to a
concrete provisioner (isGko/isTerraform) before use, so it cannot be called
from a shared scenario body. This PR implements the registry consolidation
and the ProvisionerView abstraction for the two existing provisioners
(GKO, Terraform), as the first slice of that doc scoped down to what we
agreed on: no UI provisioner, no HTTP provisioner yet, no fixture generator.

## Summary of changes

- New src/provisioners/registry.ts is the single source of truth for the
  provisioner set (PROVISIONER_ORDER, PROVISIONER_LANES). The four previously
  hardcoded spots (ProvisionerId union, forEachProvisioner's generation
  order, the --provision-with CLI validation, Playwright's per-lane
  file/tag filtering) now derive from it.
- New Provisioned.view: ProvisionerView, reached without narrowing (unlike
  checks). Three possible states only - applied / failed / gone - with no
  fourth "unknown" outcome: a provisioner that cannot yet tell what happened
  must throw rather than return an ambiguous result.
- GKO's implementation reads the CR's own status.conditions (new
  kubectl.getCondition() helper; no equivalent existed before, since
  waitForCondition delegates entirely to `kubectl wait`), using
  status.errors.severe as the failure detail.
- Terraform's implementation reads the workspace's own state
  (terraform show -json), classifying a tainted resource as failed. The
  state<->tainted mapping was verified empirically against a live APIM
  instance via a real taint/untaint cycle, not assumed - see the commit
  message and the new e2e test (e2e/tests/terraform/provisioner-view.test.ts)
  for details.
- Small in-passing fix: Provisioner.attach()'s doc comment claimed it was
  unimplemented; GKO's implementation already exists.

## Out of scope

- The HTTP/Automation-API provisioner and the UI provisioner (spike doc §5/§6).
- The canonical fixture schema, per-provisioner emitters, and the
  `new:journey` generator (spike doc §3).
- The "structural meta-test + offline ladder" (§4) and doc corrections (§7)
  items from the spike doc - not specified in enough detail to scope, and
  agreed out of scope for now.

See: https://gravitee.atlassian.net/wiki/spaces/DE/pages/356843522/spike-provisioners