### PR TITLE
docs: provide agent rules and skills for the e2e suite

### DIFF
--- a/test/platform-test/.agent/rules/e2e-framework-development.md
+++ b/test/platform-test/.agent/rules/e2e-framework-development.md
@@ -1,0 +1,139 @@
+# Rules: extending the e2e framework
+
+Audience: any agent (SDET) **changing the framework itself**: `src/` (the
+`@gravitee/platform-test` library), `e2e/helpers/`, `e2e/setup.ts`,
+`e2e/playwright*.config.ts`, `scripts/`, or the package surface.
+
+Adding or changing a *test* is a different job: see
+[`e2e-test-authoring.md`](./e2e-test-authoring.md).
+
+Procedures live in the `add-provisioner` and `extend-platform-assertions`
+skills. These are the invariants they rest on.
+
+---
+
+## Layering
+
+```
+src/            @gravitee/platform-test - runner-agnostic, publishable, no Playwright
+e2e/            the Playwright binding - config, fixtures, helpers, tests
+```
+
+- **`src/` must not import from `e2e/`.** It is published as a standalone
+  package and consumed by `runner-examples/jest` as well as by this suite.
+- The two things `src/` cannot own are supplied by the e2e binding in
+  [`e2e/helpers/provisioner-env.ts`](../../e2e/helpers/provisioner-env.ts): the
+  APIM auth/server environment loaded from `config.yaml`, and fixture-path
+  resolution via `fixture()`. Scenario authors pass fixture-relative paths;
+  that module resolves them to the absolute paths the `src/` constructors expect.
+- [`e2e/helpers/kubectl.ts`](../../e2e/helpers/kubectl.ts) and
+  [`e2e/helpers/terraform.ts`](../../e2e/helpers/terraform.ts) are thin shims
+  over `src/provisioners/engines/`. Put logic in the engine, not the shim.
+
+## Library design principles
+
+From [`README.md`](../../README.md#design-principles); do not erode them:
+
+| Principle | Implementation |
+|---|---|
+| **void + throw** | Success = `void`, failure = a `node:assert` `AssertionError` |
+| **Partial matching** | Only assert fields the caller specifies; ignore the rest |
+| **Minimal deps** | Native `fetch`, `node:assert`, `yaml` for config only |
+| **Runner-agnostic** | Works with Vitest, Jest, `node:test`, Playwright |
+| **Extensible** | New product surfaces (AM, AE, Cockpit) follow the same shape |
+
+## Assertion naming triplet
+
+[`src/assertions/apim/mapi.ts`](../../src/assertions/apim/mapi.ts) uses one
+naming contract. Match it when adding a method:
+
+| Prefix | Behaviour | Signature shape |
+|---|---|---|
+| `assertX(...)` | single shot; throws `AssertionError` on mismatch | `Promise<void>` |
+| `waitForX(...)` | polled variant of the same assertion | takes a trailing `PollOptions` |
+| `checkX(...)` | non-throwing; returns the report for the caller to inspect | `Promise<AssertionReport>` |
+| `listX(...)` / `createX(...)` / `deleteX(...)` | plain data access used by tests to build assertions | returns data |
+
+Not every family needs all three. Add `waitForX` whenever the value converges
+asynchronously, which is almost always true for anything written through the
+Automation API.
+
+## Provisioner contracts
+
+- **[`registry.ts`](../../src/provisioners/registry.ts) is the single source of
+  truth** for the set of provisioners. The `ProvisionerId` type,
+  `forEachProvisioner`'s generation order, the `--provision-with` flag, and the
+  Playwright lane `grepInvert` all derive from it. Never hardcode a provisioner
+  list anywhere else.
+- **`ProvisionerView.read()` has exactly three outcomes**: `applied`, `failed`,
+  `gone`. There is deliberately no `unknown`. A provisioner that cannot yet tell
+  what happened **must throw**, so a half-implemented `read()` fails loudly
+  instead of passing silently. See
+  [`view.ts`](../../src/provisioners/view.ts).
+- **`view` vs `checks`:** anything expressible as "did MY layer land this role?"
+  belongs in `view`, which shared scenario bodies call without narrowing.
+  `checks` is the narrowed escape hatch (`isTerraform()`) and stays rare; a
+  provisioner with none must not declare the property at all, so shared bodies
+  cannot reach for it by habit. See
+  [`types.ts`](../../src/provisioners/types.ts).
+- **Id resolution is defined once.** `BaseProvisioned` implements `apiId()`,
+  `applicationId()`, `subscriptionId()`, `groupId()` on top of a single
+  `resolveId(role)` that each provisioner implements. Adding a kind is one line
+  in [`base.ts`](../../src/provisioners/base.ts), not a new method per
+  provisioner.
+- **`destroy()` and `cleanup()` must never throw.** They run in `finally` and in
+  the `afterEach` safety net; a teardown failure must not mask a test result.
+
+## Lanes
+
+Lane selection is **by title tag only**; nothing keys off the folder a test
+lives in, which is what lets the tree be reorganised freely.
+
+- [`scripts/check-lanes.mjs`](../../scripts/check-lanes.mjs) asserts the lanes
+  **partition** the suite exactly: no test in two lanes, none in zero. Run it
+  after any change to tags, lane logic, or the test tree.
+- It imports from `dist/`, so **`npm run build` must run before
+  `npm run check:lanes`**.
+- The config's `grepInvert` is **case-sensitive** on purpose: Playwright's CLI
+  `--grep` is case-insensitive, so a bare `@gko` would also match every
+  `@GKO-NNNN` Xray tag.
+
+## Package surface
+
+- A new importable path needs an entry in the `exports` map of
+  [`package.json`](../../package.json), and a matching `index.ts` re-export.
+- Keep `dependencies` minimal. A new runtime dependency needs a reason that
+  survives "can native `fetch` do this?".
+- **Apache 2.0 licence header on every new `.ts` / `.mjs` file.** Enforced by CI
+  (`job-lint-licenses`); copy the header from any existing source file.
+
+## Docs contract
+
+Each document has one job. Do not cross-write; PARITY.md records that drift
+happened before precisely because nothing said what each file was for.
+
+| File | Answers |
+|---|---|
+| [`README.md`](../../README.md) | the library API: what `@gravitee/platform-test` exposes |
+| [`e2e/README.md`](../../e2e/README.md) | bootstrap and how to run the suite |
+| [`AGENTS.md`](../../AGENTS.md) | the authoring model and where a test goes |
+| [`PARITY.md`](../../PARITY.md) | coverage status: GKO to Terraform parity and the backlog |
+| [`e2e/tests/user-journeys/README.md`](../../e2e/tests/user-journeys/README.md) | the journey catalog |
+| `.agent/rules/*.md` | the invariants, per audience |
+| `.claude/skills/*/SKILL.md` | the procedures |
+
+## Verification gate
+
+Any framework change runs the whole gate, not just the part you touched:
+
+```bash
+npm run build
+npm run typecheck && npm run typecheck:e2e && npm run typecheck:examples
+npm test                 # vitest unit tests, no cluster needed
+npm run check:lanes      # needs the build above
+npm run e2e -- --provision-with gko    # at least one real lane
+```
+
+`build`, `typecheck*`, `test` and `check:lanes` need no cluster and should be
+run first. Never report a framework change as done on the cluster-free checks
+alone: the layer exists to talk to a live platform.

--- a/test/platform-test/.agent/rules/e2e-test-authoring.md
+++ b/test/platform-test/.agent/rules/e2e-test-authoring.md
@@ -1,0 +1,164 @@
+# Rules: writing e2e tests
+
+Audience: any agent **adding or changing a test** under `test/platform-test/e2e/`.
+
+The suite drives a **real** Kubernetes cluster running APIM + Gateway + the GKO
+operator, plus the Terraform APIM provider. There are no mocks: every test
+mutates live cluster and APIM state, serially, against one shared APIM.
+
+Procedure lives in the `write-e2e-test` skill. These are the invariants that
+hold whether or not you invoke it.
+
+---
+
+## Golden rules
+
+> These are the mistakes that have actually broken CI.
+
+1. **Every test cleans up everything it creates, with a safety net.** Inline
+   cleanup does not run if the test times out, and a leaked APIM resource
+   poisons every later test that reuses the same name. `forEachProvisioner`
+   gives you this for free; a hand-rolled test needs its own
+   `afterEach`/`afterAll`.
+2. **Never fix a failure by raising a timeout or skipping the test.** A 30s
+   timeout that needs 31s is hiding a real reconcile, apply, or consistency
+   problem.
+3. **Run the test you changed before reporting done.**
+   `npm run e2e -- --grep @GKO-xxxx`. Do not claim green without a run.
+4. **Use `npm run e2e`, never bare `npx playwright test`.** The bare command
+   skips `globalSetup` (the infra pre-flight checks) and gives misleading
+   failures.
+5. **Clean up in reverse dependency order:** subscriptions, then applications,
+   then APIs. The GKO admission webhook blocks deleting an application that
+   still has subscriptions. Never delete shared preconditions: the `dev-ctx`
+   ManagementContext, or the APIM org/environment Terraform authenticates
+   against.
+6. **Every test carries its provisioner tag.** Lane selection is by title tag
+   alone. `npm run check:lanes` enforces it.
+
+## Polling and eventual consistency
+
+Both `kubectl apply` and `terraform apply` return before APIM/Gateway have
+converged. Never assert immediately after an apply.
+
+- Use `mapi.waitForApiMatches()` / `expect.poll()` / the `poll()` util, not a
+  single-shot assertion. This is the convergence check that matters for **both**
+  drivers, since both write to APIM via the Automation API.
+- **Combine polled checks atomically:** `expect.poll(() => fetch…).toMatchObject({…})`
+  rather than polling one field then re-fetching for the rest.
+- **To trigger a GKO reconcile, re-`kubectl apply -f` a modified CR file.** Not
+  `kubectl patch` or `kubectl annotate`. For Terraform, edit the vars and
+  re-apply.
+
+## Resource isolation
+
+The suite runs **serially with a single worker** against **one shared APIM**:
+
+- **API/App names are a shared global namespace.** If one test leaks a name, the
+  next file's apply collides with stuck state and times out, so one root failure
+  cascades. Prefer a unique, test-scoped name over reusing an existing fixture's.
+- **APIM/MongoDB state persists across cluster restarts.** Only `kind delete
+  cluster` or a full Helm uninstall plus PV delete wipes it.
+
+### Safety-net cleanup (hand-rolled tests only)
+
+`forEachProvisioner` handles this for you. A test that provisions directly needs:
+
+```ts
+import * as kubectl from "../../../helpers/kubectl.js";
+
+test.describe(`… ${PROVISIONER.GKO}`, () => {
+  test.afterEach(async () => {
+    for (const f of ["<sub>/crd.yaml", "<app>/crd.yaml", "<api>/crd.yaml"]) {
+      await kubectl.del(fixture(f)).catch(() => {});   // reverse dependency order
+    }
+  });
+});
+```
+
+For Terraform, track the workspace and `destroyWorkspace(ws)` in `afterAll`; it
+re-runs `destroy` as a no-op if a test already destroyed inline, so it is always
+safe to call.
+
+## `view` vs `checks`
+
+- **`provisioned.view`** is the agnostic readout: *"did MY layer land this
+  role?"*, answered from the provisioner's own record (GKO's CR status,
+  Terraform's state), never from APIM. Callable from shared bodies with no
+  narrowing, via `assertProvisioner(provisioned, role, "applied" | "failed" | "gone")`.
+
+  Use it **after `remove()`** (expect `"gone"`) and on **failure paths**.
+  Do **not** use it as a convergence wait after `update()`: GKO's condition
+  `observedGeneration` can lag indefinitely after a re-apply (GKO-2940), so a
+  post-update read can return the *pre*-update `Accepted=True` and pass without
+  asserting anything. `mapi` is the convergence signal after an update.
+
+  Terraform's `read()` needs `addresses: { role: "apim_x.name" }` in the scenario
+  spec (`[0]`-suffixed for a `count`-gated resource) and throws without it.
+
+- **`provisioned.checks`** is the escape hatch for assertions only one
+  provisioner can make, narrowed with `isTerraform()`. Terraform-only today:
+  drift, redaction, plan exit codes, taint. **GKO declares none**: its
+  control-plane readouts *are* the `view` question, and the remaining Kubernetes
+  primitives (admission rejection, events) are reached through the kubectl engine
+  in tests where nothing is provisioned.
+
+- **Gaps without noise:** a planned-but-unimplemented provisioner goes in
+  `pending: { terraform: "<reason>" }` and renders as a visible `test.fixme`,
+  never a silent skip. A provisioner absent from both is N/A by design.
+
+## Xray tagging
+
+- Test ids live **only** in [`e2e/helpers/tags.ts`](../../e2e/helpers/tags.ts) as
+  `XRAY.*` constants, and are interpolated into test titles:
+  ``test(`Description ${XRAY.CATEGORY.TEST_ID}`, …)``.
+- A new test with no ticket yet gets a `@GKO-TBD-*` placeholder in `tags.ts`;
+  run `/xray-sync-tests` to file the real Test tickets and rewrite the file.
+- Each provisioner arm carries **its own** id: GKO and Terraform are different
+  Jira tickets.
+- E2E files reference **Xray Test ids only**. Never a Story or bug key in a
+  describe title, docstring, comment or fixture name.
+- `TAGS.REGRESSION` marks the regression pack. `since("4.12")` declares the
+  oldest APIM version a test needs, so `--run-up-to-version` skips it on older
+  clusters instead of failing.
+
+## APIM behaviours worth knowing
+
+Quirks of the **APIM backend / Automation API**, not the operator:
+
+- **Origin labels:** `origin: MANAGEMENT` = written via mAPI; `origin: KUBERNETES`
+  = written via the Automation API, the write path for **both** GKO and
+  Terraform, so origin alone does not tell you which driver created a resource.
+- **API-key listing returns revoked/expired keys:** no server-side filter. Filter
+  client-side on `revoked`/`expired`.
+- **API-key values are unique per API**, including already-revoked entries.
+  Custom-key tests must generate a per-run unique value.
+- **`syncFrom: MANAGEMENT`** is the default for almost all V4 fixtures; not a
+  discriminator when triaging.
+
+GKO-specific: **HRID to ID** is `namespace + "-" + name`, from which APIM derives
+a deterministic UUIDv3. Use it to correlate CR to APIM API.
+
+## When a test fails
+
+Always consider that the root cause is a **bug in the component under test**, not
+the test. Flag it explicitly rather than working around it. The
+`investigate-e2e-failure` skill carries the full decision tree.
+
+## Committing
+
+> **No AI attribution on commits or PRs.** Whatever agent you are, do not add an
+> AI co-author or attribution trailer: no `Co-Authored-By: …`, no "Generated
+> with …" footer.
+
+- Conventional Commits, `test:` / `docs:` / `fix:` prefix, plain body.
+- Wrap commit bodies at ~72 columns: CI fails on `body-max-line-length` > 120.
+- Ask before committing or pushing.
+
+Attribution is **enforced by committed config**, but verify your trailers if your
+tool ignores it: [`.claude/settings.json`](../../.claude/settings.json) sets
+`attribution.commit`/`attribution.pr` to empty strings;
+[`.cursor/cli-config.json`](../../.cursor/cli-config.json) sets
+`attributeCommitsToAgent`/`attributePRsToAgent` to `false`. Adding a new agent?
+Drop its equivalent config under `test/platform-test/` (this suite is
+self-contained and may move to its own repo) rather than relying on this prose.

--- a/test/platform-test/.claude/settings.json
+++ b/test/platform-test/.claude/settings.json
@@ -2,5 +2,24 @@
   "attribution": {
     "commit": "",
     "pr": ""
+  },
+  "permissions": {
+    "allow": [
+      "Bash(npm run build)",
+      "Bash(npm test)",
+      "Bash(npm run test:*)",
+      "Bash(npm run typecheck)",
+      "Bash(npm run typecheck:*)",
+      "Bash(npm run check:lanes)",
+      "Bash(npm run e2e)",
+      "Bash(npm run e2e:*)",
+      "Bash(npm run e2e -- *)",
+      "Bash(npm --prefix test/platform-test run *)",
+      "Bash(kubectl get:*)",
+      "Bash(kubectl describe:*)",
+      "Bash(kubectl logs:*)",
+      "Bash(kubectl cluster-info:*)",
+      "Bash(terraform providers schema:*)"
+    ]
   }
 }

--- a/test/platform-test/.claude/skills/add-provisioner/SKILL.md
+++ b/test/platform-test/.claude/skills/add-provisioner/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: add-provisioner
+description: Add a new provisioner (a creation path such as the Automation API over HTTP, the APIM console UI, or a new IaC driver) or a new engine to the Gravitee platform-test framework, so existing user journeys gain another arm. Use when asked to support a new way of creating APIM resources in the e2e suite, add a lane, extend the provisioner layer, or make journeys run through an additional driver.
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep
+---
+
+# add-provisioner
+
+The provisioner layer is what lets one journey assert the same platform outcome
+regardless of how the resources were created. Adding a provisioner should make
+every existing journey capable of a new arm without touching a single assertion.
+
+Invariants: [`.agent/rules/e2e-framework-development.md`](../../../.agent/rules/e2e-framework-development.md).
+Annotated contracts and the two worked implementations:
+[`references/provisioner-contract.md`](references/provisioner-contract.md).
+
+Work from `test/platform-test/`.
+
+---
+
+## Step 1: register it
+
+[`src/provisioners/registry.ts`](../../../src/provisioners/registry.ts) is the
+single source of truth. Add the id and its lane tag:
+
+```ts
+export const PROVISIONER_ORDER = ["gko", "terraform", "<id>"] as const;
+
+export const PROVISIONER_LANES: readonly ProvisionerLane[] = [
+  { id: "gko", tag: "@gko" },
+  { id: "terraform", tag: "@terraform" },
+  { id: "<id>", tag: "@<id>" },
+];
+```
+
+Everything else follows for free: the `ProvisionerId` union,
+`forEachProvisioner`'s generation order, `--provision-with <id>` in
+`scripts/e2e.mjs`, and the lane `grepInvert` in `e2e/playwright.config.ts`. **Do
+not** add a hardcoded list anywhere else. If you find yourself wanting to, the
+thing you are editing should derive from the registry instead.
+
+Choose the tag lowercase and distinct from the uppercase `@GKO-NNNN` Xray
+prefix; also add it to `PROVISIONER` in
+[`e2e/helpers/tags.ts`](../../../e2e/helpers/tags.ts) so single-provisioner
+tests can carry it.
+
+## Step 2: build the engine (if there is one)
+
+`src/provisioners/engines/` holds the mechanical drivers (`kubectl.ts`,
+`terraform-core.ts`): process invocation, workspace lifecycle, error surfacing.
+Keep this layer free of scenario semantics. If the new provisioner is a plain
+HTTP client, reuse `src/utils/http/` rather than adding a dependency.
+
+## Step 3: implement `Provisioner`
+
+```ts
+export class XProvisioner<P = unknown> implements Provisioner<P> {
+  readonly provisionerId = "<id>";
+
+  async provision(params: P): Promise<Provisioned<P>> { … }
+
+  /** Best-effort teardown WITHOUT a live handle, for a provision() that failed
+   *  partway. Idempotent and tolerant. Omit if the driver self-cleans. */
+  async cleanup(): Promise<void> { … }
+
+  /** Optional seam for upgrade testing: rebuild a handle from stable HRIDs
+   *  after the in-memory state is gone. GKO implements it; Terraform does not. */
+  async attach(refs): Promise<Provisioned<P>> { … }
+}
+```
+
+The scenario spec it takes should mirror `GkoScenarioSpec` / `TfScenarioSpec`:
+a role map, the parameterized apply hook, and whatever the driver needs to find
+its own resources.
+
+## Step 4: implement `Provisioned` on `BaseProvisioned`
+
+Extend [`BaseProvisioned`](../../../src/provisioners/base.ts) so
+`apiId()` / `applicationId()` / `subscriptionId()` / `groupId()` all come from
+one `resolveId(role)`. Do not reimplement the getters.
+
+Then implement `contextPath()`, `update(params)`, `remove(role)` and
+`destroy()`.
+
+- **`remove(role)` removes that role the way a user would**, leaving the rest of
+  the scenario standing (GKO deletes that CR; Terraform drops the resource from
+  desired state and re-applies). It is what lets a journey assert partial
+  teardown.
+- **`destroy()` must be idempotent and must never throw.** It runs in `finally`
+  and in the `afterEach` safety net; a teardown failure must not mask a result.
+
+## Step 5: implement `ProvisionerView`
+
+```ts
+async read(role: Role): Promise<ProvisionerViewResult<XViewDetail>>
+```
+
+Exactly three outcomes: `applied`, `failed`, `gone`. **There is no `unknown`.**
+A provisioner that cannot yet tell what happened must **throw**, so
+`assertProvisioner` retries it instead of a half-implemented `read()` passing
+silently.
+
+`detail` carries the driver's own evidence: a condition, a plan diff, an HTTP
+error body.
+
+## Step 6: `checks`, only if unavoidable
+
+`ProvisionerChecks` is the narrowed escape hatch for assertions only this
+provisioner can make. Before adding one, ask whether it is really "did MY layer
+land this role?", which belongs in `view` and needs no narrowing. GKO declares
+none, deliberately. If you do add one, ship the type guard alongside it
+(`isTerraform` is the model) and export both from
+`src/provisioners/index.ts`.
+
+## Step 7: bind it for the e2e suite
+
+`src/` cannot import from `e2e/`, so the environment and fixture-path resolution
+are supplied by [`e2e/helpers/provisioner-env.ts`](../../../e2e/helpers/provisioner-env.ts).
+Add an `xScenario()` factory there, taking fixture-relative paths and returning
+`() => Provisioner<P>`, matching `gkoScenario` / `tfScenario`.
+
+Scenario authors must never construct a provisioner directly.
+
+## Step 8: verify
+
+```bash
+npm run build
+npm run typecheck && npm run typecheck:e2e && npm run typecheck:examples
+npm test
+npm run check:lanes          # needs the build; the lane count must grow and still partition
+npm run e2e -- --provision-with <id>
+```
+
+`check:lanes` is the guard that matters here: it asserts every test runs in
+exactly one lane. A new lane whose tag is wrong shows up as tests in two lanes
+or none, and both still pass an untagged full run.
+
+## Step 9: wire CI and docs
+
+- Add the lane to the matrix in `.circleci/config.yml` next to `gko` and
+  `terraform`.
+- [`PARITY.md`](../../../PARITY.md): what the new driver can and cannot express,
+  and the resulting backlog.
+- [The catalog](../../../e2e/tests/user-journeys/README.md): the new arm's column.
+- [`AGENTS.md`](../../../AGENTS.md) and [`e2e/README.md`](../../../e2e/README.md):
+  the lane in the tree and in the run commands.
+
+## Step 10: adopt it journey by journey
+
+Do not try to light up every journey at once.
+
+- Add the arm to one journey, prove it end to end, then fan out.
+- Every journey without the arm gets `pending: { <id>: "<reason>" }`, which
+  renders as a visible `test.fixme`. A silent absence is a gap nobody sees; a
+  provisioner absent from both `provisioners` and `pending` reads as "N/A by
+  design", so only leave it out when that is true.
+- Each arm carries **its own Xray id**: add `@GKO-TBD-*` placeholders and run
+  `/xray-sync-tests`.
+
+## Checklist
+
+- [ ] Registered in `registry.ts` only; no hardcoded provisioner list added anywhere
+- [ ] Lane tag added to `PROVISIONER` in `tags.ts`
+- [ ] `Provisioned` extends `BaseProvisioned`; getters not reimplemented
+- [ ] `destroy()` idempotent and non-throwing; `cleanup()` tolerant
+- [ ] `view.read()` returns three states and throws when it cannot tell
+- [ ] `checks` added only for something `view` genuinely cannot express
+- [ ] `xScenario()` factory in `provisioner-env.ts`; `src/` still imports nothing from `e2e/`
+- [ ] Apache 2.0 header on every new file; `exports` map updated if a new import path
+- [ ] Full verification gate green, including a real `--provision-with <id>` run
+- [ ] CI matrix, PARITY.md, catalog, AGENTS.md, e2e/README.md updated
+- [ ] Journeys either have the arm or an explicit `pending` reason

--- a/test/platform-test/.claude/skills/add-provisioner/references/provisioner-contract.md
+++ b/test/platform-test/.claude/skills/add-provisioner/references/provisioner-contract.md
@@ -1,0 +1,209 @@
+# The provisioner contract
+
+Annotated reference for the interfaces in `src/provisioners/`, plus the two
+implementations to read as worked examples. Read the source alongside this; the
+files are short and heavily commented.
+
+| File | Holds |
+|---|---|
+| [`registry.ts`](../../../../src/provisioners/registry.ts) | `PROVISIONER_ORDER`, `PROVISIONER_LANES`, the `ProvisionerId` type |
+| [`types.ts`](../../../../src/provisioners/types.ts) | `Provisioner`, `Provisioned`, `Role`, `ProvisionerChecks` |
+| [`view.ts`](../../../../src/provisioners/view.ts) | `ProvisionerView`, `ProvisionerState`, `assertProvisioner` |
+| [`base.ts`](../../../../src/provisioners/base.ts) | `BaseProvisioned`, the shared id getters |
+| [`gko/`](../../../../src/provisioners/gko/) | `GkoProvisioner`, `GkoView`, `subscriptionYaml` |
+| [`terraform/`](../../../../src/provisioners/terraform/) | `TerraformProvisioner`, `TerraformView`, `TerraformChecks` |
+| [`engines/`](../../../../src/provisioners/engines/) | `kubectl.ts`, `terraform-core.ts` |
+
+---
+
+## `Role`
+
+```ts
+type Role = "api" | "application" | "subscription" | "plan" | (string & {});
+```
+
+A logical name inside a scenario, mapped per provisioner to a concrete resource.
+The union gives autocomplete for the common roles while still allowing
+scenario-specific keys. `BaseProvisioned` builds the internal role string as
+`kind` or `kind:label`, so `apiId("two-plans")` resolves the role `api:two-plans`.
+
+## `Provisioner<P>`
+
+```ts
+interface Provisioner<P = unknown> {
+  readonly provisionerId: ProvisionerId;
+  provision(params: P): Promise<Provisioned<P>>;
+  cleanup?(): Promise<void>;
+  attach?(refs: Partial<Record<Role, { hrid: string }>>): Promise<Provisioned<P>>;
+}
+```
+
+- `provision` stands the scenario up with initial params and returns a live
+  handle.
+- `cleanup` is best-effort teardown **without** a handle, for the case where
+  `provision()` itself failed partway (a CR applied but reconcile stuck). Omit it
+  when the driver self-cleans on a failed provision, as Terraform does.
+- `attach` is the upgrade-testing seam: rebuild a handle from stable HRIDs after
+  the original in-memory state is gone, which is what lets
+  `tests/upgrade/survival.before.spec.ts` and `survival.after.spec.ts` run as two
+  separate processes either side of a `gck patch`. GKO implements it; Terraform
+  does not.
+
+## `Provisioned<P>`
+
+```ts
+interface Provisioned<P = unknown> {
+  readonly provisionerId: ProvisionerId;
+
+  apiId(label?: string): Promise<string>;
+  subscriptionId(label?: string): Promise<string>;
+  applicationId(label?: string): Promise<string>;
+  groupId(label?: string): Promise<string>;
+  contextPath(): Promise<string>;
+
+  update(params: P): Promise<void>;
+  remove(role: Role): Promise<void>;
+  destroy(): Promise<void>;
+
+  readonly view: ProvisionerView;
+  readonly checks?: ProvisionerChecks;
+}
+```
+
+Extend `BaseProvisioned` and implement one `resolveId(role)`; the four getters
+come from it. Ids are resolved once, then cached.
+
+Adding a new kind is **one line in `base.ts`**, not a method per provisioner:
+
+```ts
+dictionaryId(label?: string): Promise<string> {
+  return this.resolveId(roleFor("dictionary", label));
+}
+```
+
+## `ProvisionerView`
+
+```ts
+type ProvisionerState = "applied" | "failed" | "gone";
+
+interface ProvisionerView<Detail = unknown> {
+  read(role: Role): Promise<{ state: ProvisionerState; detail: Detail }>;
+}
+```
+
+Three outcomes, no fourth. An "unknown" state would let a half-implemented
+`read()` pass silently, so a provisioner that cannot yet tell **must throw**.
+
+`assertProvisioner(provisioned, role, expected, options?)` polls `read()`,
+retrying both the transient throw and a not-yet-`expected` state. Callable from
+shared scenario bodies without narrowing.
+
+Where it is used: after `remove()` (expect `"gone"`) and on failure paths
+(expect `"failed"`, whose `detail` carries the driver's reason). Not as a
+convergence wait after `update()`, because GKO's condition `observedGeneration`
+can lag after a re-apply (GKO-2940).
+
+## `ProvisionerChecks`
+
+```ts
+interface ProvisionerChecks {
+  readonly provisionerId: ProvisionerId;
+}
+```
+
+The base carries only the discriminant; a concrete shape (`TerraformChecks`)
+extends it, and a type guard (`isTerraform`) narrows it. Deliberately rare:
+anything expressible as "did MY layer land this role?" belongs in `view`.
+
+A provisioner with no unique assertions **omits the property entirely**, so
+shared bodies cannot reach for it by habit. GKO does exactly this: its
+control-plane readouts are the `view` question, and the remaining Kubernetes
+primitives (admission rejection, events) are reached through the kubectl engine
+in tests where nothing is provisioned.
+
+Terraform's checks today: drift detection, sensitive-value redaction, plan exit
+codes, taint.
+
+---
+
+## Worked example: GKO
+
+```ts
+interface GkoScenarioSpec<P = unknown> {
+  manifests: string[];              // absolute paths, applied in order at provision()
+  roles: GkoRoles;                  // role -> CR name (string) or { kind, name }
+  dynamicRoles?: Role[];            // roles created by applyParams; awaited after it
+  contextPath?: string;             // GKO has no output to read it from
+  applyParams?: (k: KubectlEngine, params: P) => Promise<void>;
+  namespace?: string;
+}
+```
+
+- **Kind by convention** from the role name: `api` → `apiv4definition`,
+  `application` → `application`, `subscription` → `subscription`,
+  `group` → `group`. Any other role must use the full `{ kind, name }` form, and
+  the provisioner throws a named error if it cannot infer one.
+- `resolveId(role)` reads `.status.id` of the role's CR.
+- `view.read(role)` reads the CR's conditions.
+- `remove(role)` deletes that CR.
+- `attach()` is implemented: HRID is `namespace + "-" + name`, which is stable
+  across an upgrade.
+
+## Worked example: Terraform
+
+```ts
+interface TfScenarioSpec<P = unknown> {
+  fixtureDir: string;                              // absolute, contains main.tf
+  env: Record<string, string>;                     // APIM_* auth, built by the e2e adapter
+  outputs?: Partial<Record<Role, string>>;         // role -> output name
+  addresses?: Partial<Record<Role, string>>;       // role -> "apim_apiv4.api", for view.read()
+  contextPathOutput?: string;                      // default "api_context_path"
+  toVars?: (params: P) => Record<string, unknown>; // params -> tfvars, per apply
+  removeVars?: Partial<Record<Role, Record<string, unknown>>>;  // how remove(role) drops it
+}
+```
+
+- `resolveId(role)` reads `terraform output`. Defaults: `api` → `api_id`,
+  `subscription` → `sub_id`, `application` → `app_id`, `group` → `group_id`.
+- `addresses` has **no default on purpose**: resource local names are not
+  standardized across fixtures (`test`, `app`, `dict`, `group`, `spg` are all in
+  use), so guessing one would point `view.read()` at the wrong resource instead
+  of failing loudly. It throws when a role needs `view` and has no address.
+- `remove(role)` merges `removeVars[role]` over the current vars and re-applies,
+  which is how a `count`-gated resource drops out of desired state. That is a
+  realistic user action, not a state surgery.
+- `cleanup()` is omitted: a failed apply self-cleans.
+
+---
+
+## The e2e binding
+
+`src/` must not import from `e2e/`. The two things it therefore cannot own are
+supplied by [`e2e/helpers/provisioner-env.ts`](../../../../e2e/helpers/provisioner-env.ts):
+
+```ts
+export function xScenario<P = unknown>(input: XScenarioInput<P>): () => Provisioner<P> {
+  return () => new XProvisioner<P>({ ...input, manifests: input.manifests.map(resolveFixturePath) });
+}
+```
+
+- **APIM environment** from `config.yaml` plus env-var overrides, memoized per
+  run (see `tfEnv()`).
+- **Fixture-path resolution**: absolute paths (co-located journey fixtures built
+  from `import.meta.url`) pass through unchanged; relative paths are rooted at
+  `e2e/fixtures/`.
+
+## How a scenario becomes tests
+
+[`e2e/helpers/for-each-provisioner.ts`](../../../../e2e/helpers/for-each-provisioner.ts)
+expands one `ScenarioDef` into one Playwright test per provisioner:
+
+- The title gets the scenario title, that arm's Xray id(s), `@<provisionerId>`,
+  the extra tags, and `@since-<v>` when declared.
+- A provisioner with a factory runs the shared body; one in `pending` renders as
+  `test.fixme`; one absent from both emits nothing.
+- The active provision is tracked at **module scope** so a single `afterEach` can
+  tear it down even when the test **times out**, which an inline `finally` cannot
+  do. Safe because the suite runs serially with one worker.
+- Timeout defaults to Playwright's 30s, or `TF_WORKSPACE_TIMEOUT_MS` for the
+  Terraform arm, overridable per provisioner via `timeoutMs`.

--- a/test/platform-test/.claude/skills/extend-platform-assertions/SKILL.md
+++ b/test/platform-test/.claude/skills/extend-platform-assertions/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: extend-platform-assertions
+description: Add or change an assertion in the @gravitee/platform-test library - a new mapi or gateway method, a new APIM entity type, or a whole new product surface such as Access Management, Alert Engine or Cockpit. Use when a test needs a platform assertion that does not exist yet, when a test is about to inline a raw fetch against APIM, or when extending the assertion library's public API.
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep
+---
+
+# extend-platform-assertions
+
+`src/assertions/` is the **provisioner-agnostic** half of the framework: the
+assertions that stay identical no matter how a resource was created. Anything a
+test inlines as a raw `fetch` against APIM is a missing method here.
+
+Invariants: [`.agent/rules/e2e-framework-development.md`](../../../.agent/rules/e2e-framework-development.md).
+Current surface: [`references` in the write-e2e-test skill](../write-e2e-test/references/assertions-cheatsheet.md).
+
+Work from `test/platform-test/`.
+
+---
+
+## Step 1: check it does not already exist
+
+```bash
+grep -nE "^  async (assert|wait|check|list|create|delete)" src/assertions/apim/mapi.ts
+grep -nE "^  async " src/assertions/apim/gateway.ts
+```
+
+`Mapi` already covers API, plan, subscription, api-key, application, group,
+category, member and page families. Extend the right family rather than adding a
+parallel one.
+
+## Step 2: pick the method shape
+
+One naming contract, no exceptions:
+
+| Prefix | Behaviour | Returns |
+|---|---|---|
+| `assertX(...)` | single shot; throws `AssertionError` on mismatch | `Promise<void>` |
+| `waitForX(..., options?: PollOptions)` | polled variant of the same assertion | `Promise<void>` |
+| `checkX(...)` | non-throwing; the caller inspects the report | `Promise<AssertionReport>` |
+| `listX` / `createX` / `deleteX` | plain data access for tests to build assertions on | the data |
+
+**Add `waitForX` whenever the value converges asynchronously**, which is true of
+anything written through the Automation API. A test that has to wrap your
+`assertX` in its own `poll()` is a sign the `waitForX` is missing.
+
+The body is always the same three lines:
+
+```ts
+async assertThingMatches(id: string, expected: DeepPartial<Thing>): Promise<void> {
+  const thing = await this.fetchThing(id);
+  const report = deepPartialMatch(thing, expected);
+  throwIfFailed(report);
+}
+
+async waitForThingMatches(
+  id: string,
+  expected: DeepPartial<Thing>,
+  options: PollOptions = {},
+): Promise<void> {
+  await poll(() => this.assertThingMatches(id, expected), {
+    description: `thing ${id} to match`,
+    ...options,
+  });
+}
+```
+
+Success is `void`; failure is a `node:assert` `AssertionError` produced by
+`deepPartialMatch` + `throwIfFailed`. Never return a boolean, never `console.log`
+a mismatch.
+
+## Step 3: model only what is asserted
+
+Add or extend the entity type in `src/types/apim.ts`.
+
+- Matching is **partial**, so fields the suite never asserts do not need
+  modelling. Mirroring the whole APIM response is churn that has to be
+  maintained against every APIM release.
+- Prefer the union of literal states (`"STARTED" | "STOPPED"`) over `string`, so
+  a typo in a test fails at `npm run typecheck:e2e`.
+
+## Step 4: know the endpoint's quirks
+
+Encode the quirk in the method rather than leaving it for each test to
+rediscover. Precedents worth copying:
+
+- `listActiveSubscriptionApiKeys` exists because APIM's api-key listing has **no
+  server-side filter** and returns revoked and expired keys.
+- `listApplicationMetadata` is a separate call because the application detail
+  response **omits** metadata.
+- `assertRespondsWithHeaders` matches header names case-insensitively and treats
+  a `null` expectation as "header absent", because that is how "the policy
+  stopped adding it" is asserted.
+- `assertNotResponds` counts a connection or TLS error as "not responding",
+  because a rejected mTLS handshake produces no HTTP status at all.
+
+Document the quirk in the method's doc comment, and add it to the
+[cheatsheet](../write-e2e-test/references/assertions-cheatsheet.md).
+
+## Step 5: a whole new product surface
+
+`src/assertions/am/` is the placeholder for Access Management and shows the
+intended shape. A new surface is a sibling of `src/assertions/apim/`:
+
+```
+src/assertions/<product>/
+  index.ts        # public re-exports
+  <client>.ts     # the class, built on HttpClient from src/utils/http/
+```
+
+Then:
+
+- Add an `exports` entry in [`package.json`](../../../package.json)
+  (`"./assertions/<product>"`), pointing at the built `dist/` paths, and mirror
+  the pattern of the existing entries.
+- Re-export from `src/index.ts` if it belongs on the top-level surface.
+- Use `HttpClient` and native `fetch`. A new runtime dependency needs a reason
+  that survives "can native `fetch` do this?".
+- Add the config block and its env-var overrides to `src/config/`, `config.yaml`,
+  and the override tables in `README.md` and `e2e/README.md`.
+
+## Step 6: test it
+
+Unit tests live under `test/` and run with vitest, **no cluster needed**:
+
+```
+test/apim/apim.test.ts        # Mapi
+test/apim/gateway.test.ts     # Gateway
+test/match/partial.test.ts    # deepPartialMatch
+test/provisioners/            # provisioner layer
+```
+
+```bash
+npm test
+```
+
+Cover the matching and report logic with a stubbed fetch: the pass case, the
+mismatch case (assert the failure path and message), and the quirk from Step 4.
+The cluster-dependent behaviour is proven by an e2e test that uses the method.
+
+## Step 7: verify and document
+
+```bash
+npm run build
+npm run typecheck && npm run typecheck:e2e && npm run typecheck:examples
+npm test
+npm run check:lanes
+npm run e2e -- --grep @GKO-NNNN     # a test that actually calls the new method
+```
+
+Then:
+
+- Add the method to the table in [`README.md`](../../../README.md).
+- Add it to the
+  [assertions cheatsheet](../write-e2e-test/references/assertions-cheatsheet.md)
+  so test authors find it.
+- Apache 2.0 header on every new file.
+
+## Checklist
+
+- [ ] Family checked for an existing method before adding one
+- [ ] Naming triplet respected; `waitForX` added if the value converges
+- [ ] void + throw via `deepPartialMatch` + `throwIfFailed`
+- [ ] Type models only what is asserted; literal unions over `string`
+- [ ] Endpoint quirks encoded in the method and documented
+- [ ] `exports` map + `src/index.ts` updated for a new import path
+- [ ] Vitest coverage for pass, mismatch, and the quirk
+- [ ] Apache 2.0 header on new files
+- [ ] Full verification gate green, including one real e2e test using the method
+- [ ] `README.md` table and the cheatsheet updated

--- a/test/platform-test/.claude/skills/investigate-e2e-failure/SKILL.md
+++ b/test/platform-test/.claude/skills/investigate-e2e-failure/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: investigate-e2e-failure
+description: Work a failing Gravitee platform e2e test (Playwright, test/platform-test) from symptom to root cause - leaked-resource cascade, eventual consistency, version gating, cluster/infra trouble, or a genuine bug in APIM, GKO or the Terraform provider. Use when an e2e test fails locally or in CI, when a suite times out, when several unrelated tests fail at once, or when asked why a test is flaky.
+allowed-tools: Bash, Read, Edit, Glob, Grep
+---
+
+# investigate-e2e-failure
+
+A failure in this suite is one of five things. Work them **in order**: the
+earlier causes produce symptoms that look exactly like the later ones, so
+skipping ahead leads to fixing a test that was never wrong.
+
+The rules this rests on are in
+[`.agent/rules/e2e-test-authoring.md`](../../../.agent/rules/e2e-test-authoring.md).
+Two of them govern this whole procedure:
+
+> **Never fix a failure by raising a timeout or skipping the test.**
+> **Always consider that the root cause is a bug in the component under test.**
+
+Work from `test/platform-test/`.
+
+---
+
+## Step 0: gather
+
+```bash
+# The run's own output
+open playwright-report/index.html          # HTML report, per-step traces
+grep -c "<failure" playwright-results/results.xml
+
+# Cluster state at the time of the failure
+kubectl get pods -A
+kubectl get apiv4definitions,applications,subscriptions -A
+kubectl logs deployment/gko-controller-manager -n default --tail=200
+
+# Reproduce the single test
+npm run e2e -- --grep @GKO-NNNN
+npm run e2e -- --grep @GKO-NNNN --provision-with terraform
+```
+
+Note **whether one test failed or many**, and **which failed first**. That single
+fact routes Steps 1 and 4.
+
+## Step 1: leaked resource cascade
+
+**Symptom:** a wave of generic 30s timeouts across unrelated suites; tests that
+pass in isolation fail in a full run.
+
+The suite runs serially, single-worker, against **one shared APIM**, and
+API/App names are a global namespace. One test that leaks a name makes every
+later apply of that name collide with stuck state.
+
+1. Find the **first** failure in the run, not the loudest one.
+2. Check that test for missing safety-net cleanup: inline `finally` does **not**
+   run on a Playwright timeout. `forEachProvisioner` provides the net; a
+   hand-rolled test needs its own `afterEach`/`afterAll`.
+3. Check cleanup order: subscriptions, then applications, then APIs. The
+   admission webhook blocks deleting an application that still has subscriptions,
+   so a wrong order leaves both behind.
+4. Sweep the leftovers and re-run:
+
+```bash
+kubectl get apiv4definitions,apidefinitions,applications,subscriptions -A
+kubectl delete apiv4definition,application,subscription -l gravitee.io/e2e=true -A
+```
+
+**Fix = add the missing safety net to the first failing test**, not a longer
+timeout on the ones that cascaded.
+
+## Step 2: eventual consistency
+
+**Symptom:** one test fails intermittently, on an assertion that immediately
+follows an apply; the value is correct when you check by hand afterwards.
+
+`kubectl apply` and `terraform apply` both return before APIM and the gateway
+have converged.
+
+- Convert the single-shot assertion to `mapi.waitForX(...)`, `expect.poll(...)`,
+  or the `poll()` util.
+- **Combine polled checks atomically:** one `expect.poll(...).toMatchObject({...})`
+  over every field. Polling one field and then re-fetching for the rest can
+  observe two different states.
+- A reconcile is triggered by re-`kubectl apply -f` on a modified CR file, not by
+  `kubectl patch` or `kubectl annotate`. A test using the latter may simply never
+  have triggered the change it is waiting for.
+- `provisioned.view` is **not** a convergence wait after `update()`: GKO's
+  condition `observedGeneration` can lag after a re-apply (GKO-2940), so a
+  post-update read can return the pre-update `Accepted=True`. Use `mapi`.
+
+## Step 3: version gate
+
+**Symptom:** the test fails only on an older APIM line, or only in the
+`--run-up-to-version` / upgrade jobs, with a "field unknown" or 400-shaped error.
+
+The feature is not in the APIM version under test. The APIM image comes from the
+`gravitee-io/gravitee` CircleCI orb, not from this repo.
+
+- Tag the test `since("<version the feature shipped in>")` so
+  `--run-up-to-version` skips it on older clusters. A `since` tag is per
+  provisioner: a feature can land in each driver at a different version.
+- **`since` is not a substitute for a skip.** Only use it when the version
+  boundary is real and known.
+- Check the local cluster's version before concluding:
+
+```bash
+kubectl get deploy -n gravitee -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.template.spec.containers[0].image}{"\n"}{end}'
+```
+
+## Step 4: infrastructure, not the test
+
+**Symptom:** `ECONNRESET`, `SocketError`, a mid-run collapse, or several
+consecutive failures that all hit the gateway or mAPI.
+
+Check the platform's own health **before** blaming the test:
+
+```bash
+kubectl get pods -n gravitee
+kubectl get pods -n gravitee -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.containerStatuses[*].restartCount}{"\t"}{.status.containerStatuses[*].lastState.terminated.reason}{"\n"}{end}'
+kubectl describe pod -n gravitee -l app.kubernetes.io/name=gateway
+```
+
+- `OOMKilled` or a climbing `restartCount` on the gateway or management API
+  means the suite starved the platform, not that the test is wrong. Say so, and
+  raise the pod's memory rather than the test's timeout.
+- `globalSetup` runs five pre-flight checks (management API, gateway, cluster,
+  CRDs, operator deployment). A failure there is an environment problem;
+  `e2e/README.md` maps each symptom to its fix.
+- Terraform arms need `terraform` on `PATH` at the CI-pinned version, and pick up
+  a locally built provider from the mirror if `scripts/build-tf-provider.sh` was
+  run.
+
+## Step 5: a bug in the component under test
+
+If Steps 1 to 4 come back clean, the failure is evidence, not noise. Establish:
+
+- **Which component:** GKO (operator), APIM backend / Automation API, gateway, or
+  the Terraform provider. The `origin` label does not tell you: `KUBERNETES`
+  means "written via the Automation API", which is the write path for **both**
+  GKO and Terraform.
+- **Does it reproduce through the other provisioner?** Running the same journey
+  with `--provision-with terraform` separates an operator bug from a platform bug
+  in one command. This is the single most useful diagnostic the suite has.
+- **Minimal repro:** the smallest manifest or HCL that shows it, saved to a file
+  so it can be attached to the ticket.
+- **Expected vs actual**, with the operator log line or HTTP response body.
+
+Watch for the recurring shapes: missing validation, silent failure, an optional
+field that is functionally required, schema mismatch between the CRD and the
+Automation API, and a successful apply/reconcile with broken runtime behaviour.
+
+### Filing it
+
+- Issue type **Private Bug** in project GKO, `Team` = **DevEx**
+  (`customfield_10001`).
+- **No** `Quality Management` / `GKO-Quality-Management` labels: those are for
+  Stories about the e2e framework, not for bugs.
+- Link the failing test to the bug as **"is tested by"**.
+- Show the full ticket draft and wait for approval before creating it.
+
+### While it is open
+
+- If the behaviour is genuinely broken, `test.fixme` the affected test **with the
+  ticket in the reason**, so the gap is visible and re-enabling it is findable.
+- If an arm cannot be expressed at all, use `pending: { <provisioner>: "<reason + ticket>" }`
+  on the scenario rather than deleting it.
+- Never green-wash by weakening the assertion.
+
+## Reporting back
+
+State plainly which of the five it was, the evidence, and what changed. If the
+answer is "a bug in the component under test", say that first: a working test
+that exposes a real defect is a success, not a failure to be worked around.

--- a/test/platform-test/.claude/skills/write-e2e-test/SKILL.md
+++ b/test/platform-test/.claude/skills/write-e2e-test/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: write-e2e-test
+description: Author or migrate a Playwright e2e test in test/platform-test - pick the right shape (shared user journey vs GKO-only vs Terraform-only), write the scenario and both provisioners' fixtures, tag it for Xray, run it, and update the catalog and PARITY docs. Use when asked to add e2e coverage, automate an Xray test, cover a new APIM/GKO/Terraform behaviour, or migrate a tests/gko test into a user journey.
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep
+---
+
+# write-e2e-test
+
+Procedure for adding coverage to the Gravitee platform e2e suite at
+`test/platform-test/`. The invariants this rests on are in
+[`.agent/rules/e2e-test-authoring.md`](../../../.agent/rules/e2e-test-authoring.md);
+read them if they are not already in context.
+
+Work from `test/platform-test/` unless stated otherwise.
+
+## References
+
+Load these on demand, not upfront:
+
+| File | When |
+|---|---|
+| `references/journey-template.md` | writing a new journey: skeletons for the scenario, `gko/*.yaml`, `terraform/main.tf`, `README.md` |
+| `references/assertions-cheatsheet.md` | choosing an assertion: the full `mapi` / `gateway` / `poll` surface |
+| `references/gko-only-test.md` | writing a hand-rolled `tests/gko/` test: safety-net cleanup, kubectl engine, admission rejection |
+
+---
+
+## Step 1: decide the shape
+
+| The system under test is… | Goes in | Shape |
+|---|---|---|
+| the platform (APIM/gateway behaviour a customer sees) | `e2e/tests/user-journeys/<persona>/<journey>/` | `*.scenario.ts` via `forEachProvisioner` |
+| the operator itself (admission, `.status`, templating, V2) | `e2e/tests/gko/<area>/` | `*.test.ts` tagged `PROVISIONER.GKO` |
+| the provider itself (drift, plan exit codes, redaction, import) | `e2e/tests/terraform/` | `*.test.ts` tagged `PROVISIONER.TERRAFORM` |
+| one journey's provisioner-specific slice | the journey folder | `<journey>-gko-only.test.ts` / `-tf-only.test.ts` |
+
+`tests/gko/` is not a lane, it is the operator under test. If a customer could do
+the same thing through Terraform, it is a journey.
+
+**Default to a journey.** Only fall back to a single-provisioner test when the
+thing being asserted is a Kubernetes or HCL mechanic, not a platform behaviour.
+
+For a `tests/gko/` or `tests/terraform/` test, jump to
+`references/gko-only-test.md` and skip to Step 6.
+
+## Step 2: place the journey
+
+1. **Persona picks the folder.** `api-producer` (designing, publishing,
+   securing, documenting an API), `api-consumer` (registering an application,
+   subscribing, calling the gateway), `platform-admin` (groups, members,
+   dictionaries, environment config). Check
+   [the catalog](../../../e2e/tests/user-journeys/README.md) for an existing home.
+2. **A new folder only when the _story_ differs, not when the config does.**
+   Variants of one story (message-API entrypoints, plan security types, api-key
+   modes) are a **named variant table plus a loop** inside the journey's own
+   `*.scenario.ts`, sharing one assertion body. Adding a folder per config
+   permutation is the single most common mistake here.
+
+Folder shape:
+
+```
+<persona>/<journey>/
+  <journey>.scenario.ts   # the shared intent, run against every provisioner
+  params.ts               # only if the two drivers need structurally different params
+  gko/        *.yaml      # the GKO custom resources
+  terraform/  main.tf     # the Terraform equivalent
+  README.md               # "As a <persona>, I ..." + how to run it
+```
+
+## Step 3: confirm the Terraform arm before writing it
+
+The provider (`gravitee-io/apim`) is Speakeasy-generated from APIM's Automation
+API OpenAPI spec, so its 10 resources map 1:1 onto the Automation API paths.
+**The local checkout drifts: always read `origin/main`.**
+
+```sh
+cd ~/dev/src/terraform-provider-apim && git fetch origin
+git show origin/main:internal/provider/provider.go | sed -n '/func.*Resources(ctx/,/^}/p'
+git show origin/main:internal/provider/apiv4_resource.go | grep -oE '^\t\t\t"[a-z_0-9]+": ' | tr -d '\t":' | sort
+```
+
+See [PARITY.md → Regenerating](../../../PARITY.md#regenerating-this-document).
+
+- **Attribute exists** → write the arm.
+- **Attribute missing** → this is an **Automation API backlog item**, not an
+  external constraint. File it, then declare the arm
+  `pending: { terraform: "<reason + ticket>" }` so it renders as a visible
+  `test.fixme`. Do not silently drop the journey to GKO-only.
+- **V2 API** → permanently GKO-only; the Automation API is V4-only by design.
+
+## Step 4: write one shared intent
+
+```ts
+forEachProvisioner<MyParams>(
+  {
+    title: "…",
+    provisioners: { gko: gkoScenario<MyParams>({…}), terraform: tfScenario<MyParams>({…}) },
+    xray: { gko: XRAY.AREA.GKO_ID, terraform: XRAY.TERRAFORM.TF_ID },
+    tags: [TAGS.REGRESSION],
+    since: { gko: "4.12", terraform: "4.12" },   // only if the feature has a minimum APIM version
+    timeoutMs: { gko: 90_000 },                  // only if 30s is genuinely not enough for the work
+  },
+  async ({ provisioned, mapi, gateway }) => { … },
+  initialParams,
+);
+```
+
+Rules for the body:
+
+- **Never branch on `provisionerId`.** If you need to, the difference belongs in
+  the fixtures or in `params.ts`, or the assertion belongs in a `-gko-only` /
+  `-tf-only` file.
+- **Assert through `mapi` / `gateway` only.** They are the provisioner-agnostic
+  platform assertions. Use `provisioned.view` only after `remove()` (expect
+  `"gone"`) and on failure paths, never as a convergence wait after `update()`.
+- **Assert the fields that carry regression value** (`visibility`,
+  `lifecycleState`, `security.type`, the policy's effect at the gateway), not
+  just that the resource exists. A use-case framing must not cost granularity.
+- **Poll, never assert immediately after an apply.** `waitFor*` or
+  `expect.poll(...).toMatchObject({...})`, combining checks atomically.
+- **Wrap stages in `test.step`** so a failure reports which stage broke.
+
+Fixture rules:
+
+- Co-locate `gko/*.yaml` and `terraform/main.tf` in the journey folder; pass
+  **absolute** paths built from `import.meta.url`.
+- GKO CRs carry the `gravitee.io/e2e: "true"` label and reference the shared
+  `dev-ctx` ManagementContext.
+- Every `main.tf` exposes `output "api_id"`, `output "sub_id"`,
+  `output "app_id"`, `output "group_id"` and `output "api_context_path"` as
+  applicable, or passes an `outputs` map. A role used with
+  `assertProvisioner` also needs `addresses: { role: "apim_x.name" }`.
+- Give resources **unique, journey-scoped names**. API/App names are a shared
+  global namespace across the whole serial suite; the GKO and TF arms must not
+  collide with each other (the convention is a `-tf` suffix on the TF arm).
+- **Structurally different parameterization goes in `params.ts`**: one shared
+  param type plus the per-provisioner closures (GKO `applyParams`, TF `toVars`).
+  Model: `api-consumer/subscribe-and-call/params.ts`.
+
+## Step 5: tag both arms
+
+Ids live only in [`e2e/helpers/tags.ts`](../../../e2e/helpers/tags.ts).
+
+- Reusing an existing Xray test: use its constant, and delete the test it
+  supersedes (Step 7).
+- New coverage: add a `@GKO-TBD-<slug>` placeholder per arm under the right
+  category, with the `// ── GKO-NNNN: <parent story>` comment convention.
+- GKO and Terraform are **different tickets**, so each arm gets its own id. A
+  list is allowed per arm when one provisioner splits into several tickets what
+  the other does in one.
+- Never put a Story or bug key in a test title, docstring, comment or fixture.
+
+## Step 6: run it
+
+```bash
+npm run e2e -- --grep @GKO-xxxx                          # the GKO arm
+npm run e2e -- --grep @GKO-yyyy --provision-with terraform # the TF arm
+npm run build && npm run check:lanes                     # lane partition guard
+npm run typecheck:e2e
+```
+
+Never report done without a run. If it fails, use the
+`investigate-e2e-failure` skill. Do not raise the timeout and do not skip.
+
+## Step 7: finish the job
+
+- **`/xray-sync-tests`** to turn every `@GKO-TBD-*` into a real Jira Test ticket
+  and rewrite `tags.ts` in place.
+- **Delete superseded tests.** Once the journey covers what a standalone
+  `tests/gko/` test did, remove that test and carry its Xray id onto the journey's
+  GKO arm. Admission or rejection cases stay in `tests/gko/<area>/` rather than
+  moving into the journey.
+- **Update [the catalog](../../../e2e/tests/user-journeys/README.md)**: one row,
+  with the journey link, what it demonstrates, and both arms' Xray ids.
+- **Update [PARITY.md](../../../PARITY.md)**: move the area from "Migratable, not
+  yet migrated" to "Migrated", or add a row to "Not expressible through
+  Terraform" with the reason.
+- **Write the journey `README.md`**: "As a `<persona>`, I …" plus how to run it.
+
+## Checklist before reporting done
+
+- [ ] Placed by persona; a new folder only because the story differs
+- [ ] Terraform arm confirmed against `origin/main`, or `pending` with a filed reason
+- [ ] Body does not branch on `provisionerId`; asserts through `mapi`/`gateway`
+- [ ] Regression-carrying fields asserted, not just existence
+- [ ] Every assertion after an apply is polled
+- [ ] Both arms tagged; ids only in `tags.ts`; no story/bug keys anywhere
+- [ ] Fixtures co-located, uniquely named, TF outputs contract honoured
+- [ ] Both arms actually run and passed (paste the result)
+- [ ] `npm run check:lanes` green
+- [ ] `/xray-sync-tests` run; catalog and PARITY.md updated; superseded tests deleted
+- [ ] Commit prefixed `test:`, body wrapped at ~72 cols, no AI attribution

--- a/test/platform-test/.claude/skills/write-e2e-test/references/assertions-cheatsheet.md
+++ b/test/platform-test/.claude/skills/write-e2e-test/references/assertions-cheatsheet.md
@@ -1,0 +1,163 @@
+# Assertions cheatsheet
+
+The provisioner-agnostic surface a scenario body asserts through. Source of
+truth: [`src/assertions/apim/mapi.ts`](../../../../src/assertions/apim/mapi.ts)
+and [`gateway.ts`](../../../../src/assertions/apim/gateway.ts). If a method you
+need is missing, add it via the `extend-platform-assertions` skill rather than
+inlining a `fetch` in the test.
+
+## Naming contract
+
+| Prefix | Behaviour |
+|---|---|
+| `assertX` | single shot; throws `AssertionError` on mismatch |
+| `waitForX` | polled variant; takes a trailing `PollOptions` (`{ timeoutMs, intervalMs, description }`) |
+| `checkX` | non-throwing; returns an `AssertionReport` for the caller to inspect |
+| `listX` / `createX` / `deleteX` | plain data access to build assertions on |
+
+**Anything read after an apply must be a `waitFor*`.** Both `kubectl apply` and
+`terraform apply` return before APIM has converged.
+
+## mAPI: APIs
+
+```ts
+await mapi.assertApiMatches(apiId, { name, definitionVersion: "V4", type: "PROXY", state: "STARTED" });
+await mapi.waitForApiMatches(apiId, { visibility: "PUBLIC", lifecycleState: "PUBLISHED" }, { timeoutMs: 30_000 });
+await mapi.checkApiMatches(apiId, {…});          // returns { pass, failures }
+
+await mapi.assertApiState(apiId, "STARTED");
+await mapi.assertApiStarted(apiId);   await mapi.waitForApiStarted(apiId, opts);
+await mapi.assertApiStopped(apiId);   await mapi.waitForApiStopped(apiId, opts);
+await mapi.assertApiHttpStatus(apiId, 404);      // e.g. after a delete
+await mapi.waitForApiAbsent(apiId, opts);
+
+await mapi.deleteApi(apiId, /* closePlans */ true);
+```
+
+Matching is **partial and positional**: only fields present in `expected` are
+checked, objects match recursively, arrays match by index, primitives are strict
+equality.
+
+## mAPI: plans, subscriptions, api-keys
+
+```ts
+await mapi.listApiPlans(apiId);
+await mapi.assertPlanMatches(apiId, planId, { security: { type: "JWT" } });
+await mapi.assertPlanStatus(apiId, planId, "PUBLISHED");
+await mapi.assertPlanPublished(apiId, planId);
+
+await mapi.assertSubscriptionMatches(apiId, subId, {…});
+await mapi.assertSubscriptionStatus(apiId, subId, "ACCEPTED");
+await mapi.assertSubscriptionAccepted(apiId, subId);
+
+await mapi.listSubscriptionApiKeys(apiId, subId);        // includes revoked/expired
+await mapi.listActiveSubscriptionApiKeys(apiId, subId);  // filtered client-side
+await mapi.waitForSubscriptionApiKeyCount(apiId, subId, 2, opts);
+```
+
+APIM's api-key listing endpoint has **no server-side filter**, so it returns
+revoked and expired keys; use the `Active` variant or filter on
+`revoked`/`expired` yourself. API-key **values are unique per API** including
+already-revoked entries, so custom-key tests need a per-run unique value.
+
+## mAPI: applications, groups, categories, members, pages
+
+```ts
+await mapi.assertApplicationMatches(appId, {…});
+await mapi.waitForApplicationMatches(appId, {…}, opts);
+await mapi.assertApplicationHttpStatus(appId, 404);
+await mapi.listApplicationMembers(appId);
+await mapi.listApplicationMetadata(appId);    // the detail response omits metadata
+
+await mapi.listGroups();
+await mapi.assertGroupMatches(hrid, {…});        await mapi.waitForGroupMatches(hrid, {…}, opts);
+await mapi.assertGroupMatchesById(id, {…});      await mapi.waitForGroupMatchesById(id, {…}, opts);
+await mapi.assertGroupAbsent(hrid);              await mapi.waitForGroupAbsent(hrid, opts);
+await mapi.assertGroupAbsentById(id);            await mapi.waitForGroupAbsentById(id, opts);
+await mapi.deleteGroup(groupId);
+await mapi.createServiceAccount(name);           // a resolvable member for group/member journeys
+
+await mapi.listCategories();
+await mapi.createCategory({ key, name, description });   // APIM drops unknown category refs silently
+await mapi.deleteCategory(categoryId);
+
+await mapi.listApiMembers(apiId);
+await mapi.listApiPages(apiId);
+```
+
+Assert the **whole member set per stage**, not just the added entry, so a
+duplicated or stale member fails the test.
+
+## Gateway
+
+```ts
+await gateway.assertResponds("/ctx", { status: 200 });
+await gateway.assertResponds("/ctx", { status: 200, headers: { Authorization: `Bearer ${token}` } });
+await gateway.assertNotResponds("/ctx", { notStatus: 200 });
+await gateway.assertRespondsWithHeaders("/ctx", { "X-Added": "yes", "X-Removed": null }, { status: 200 });
+```
+
+- All three **poll internally** (500ms interval, 30s window by default).
+- `assertNotResponds` treats a connection or TLS error as "not responding",
+  which is how a rejected mTLS handshake is asserted.
+- `assertRespondsWithHeaders` matches header names case-insensitively; a `null`
+  expectation asserts the header is **absent**, which is how "the policy stopped
+  adding it" is checked.
+- A policy is only really proven **at the gateway**: APIM will happily record a
+  flow the gateway never applies.
+
+mTLS:
+
+```ts
+import { createTlsFetch } from "@gravitee/platform-test/utils/http";
+const secureGw = mapi.gateway({ baseUrl: mtlsGatewayBaseUrl }, createTlsFetch({ cert, key, ca }));
+```
+
+## Provisioner readout
+
+```ts
+import { assertProvisioner } from "@gravitee/platform-test/provisioners";
+
+await provisioned.remove("subscription");
+await assertProvisioner(provisioned, "subscription", "gone");
+```
+
+Three states only: `applied`, `failed`, `gone`. Use after `remove()` and on
+failure paths. **Not** as a convergence wait after `update()`: GKO's condition
+`observedGeneration` can lag after a re-apply (GKO-2940), so a post-update read
+can return the pre-update `Accepted=True` and pass without asserting anything.
+`mapi` is the convergence signal after an update.
+
+The Terraform arm needs `addresses: { role: "apim_x.name" }` in its scenario
+spec (with a `[0]` suffix for a `count`-gated resource) and throws without it.
+
+## Polling utilities
+
+```ts
+import { poll, deepPartialMatch } from "@gravitee/platform-test";
+
+await poll(() => mapi.assertApiStarted(apiId), {
+  timeoutMs: 15_000,
+  intervalMs: 1_000,
+  description: "API to reach STARTED state",
+});
+
+// Playwright-native, for anything not covered by a waitFor*:
+await expect.poll(() => fetchSomething()).toMatchObject({ a: 1, b: 2 });
+```
+
+**Combine polled checks atomically.** One `expect.poll(...).toMatchObject({...})`
+over every field, not one poll per field followed by a fresh fetch for the rest:
+the second read can observe a different state.
+
+## Anti-patterns
+
+| Do not | Do |
+|---|---|
+| bump `timeout` to make a test pass | find the real convergence signal and poll it |
+| `test.skip` a failing test | `since()` if it is a version gate, `pending` if the arm is unimplemented, otherwise fix it |
+| assert immediately after `kubectl apply` / `terraform apply` | `waitFor*` or `expect.poll` |
+| poll one field, then re-fetch for the rest | one atomic `toMatchObject` |
+| branch the body on `provisionerId` | move the difference into fixtures, `params.ts`, or a `-gko-only` / `-tf-only` file |
+| `kubectl patch` / `kubectl annotate` to trigger a reconcile | re-`kubectl apply -f` a modified CR file |
+| assert only that a resource exists | assert the fields that carry regression value |

--- a/test/platform-test/.claude/skills/write-e2e-test/references/gko-only-test.md
+++ b/test/platform-test/.claude/skills/write-e2e-test/references/gko-only-test.md
@@ -1,0 +1,143 @@
+# Hand-rolled single-provisioner tests
+
+For `e2e/tests/gko/<area>/` (the **operator** under test) and
+`e2e/tests/terraform/` (the **provider** under test). Everything a customer could
+also do through the other driver belongs in a user journey instead: see the main
+skill's routing table.
+
+Legitimate `tests/gko/` subjects: admission webhooks and CRD schema validation,
+CR `.status` conditions and reconciliation, ConfigMap/Secret templating,
+ManagementContext lifecycle, CRD defaulting, import/export round-trips, V2 APIs
+(the Automation API is V4-only by design).
+
+Legitimate `tests/terraform/` subjects: drift detection, `terraform import`,
+data sources, `plan -detailed-exitcode`, provider-side schema validation,
+sensitive-attribute redaction.
+
+---
+
+## Shape
+
+```ts
+<LICENCE>
+
+/**
+ * <What is under test and why it is provisioner-specific.>
+ *
+ * Xray tests:
+ *   GKO-NNNN: <one line per test in this file>
+ *
+ * Preconditions:
+ *   - APIM, Gateway, and GKO operator are running
+ *   - A ManagementContext "dev-ctx" exists in the default namespace
+ */
+
+import { test, expect } from "../../../setup.js";
+import { XRAY, TAGS, PROVISIONER } from "../../../helpers/tags.js";
+import * as kubectl from "../../../helpers/kubectl.js";
+
+const RESOURCE_NAME = "e2e-<area>-<what>";
+
+test.describe(`<Area> — <behaviour> ${PROVISIONER.GKO}`, () => {
+  // Safety-net cleanup: inline cleanup does not run when a test times out.
+  // Reverse dependency order; each delete ignores errors.
+  test.afterEach(async () => {
+    await kubectl.deleteResource("apiv4definition", RESOURCE_NAME).catch(() => {});
+  });
+
+  test(`<what it proves> ${XRAY.AREA.ID} ${TAGS.REGRESSION}`, async ({ kubectl, mapi }) => {
+    // …
+  });
+});
+```
+
+**The provisioner tag on the describe title is mandatory.** Lane selection is by
+title tag alone: a missing tag means the test runs in *every* lane, a wrong one
+means it runs in the wrong lane, two means it runs in none. All three still pass
+an untagged full run, which is why `npm run check:lanes` exists. Run it.
+
+## Cleanup
+
+Two ways to clean up, both needed:
+
+```ts
+// 1. By resource kind + name, when the manifest was built inline:
+await kubectl.deleteResource("subscription", SUB_NAME).catch(() => {});
+await kubectl.deleteResource("application", APP_NAME).catch(() => {});
+await kubectl.deleteResource("apiv4definition", API_NAME).catch(() => {});
+
+// 2. By fixture file, when the manifest came from e2e/fixtures/:
+for (const f of ["<sub>/crd.yaml", "<app>/crd.yaml", "<api>/crd.yaml"]) {
+  await kubectl.del(fixture(f)).catch(() => {});
+}
+```
+
+- **Reverse dependency order: subscriptions, applications, APIs.** The admission
+  webhook blocks deleting an application that still has subscriptions.
+- **Always `.catch(() => {})`** on each call so one missing resource does not
+  abort the rest of the teardown.
+- **Never delete shared preconditions**: the `dev-ctx` ManagementContext, or the
+  APIM org/environment Terraform authenticates against.
+- Even a test whose resource should have been *rejected* needs the safety net:
+  if a regression makes admission accept it, it must not leak downstream.
+
+For Terraform, track the workspace and call `destroyWorkspace(ws)` in
+`afterAll`; it re-runs `destroy` as a no-op when a test already destroyed
+inline, so it is always safe.
+
+## kubectl engine
+
+`e2e/helpers/kubectl.ts` re-exports `src/provisioners/engines/kubectl.ts`
+unchanged. It is also available as a Playwright fixture (`async ({ kubectl }) =>`).
+
+| Function | Use |
+|---|---|
+| `apply(yamlPath, ns?)` / `applyString(yaml, ns?)` | create or update |
+| `applyExpectFailure(path)` / `applyStringExpectFailure(yaml)` | **negative tests**: returns stderr for assertion |
+| `applyDryRun(yamlPath, ns?)` | exercise admission without persisting |
+| `del(yamlPath, ns?)` / `deleteResource(kind, name, ns?)` | teardown |
+| `delExpectFailure(yamlPath)` | assert a deletion is blocked |
+| `get<T>(kind, name, ns?)` / `getStatus<T>()` / `getField<T>()` / `getCondition()` | read CR state |
+| `exists()` / `waitForExists()` / `waitForDeletion()` / `waitForCondition()` | wait on cluster state |
+| `findPod()` / `rolloutRestart()` / `waitForRollout()` | operator-lifecycle tests |
+| `writeConfigMap()` / `readConfigMap()` | cross-process handshakes (upgrade survival) |
+
+**To trigger a reconcile, re-`apply` a modified CR file.** Not `kubectl patch`,
+not `kubectl annotate`.
+
+## Negative tests: pin the rejection to its cause
+
+A rejection test that only asserts "apply failed" passes for the wrong reason as
+soon as the manifest drifts. Assert the value **and** its field path:
+
+```ts
+const stderr = await kubectl.applyStringExpectFailure(v4Manifest({ name, type: "EDGE" }));
+expect(stderr.toLowerCase()).toContain("unsupported value");
+expect(stderr).toContain("EDGE");
+expect(stderr).toContain("spec.type");
+```
+
+Keep the rest of the manifest valid, so the offending field is the only possible
+cause. `metadata.name` must stay RFC 1123 DNS-safe, so map underscores to
+hyphens when deriving a name from an enum value.
+
+## Fixtures
+
+Hand-rolled tests use the central `e2e/fixtures/<domain>/<scenario>/` tree via
+`fixture("domain/scenario/crd.yaml")`. Conventions:
+
+- Domain folders mirror the `tests/gko/` folders (`admission-webhook/`,
+  `api-lifecycle/`, `categories/`, `policies/`).
+- Scenario folders describe **what is being tested**, not what kind of CR sits at
+  the top of the manifest: a V4 API with a JWT plan is `plans/v4-jwt/`, not
+  `api-v4-definitions/`.
+- Prefix with `v2-` / `v4-` inside domains holding both.
+- Build the manifest inline (a template function plus `applyString`) when the
+  test needs to vary one field across many cases; a fixture file per enum value
+  is noise.
+
+## Docstring
+
+Every file opens with: what is under test, why it is provisioner-specific, the
+`Xray tests:` list (one line per test, id plus intent), and `Preconditions:`.
+Reference **Xray Test ids only**, never a Story or bug key.

--- a/test/platform-test/.claude/skills/write-e2e-test/references/journey-template.md
+++ b/test/platform-test/.claude/skills/write-e2e-test/references/journey-template.md
@@ -1,0 +1,346 @@
+# Journey templates
+
+Copy-paste skeletons for a new `e2e/tests/user-journeys/<persona>/<journey>/`.
+Derived from `api-producer/publish-api-and-serve-traffic/`, which is the
+reference implementation to read when in doubt.
+
+Every `.ts` and `.yaml` file starts with the Apache 2.0 licence header (CI job
+`job-lint-licenses` enforces it for sources). Copy it from any existing file in
+the suite; it is elided below for brevity as `<LICENCE>`.
+
+---
+
+## `<journey>.scenario.ts`
+
+```ts
+<LICENCE>
+
+/**
+ * Journey: <one line, the customer-visible outcome>.
+ *
+ * As a <persona>, I <story>. <What is asserted and why it carries regression
+ * value.>
+ *
+ * Fixtures are co-located in this folder. <Anything that stays GKO-only or
+ * Terraform-only, and why.>
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "../../../../setup.js";
+import { XRAY, TAGS } from "../../../../helpers/tags.js";
+import { forEachProvisioner } from "../../../../helpers/for-each-provisioner.js";
+import { gkoScenario, tfScenario } from "../../../../helpers/provisioner-env.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+/** The single knob this journey varies. */
+interface MyParams {
+  state: "STARTED" | "STOPPED";
+}
+
+forEachProvisioner<MyParams>(
+  {
+    title: "<Imperative sentence describing the journey>",
+    provisioners: {
+      gko: gkoScenario<MyParams>({
+        manifests: [path.join(here, "gko/api.yaml")],
+        roles: { api: "<cr-metadata-name>" },   // role -> CR name; kind by convention
+        contextPath: "/<context-path>",
+        // Parameterized resources are applied here instead of via `manifests`.
+        // Declare them in `dynamicRoles` so their ids resolve after this runs.
+        // dynamicRoles: ["subscription"],
+        // applyParams: async (k, params) => { await k.apply(path.join(here, `gko/${params.state}.yaml`)); },
+      }),
+      terraform: tfScenario<MyParams>({
+        fixture: path.join(here, "terraform"),
+        toVars: (params) => ({ state: params.state }),
+        // addresses: { api: "apim_apiv4.api" },   // required for view/assertProvisioner
+        // outputs: { api: "api_id" },             // only to override the defaults
+        // removeVars: { subscription: { create_subscription: false } },
+      }),
+    },
+    xray: {
+      gko: XRAY.<AREA>.<ID>,               // a string[] is allowed when one arm covers several tickets
+      terraform: XRAY.TERRAFORM.<ID>,
+    },
+    tags: [TAGS.REGRESSION],
+    // since: { gko: "4.12", terraform: "4.12" },
+    // timeoutMs: { gko: 90_000 },
+    // pending: { terraform: "no `x` attribute on apim_apiv4 yet (GKO-NNNN)" },
+  },
+  async ({ provisioned, mapi, gateway }) => {
+    const apiId = await provisioned.apiId();
+    const ctx = await provisioned.contextPath();
+
+    await test.step("<what the initial state proves>", async () => {
+      await mapi.waitForApiMatches(
+        apiId,
+        { state: "STARTED", visibility: "PUBLIC", lifecycleState: "PUBLISHED" },
+        { timeoutMs: 30_000 },
+      );
+      await gateway.assertResponds(ctx, { status: 200 });
+    });
+
+    await test.step("<what the change proves>", async () => {
+      await provisioned.update({ state: "STOPPED" });
+      await mapi.waitForApiStopped(apiId, { timeoutMs: 30_000 });
+      await gateway.assertResponds(ctx, { status: 404 });
+    });
+  },
+  { state: "STARTED" },
+);
+```
+
+### Variant table (the shape to use instead of a second folder)
+
+When the story is the same and only the configuration differs, keep one folder
+and one assertion body:
+
+```ts
+const VARIANTS = [
+  { name: "http-get", manifest: "gko/api-http-get.yaml", entrypoint: "http-get" },
+  { name: "sse", manifest: "gko/api-sse.yaml", entrypoint: "sse" },
+] as const;
+
+for (const variant of VARIANTS) {
+  forEachProvisioner(
+    {
+      title: `Publish a message API over ${variant.name}`,
+      provisioners: { gko: gkoScenario({ manifests: [path.join(here, variant.manifest)], … }), … },
+      xray: { gko: XRAY.MESSAGE_APIS[variant.xrayKey], … },
+      tags: [TAGS.REGRESSION],
+    },
+    async ({ provisioned, mapi }) => { /* one shared body */ },
+  );
+}
+```
+
+---
+
+## `gko/<resource>.yaml`
+
+```yaml
+<LICENCE>
+
+# <What this manifest represents in the journey, and what re-applying a sibling
+# manifest changes.>
+apiVersion: gravitee.io/v1alpha1
+kind: ApiV4Definition
+metadata:
+  name: <journey-scoped-name>
+  labels:
+    gravitee.io/e2e: "true"
+spec:
+  contextRef:
+    name: "dev-ctx"
+    namespace: "default"
+  name: "<journey-scoped-name>"
+  description: "<why this API exists in the journey>"
+  version: "1.0.0"
+  type: PROXY
+  state: STARTED
+  visibility: PUBLIC
+  lifecycleState: PUBLISHED
+  definitionContext:
+    origin: KUBERNETES
+    syncFrom: MANAGEMENT
+  listeners:
+    - type: HTTP
+      paths:
+        - path: "/<context-path>"
+      entrypoints:
+        - type: http-proxy
+          qos: AUTO
+  endpointGroups:
+    - name: Default HTTP proxy group
+      type: http-proxy
+      endpoints:
+        - name: Default HTTP proxy
+          type: http-proxy
+          inheritConfiguration: false
+          configuration:
+            target: https://api.gravitee.io/echo
+  flowExecution:
+    mode: DEFAULT
+    matchRequired: false
+  plans:
+    KeyLess:
+      name: "Free plan"
+      description: "This plan does not require any authentication"
+      security:
+        type: "KEY_LESS"
+```
+
+Notes:
+
+- `metadata.name` must be RFC 1123 DNS-safe.
+- The HRID is `namespace + "-" + name`, from which APIM derives a deterministic
+  UUIDv3. Use it to correlate a CR with its APIM resource.
+- Never delete the shared `dev-ctx` ManagementContext in a test.
+
+---
+
+## `terraform/main.tf`
+
+```hcl
+# <What this configuration represents, and which variable the scenario re-applies.>
+terraform {
+  required_providers {
+    apim = {
+      source = "gravitee-io/apim"
+    }
+  }
+}
+
+provider "apim" {}
+
+variable "environment_id" {
+  type    = string
+  default = "DEFAULT"
+}
+
+variable "organization_id" {
+  type    = string
+  default = "DEFAULT"
+}
+
+variable "state" {
+  type    = string
+  default = "STARTED"
+}
+
+resource "apim_apiv4" "api" {
+  environment_id  = var.environment_id
+  organization_id = var.organization_id
+  hrid            = "<journey-scoped-name>-tf"
+  name            = "<journey-scoped-name>-tf"
+  description     = "<same intent as the GKO arm>"
+  version         = "1"
+  type            = "PROXY"
+  state           = var.state
+  lifecycle_state = "PUBLISHED"
+  visibility      = "PUBLIC"
+
+  listeners = [
+    {
+      http = {
+        type        = "HTTP"
+        paths       = [{ path = "/<context-path>-tf/" }]
+        entrypoints = [{ type = "http-proxy" }]
+      }
+    }
+  ]
+
+  endpoint_groups = [
+    {
+      name = "Default HTTP proxy group"
+      type = "http-proxy"
+      endpoints = [
+        {
+          name                  = "default-endpoint"
+          type                  = "http-proxy"
+          inherit_configuration = false
+          configuration         = jsonencode({ target = "https://api.gravitee.io/echo" })
+        }
+      ]
+    }
+  ]
+
+  plans = [
+    {
+      hrid       = "keyless"
+      name       = "Free plan"
+      type       = "API"
+      mode       = "STANDARD"
+      validation = "AUTO"
+      status     = "PUBLISHED"
+      security   = { type = "KEY_LESS" }
+    }
+  ]
+}
+
+# Output contract: the provisioner resolves roles to APIM ids by these names.
+output "api_id" {
+  value = apim_apiv4.api.id
+}
+
+output "api_context_path" {
+  value = "/<context-path>-tf"
+}
+```
+
+Default role to output mapping: `api` → `api_id`, `subscription` → `sub_id`,
+`application` → `app_id`, `group` → `group_id`, context path →
+`api_context_path`. Override with the scenario's `outputs` /
+`contextPathOutput`.
+
+The TF arm's resource names carry a `-tf` suffix so the two arms never collide
+in APIM's shared name space.
+
+---
+
+## `params.ts` (only when the drivers diverge structurally)
+
+One shared param type plus the per-provisioner closures. Full example:
+`api-consumer/subscribe-and-call/params.ts`.
+
+```ts
+<LICENCE>
+
+/**
+ * Parameter binding for <journey>. ONE shared param type drives every
+ * provisioner; the per-provisioner closures translate it into the GKO manifest
+ * and the Terraform tfvars. This is the scenario-specific seam the provisioner
+ * core deliberately does not own.
+ */
+
+import type { KubectlEngine } from "../../../../../src/provisioners/index.js";
+
+export interface MyParams {
+  /** … */
+}
+
+/**
+ * Per-process suffix so re-runs get fresh values. APIM enforces uniqueness on
+ * some fields (api-key values per API) across active AND revoked state, and the
+ * local MongoDB persists across cluster restarts, so hardcoded values collide on
+ * a second run.
+ */
+export const RUN_ID = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+
+export function gkoApply(/* … */) {
+  return async (kubectl: KubectlEngine, params: MyParams): Promise<void> => {
+    await kubectl.applyString(/* built manifest */);
+  };
+}
+
+export function toVars(params: MyParams): Record<string, unknown> {
+  return { /* tfvars */ };
+}
+```
+
+---
+
+## `README.md`
+
+```markdown
+# <Journey title>
+
+**As an <persona>, I <story>.**
+
+<Two or three sentences: what the journey stands up, what it asserts, and any
+stage that exists to catch a specific regression.>
+
+| Arm | Fixtures | Xray |
+|---|---|---|
+| GKO | [`gko/`](./gko/) | @GKO-NNNN |
+| Terraform | [`terraform/`](./terraform/) | @GKO-MMMM |
+
+## Running it
+
+```sh
+npm --prefix test/platform-test run e2e -- --grep @GKO-NNNN
+npm --prefix test/platform-test run e2e -- --grep @GKO-MMMM --provision-with terraform
+```
+```

--- a/test/platform-test/.gitignore
+++ b/test/platform-test/.gitignore
@@ -6,3 +6,13 @@ test-results/
 playwright-report/
 playwright-results/
 e2e/playwright-results/
+
+# The shared agent config and skills are part of the suite and must be
+# committed. Many contributors ignore .claude/ globally, which would silently
+# drop them. This is an allowlist rather than a negation of the whole tree, so
+# whatever else an agent writes here (local settings, session state) stays
+# ignored by default.
+!.claude/
+.claude/*
+!.claude/settings.json
+!.claude/skills/

--- a/test/platform-test/AGENTS.md
+++ b/test/platform-test/AGENTS.md
@@ -1,40 +1,30 @@
 # AGENTS.md: platform-test (E2E suite)
 
+@.agent/rules/e2e-test-authoring.md
+@.agent/rules/e2e-framework-development.md
+
 Guidance for AI coding agents working under `test/platform-test/`. This is the
 Playwright (TypeScript) end-to-end suite that drives a **real** local Kubernetes
 cluster running APIM + Gateway + the GKO operator, plus the Terraform APIM
 provider. There are **no mocks**: every test mutates live cluster + APIM state.
 
-> Read this before editing or adding tests. For environment bootstrap (`gck`,
-> Helm, pre-flight checks) read [`e2e/README.md`](e2e/README.md); for the
-> assertion library API read [`README.md`](README.md); for coverage status and
-> what is left to migrate read [`PARITY.md`](PARITY.md). Do not duplicate those
-> here.
+## Start here
 
----
+| You are… | Read | Then invoke |
+|---|---|---|
+| adding or changing a **test** | [`.agent/rules/e2e-test-authoring.md`](.agent/rules/e2e-test-authoring.md) | `write-e2e-test` |
+| chasing a **failing test** | same | `investigate-e2e-failure` |
+| adding a **provisioner** or engine | [`.agent/rules/e2e-framework-development.md`](.agent/rules/e2e-framework-development.md) | `add-provisioner` |
+| extending the **assertion library** | same | `extend-platform-assertions` |
 
-## Golden rules
+The two rules files are the invariants and are imported above, so they load with
+this file. The four skills live in [`.claude/skills/`](.claude/skills/) and carry
+the step-by-step procedures.
 
-> **Critical: these are the mistakes that have actually broken CI.**
-
-1. **Every test cleans up everything it creates, with a safety net.** Inline
-   cleanup does **not** run if the test times out, and a leaked APIM resource
-   poisons every later test that reuses the same name. `forEachProvisioner` gives
-   you this for free; a hand-rolled test needs its own `afterEach`/`afterAll`.
-2. **Never fix a failure by raising a timeout or skipping the test.** A 30s
-   timeout that needs 31s is hiding a real reconcile, apply, or consistency
-   problem.
-3. **Run the test you changed before reporting done.** `npm run e2e -- --grep
-   @GKO-xxxx`. Don't claim green without a run.
-4. **Use `npm run e2e`, never bare `npx playwright test`.** The bare command
-   skips `globalSetup` (the infra pre-flight checks) and gives misleading
-   failures.
-5. **Clean up in reverse dependency order:** subscriptions → applications →
-   APIs. The GKO admission webhook blocks deleting an application that still has
-   subscriptions. Never delete shared preconditions: the `dev-ctx`
-   ManagementContext, or the APIM org/environment Terraform authenticates against.
-6. **Every test carries its provisioner tag.** Lane selection is by title tag
-   alone (below). `npm run check:lanes` enforces it.
+For environment bootstrap (`gck`, Helm, pre-flight checks) read
+[`e2e/README.md`](e2e/README.md); for the assertion library API read
+[`README.md`](README.md); for coverage status and what is left to migrate read
+[`PARITY.md`](PARITY.md). Do not duplicate those here.
 
 ---
 
@@ -48,6 +38,8 @@ provisioner.
 
 ```
 test/platform-test/
+  .agent/rules/                 # the invariants, per audience
+  .claude/skills/               # the procedures, per audience
   src/                          # @gravitee/platform-test (runner-agnostic; `npm run typecheck`)
     assertions/apim/            # mapi, gateway — shared, provisioner-agnostic assertions
     config/                     # config.yaml loading
@@ -88,27 +80,23 @@ customer could also do through Terraform belongs in a journey.
 
 ## Adding a user journey
 
-1. **Pick the persona folder** — who performs this journey? `api-producer`,
+Full procedure: the [`write-e2e-test`](.claude/skills/write-e2e-test/SKILL.md)
+skill. Two rules decide placement, and they are the ones most often got wrong:
+
+1. **Persona picks the folder** — who performs this journey? `api-producer`,
    `api-consumer`, `platform-admin`. See the
    [catalog](./e2e/tests/user-journeys/README.md).
 2. **A new folder only when the _story_ differs, not when the config does.**
    Variants of one story (message-API entrypoints, plan security types, api-key
    modes) are a **named variant table + loop** inside the journey's own
    `*.scenario.ts`, sharing one assertion body.
-3. **Confirm the Terraform path first.** Read the provider schema on
-   `origin/main` (the local checkout drifts) — see
-   [PARITY.md → Regenerating](./PARITY.md#regenerating-this-document). A missing
-   attribute is an Automation-API backlog item: file it and mark the arm
-   `pending`, do not silently drop the journey.
-4. **Author one shared intent**, not two tests. The body must not branch on
-   `provisionerId`. Assert the fields that carry regression value
-   (`visibility`, `lifecycleState`, `security.type`) so the use-case framing does
-   not lose granularity.
-5. **De-dup.** Once the journey covers what a standalone GKO/TF test did, **delete
-   that test** and carry its Xray id onto the journey arm.
-6. **Tag & sync.** Each arm carries its own Xray id; add a `@GKO-TBD-*`
-   placeholder for a new arm in `helpers/tags.ts`, then run `/xray-sync-tests`.
-   Update the catalog and PARITY.md.
+
+Then: confirm the Terraform path against the provider schema on `origin/main`
+(a missing attribute is an Automation-API backlog item to file, not a reason to
+drop the arm), author **one shared intent** whose body never branches on
+`provisionerId`, delete any `tests/gko/` test the journey supersedes and carry
+its Xray id onto the GKO arm, tag both arms, and update the catalog and
+PARITY.md.
 
 ```ts
 forEachProvisioner<MyParams>(
@@ -154,33 +142,6 @@ Parameterization that differs structurally per provisioner lives in a co-located
 `params.ts` exposing one shared param type plus the per-provisioner closures (GKO
 `applyParams`, TF `toVars`). See `api-consumer/subscribe-and-call/`.
 
-### `view` vs `checks`
-
-- **`provisioned.view`** — the agnostic readout: *"did MY layer land this role?"*,
-  answered from the provisioner's own record (GKO's CR status, Terraform's state),
-  never from APIM. Callable from shared bodies with no narrowing, via
-  `assertProvisioner(provisioned, role, "applied" | "failed" | "gone")`.
-
-  Use it **after `remove()`** (expect `"gone"`) and on **failure paths**.
-  Do **not** use it as a convergence wait after `update()`: GKO's condition
-  `observedGeneration` can lag indefinitely after a re-apply (GKO-2940), so a
-  post-update read can return the *pre*-update `Accepted=True` and pass without
-  asserting anything. `mapi` is the convergence signal after an update.
-
-  Terraform's `read()` needs `addresses: { role: "apim_x.name" }` in the scenario
-  spec (`[0]`-suffixed for a `count`-gated resource) and throws without it.
-
-- **`provisioned.checks`** — the escape hatch for assertions only one provisioner
-  can make, narrowed with `isTerraform()`. Terraform-only today: drift,
-  redaction, plan exit codes, taint. **GKO declares none** — its control-plane
-  readouts *are* the `view` question, and the remaining Kubernetes primitives
-  (admission rejection, events) are reached through the kubectl engine in tests
-  where nothing is provisioned.
-
-- **Gaps without noise:** a planned-but-unimplemented provisioner goes in
-  `pending: { terraform: "<reason>" }` and renders as a visible `test.fixme`,
-  never a silent skip. A provisioner absent from both is N/A by design.
-
 ## Selecting what to run
 
 `npm run e2e` is the single entry point for every suite; the other scripts are
@@ -209,93 +170,5 @@ Do **not** use `--grep @gko`: Playwright's CLI `--grep` is case-insensitive, so
 config's own `grepInvert` is case-sensitive for exactly this reason.
 
 The flags are orthogonal and combine: `--provision-with gko --run-up-to-version 4.11`.
-
-## Polling & eventual consistency
-
-Both `kubectl apply` and `terraform apply` return before APIM/Gateway have
-converged. Never assert immediately after an apply.
-
-- Use `mapi.waitForApiMatches()` / `expect.poll()` / the `poll()` util, not a
-  single-shot assertion. This is the convergence check that matters for **both**
-  drivers, since both write to APIM via the Automation API.
-- **Combine polled checks atomically:** `expect.poll(() => fetch…).toMatchObject({…})`
-  rather than polling one field then re-fetching for the rest.
-- **To trigger a GKO reconcile, re-`kubectl apply -f` a modified CR file.** Not
-  `kubectl patch`/`annotate`. For Terraform, edit the vars and re-apply.
-
-## Resource isolation
-
-The suite runs **serially with a single worker** against **one shared APIM**:
-
-- **API/App names are a shared global namespace.** If one test leaks a name, the
-  next file's apply collides with stuck state and times out, so one root failure
-  cascades. Prefer a unique, test-scoped name over reusing an existing fixture's.
-- **APIM/MongoDB state persists across cluster restarts.** Only `kind delete
-  cluster` or a full Helm uninstall + PV delete wipes it.
-
-### Safety-net cleanup (hand-rolled tests only)
-
-`forEachProvisioner` handles this for you. A test that provisions directly needs:
-
-```ts
-import * as kubectl from "../../../helpers/kubectl.js";
-
-test.describe(`… ${PROVISIONER.GKO}`, () => {
-  test.afterEach(async () => {
-    for (const f of ["<sub>/crd.yaml", "<app>/crd.yaml", "<api>/crd.yaml"]) {
-      await kubectl.del(fixture(f)).catch(() => {});   // reverse dependency order
-    }
-  });
-});
-```
-
-For Terraform, track the workspace and `destroyWorkspace(ws)` in `afterAll`; it
-re-runs `destroy` as a no-op if a test already destroyed inline, so it is always
-safe to call.
-
-## APIM behaviours worth knowing
-
-Quirks of the **APIM backend / Automation API**, not the operator:
-
-- **Origin labels:** `origin: MANAGEMENT` = written via mAPI; `origin: KUBERNETES`
-  = written via the Automation API — the write path for **both** GKO and
-  Terraform, so origin alone does not tell you which driver created a resource.
-- **API-key listing returns revoked/expired keys:** no server-side filter. Filter
-  client-side on `revoked`/`expired`.
-- **API-key values are unique per API**, including already-revoked entries. Custom-key
-  tests must generate a per-run unique value.
-- **`syncFrom: MANAGEMENT`** is the default for almost all V4 fixtures; not a
-  discriminator when triaging.
-
-GKO-specific: **HRID → ID** is `namespace + "-" + name`, from which APIM derives a
-deterministic UUIDv3. Use it to correlate CR ↔ APIM API.
-
-## When a test fails
-
-1. **Leaked resource / cascade?** A wave of generic 30s timeouts across unrelated
-   suites usually means one earlier test leaked a shared-named resource. Find the
-   *first* failure and the missing safety-net cleanup.
-2. **Eventual consistency?** Convert a flaky single-shot assertion to
-   `poll()` / `expect.poll()`. Don't bump the timeout.
-3. **APIM image too old?** Some tests need a fix not yet in the pinned APIM (the
-   version comes from the `gravitee-io/gravitee` CircleCI orb, not this repo).
-
-Always consider that the root cause is a **bug in the component under test**, not
-the test. Flag it explicitly rather than working around it.
-
-## Committing
-
-> **Critical: no AI attribution on commits or PRs.** Whatever agent you are, do
-> **not** add an AI co-author or attribution trailer: no `Co-Authored-By: …`, no
-> "Generated with …" footer. Match the repo's style: a `test:` / `docs:` / `fix:`
-> prefixed subject and a plain body.
-
-This is **enforced by committed config**, but verify your trailers if your tool
-ignores it: [`.claude/settings.json`](.claude/settings.json) sets
-`attribution.commit`/`attribution.pr` to empty strings;
-[`.cursor/cli-config.json`](.cursor/cli-config.json) sets
-`attributeCommitsToAgent`/`attributePRsToAgent` to `false`. Adding a new agent?
-Drop its equivalent config under `test/platform-test/` (this suite is
-self-contained and may move to its own repo) rather than relying on this prose.
 
 Reports: `playwright-results/` (JUnit XML), `playwright-report/` (HTML).

--- a/test/platform-test/PARITY.md
+++ b/test/platform-test/PARITY.md
@@ -6,9 +6,11 @@ and what is left to migrate. It answers "where do we stand?".
 
 It is **not** the authoring guide. How to write a test (persona folders, the
 variant-matrix rule, cleanup patterns, `view` vs `checks`) lives in
-[AGENTS.md](./AGENTS.md); the journey list lives in the
-[catalog](./e2e/tests/user-journeys/README.md). Keep those boundaries — this file
-drifted before precisely because nothing said what it was for.
+[AGENTS.md](./AGENTS.md) and the
+[`write-e2e-test`](./.claude/skills/write-e2e-test/SKILL.md) skill; the journey
+list lives in the [catalog](./e2e/tests/user-journeys/README.md). Keep those
+boundaries — this file drifted before precisely because nothing said what it was
+for.
 
 > Regenerate the provider tables below from source rather than editing by hand;
 > see [Regenerating this document](#regenerating-this-document).

--- a/test/platform-test/README.md
+++ b/test/platform-test/README.md
@@ -246,6 +246,11 @@ npm run check:lanes         # assert the provisioner lanes partition the suite
 For the e2e suite itself see [e2e/README.md](e2e/README.md) (bootstrap) and
 [AGENTS.md](AGENTS.md) (how to write a test).
 
+AI agents contributing here have two rule sets in [`.agent/rules/`](.agent/rules/)
+(writing tests · extending the framework) and four skills in
+[`.claude/skills/`](.claude/skills/): `write-e2e-test`,
+`investigate-e2e-failure`, `add-provisioner`, `extend-platform-assertions`.
+
 ## License
 
 Apache-2.0

--- a/test/platform-test/e2e/tests/user-journeys/README.md
+++ b/test/platform-test/e2e/tests/user-journeys/README.md
@@ -66,8 +66,9 @@ npm --prefix test/platform-test run e2e -- --grep @GKO-335 --provision-with terr
 
 ## Authoring a new journey
 
-See [AGENTS.md → Adding a user journey](../../../AGENTS.md#adding-a-user-journey).
-Two rules decide where a test goes:
+See [AGENTS.md → Adding a user journey](../../../AGENTS.md#adding-a-user-journey),
+or invoke the [`write-e2e-test`](../../../.claude/skills/write-e2e-test/SKILL.md)
+skill for the full procedure. Two rules decide where a test goes:
 
 1. **Persona** picks the folder — who performs this journey?
 2. **A new folder only when the _story_ differs**, not when the configuration


### PR DESCRIPTION
## Purpose

Implements the *Agent Rules & Skills* section of the [E2E Testing Strategy and Framework](https://gravitee.atlassian.net/wiki/spaces/DE/pages/349929483) page: the framework should ship two sets of rules and skills, one for agents writing tests and one for SDETs extending it. Claude Code is the first target.

`AGENTS.md` was a single 300-line mixed-audience document. An agent asked to add a test had to infer the procedure from it; an agent asked to extend the framework found almost nothing (adding a provisioner was two lines). Neither audience had anything invocable.

Everything lands under `test/platform-test/`, which is self-contained and may move to its own repo.

## Summary of changes

**Two rule sets** under `.agent/rules/`, mirroring the convention the repo root already uses and imported from `AGENTS.md`:

| File | Audience |
|---|---|
| `e2e-test-authoring.md` | writing tests: golden rules, polling, isolation, safety-net cleanup, `view` vs `checks`, Xray tagging, APIM quirks, commit conventions |
| `e2e-framework-development.md` | extending it: `src/` to `e2e/` layering, the assert/waitFor/check triplet, the three-state `ProvisionerView`, `registry.ts` as single source of truth, exports map, licence headers, docs contract, verification gate |

The first file is content moved out of `AGENTS.md` unchanged. The second is new: it records invariants that were only implicit in the code.

**Four skills** under `.claude/skills/`:

| Skill | Set | Covers |
|---|---|---|
| `write-e2e-test` | author | route journey vs `tests/gko` vs `tests/terraform`, then the journey path end to end. Three references: file skeletons, the `mapi`/`gateway` surface, hand-rolled tests |
| `investigate-e2e-failure` | author | symptom to root cause in a fixed order: leak cascade, eventual consistency, version gate, infrastructure, product bug |
| `add-provisioner` | SDET | add a creation path so existing journeys gain an arm. Reference annotates the interface set with GKO and Terraform as worked examples |
| `extend-platform-assertions` | SDET | add to `mapi`/`gateway` or stand up a new product surface |

**`AGENTS.md`** drops from 302 to 174 lines, keeping the shared context (the tree, where a test goes, the `forEachProvisioner` example, how to select a run) and gaining a routing table. Content moved rather than being copied, so there is nothing to drift. The `#adding-a-user-journey` anchor that `e2e/README.md` and the journey catalog link to is preserved.

**`.gitignore`** negates `.claude/` for this directory. Ignoring it globally is common, and it silently dropped the skills from any commit made on such a checkout. `.claude/settings.json` also pre-approves the suite's routine commands.

No TypeScript, fixture or CI changes; nothing under `src/` or `e2e/tests/` moves.

## Out of scope

- Cursor/Copilot-specific rule files. Claude Code is the stated first target, and `.agent/rules/` is already tool-agnostic.
- Splitting `test/platform-test/` into its own repo.
- Updating the Confluence page, which can follow once this lands.

See: https://gravitee.atlassian.net/browse/GKO-3097