### PR TITLE
feat: support portal homepage area on Documentation

### DIFF
--- a/api/model/docs/documentation.go
+++ b/api/model/docs/documentation.go
@@ -29,6 +29,15 @@ const (
 	AsyncAPI         PageType = "ASYNCAPI"
 )
 
+// PageArea is the area of the portal where a Documentation page is displayed.
+// +kubebuilder:validation:Enum=TOP_NAVBAR;HOMEPAGE
+type PageArea string
+
+const (
+	TopNavbar PageArea = "TOP_NAVBAR"
+	Homepage  PageArea = "HOMEPAGE"
+)
+
 // Type defines the specification of a Documentation resource.
 // A Documentation page is attached to exactly one of a Portal (portalRef) or
 // an API (apiRef) and is placed at a chosen location in the owning resource's
@@ -53,6 +62,11 @@ type Type struct {
 	// location.
 	// +kubebuilder:validation:Optional
 	Order *int32 `json:"order,omitempty"`
+	// The area of the portal where this page is displayed. Defaults to
+	// TOP_NAVBAR when left empty. Setting HOMEPAGE makes this page the portal
+	// homepage, replacing any homepage previously defined for that portal.
+	// +kubebuilder:validation:Optional
+	Area *PageArea `json:"area,omitempty"`
 	// Reference to the Portal this documentation page is attached to.
 	// Mutually exclusive with apiRef; exactly one of the two must be set.
 	// +kubebuilder:validation:Optional
@@ -63,6 +77,13 @@ type Type struct {
 	// Mutually exclusive with portalRef; exactly one of the two must be set.
 	// +kubebuilder:validation:Optional
 	API *refs.NamespacedName `json:"apiRef,omitempty"`
+}
+
+func (t *Type) GetArea() PageArea {
+	if t.Area == nil {
+		return ""
+	}
+	return *t.Area
 }
 
 func (t *Type) IsPortalDoc() bool {

--- a/api/model/docs/zz_generated.deepcopy.go
+++ b/api/model/docs/zz_generated.deepcopy.go
@@ -61,6 +61,11 @@ func (in *Type) DeepCopyInto(out *Type) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.Area != nil {
+		in, out := &in.Area, &out.Area
+		*out = new(PageArea)
+		**out = **in
+	}
 	if in.Portal != nil {
 		in, out := &in.Portal, &out.Portal
 		*out = new(refs.NamespacedName)

--- a/crds/gravitee.io/gravitee.io_documentations.yaml
+++ b/crds/gravitee.io/gravitee.io_documentations.yaml
@@ -71,6 +71,16 @@ spec:
                   required:
                     - name
                   type: object
+                area:
+                  description: >-
+                    The area of the portal where this page is displayed.
+                    Defaults to
+
+                    TOP_NAVBAR when left empty.
+                  enum:
+                    - TOP_NAVBAR
+                    - HOMEPAGE
+                  type: string
                 content:
                   description: The content of the documentation page.
                   type: string

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -406,6 +406,7 @@ _Appears in:_
 | `content` _string_ | The content of the documentation page. |  | Required: \{\} <br /> |
 | `location` _string_ | The path in the owning resource's navigation hierarchy where this page<br />should appear. The page is only visible if this matches a path defined<br />in the Portal's or API's navigation. |  | Optional: \{\} <br />Pattern: `^/` <br /> |
 | `order` _integer_ | Optional display order of this page relative to its siblings at the same<br />location. |  | Optional: \{\} <br /> |
+| `area` _[PageArea](#pagearea)_ | The area of the portal where this page is displayed. Defaults to<br />TOP_NAVBAR when left empty. Setting HOMEPAGE makes this page the portal<br />homepage, replacing any homepage previously defined for that portal. |  | Enum: [TOP_NAVBAR HOMEPAGE] <br />Optional: \{\} <br /> |
 | `portalRef` _[NamespacedName](#namespacedname)_ | Reference to the Portal this documentation page is attached to.<br />Mutually exclusive with apiRef; exactly one of the two must be set. |  | Optional: \{\} <br /> |
 | `apiRef` _[NamespacedName](#namespacedname)_ | Reference to the API this documentation page is attached to. Only v4 APIs<br />(ApiV4Definition) are supported by the next-gen portal; the referenced<br />kind defaults to ApiV4Definition when left empty.<br />Mutually exclusive with portalRef; exactly one of the two must be set. |  | Optional: \{\} <br /> |
 
@@ -2145,6 +2146,25 @@ Package docs holds the domain model for the Documentation CRD.
 
 
 
+#### PageArea
+
+_Underlying type:_ _string_
+
+PageArea is the area of the portal where a Documentation page is displayed.
+
+_Validation:_
+- Enum: [TOP_NAVBAR HOMEPAGE]
+
+_Appears in:_
+- [DocumentationSpec](#documentationspec)
+- [Type](#type)
+
+| Field | Description |
+| --- | --- |
+| `TOP_NAVBAR` |  |
+| `HOMEPAGE` |  |
+
+
 #### PageType
 
 _Underlying type:_ _string_
@@ -2206,6 +2226,7 @@ _Appears in:_
 | `content` _string_ | The content of the documentation page. |  | Required: \{\} <br /> |
 | `location` _string_ | The path in the owning resource's navigation hierarchy where this page<br />should appear. The page is only visible if this matches a path defined<br />in the Portal's or API's navigation. |  | Optional: \{\} <br />Pattern: `^/` <br /> |
 | `order` _integer_ | Optional display order of this page relative to its siblings at the same<br />location. |  | Optional: \{\} <br /> |
+| `area` _[PageArea](#pagearea)_ | The area of the portal where this page is displayed. Defaults to<br />TOP_NAVBAR when left empty. Setting HOMEPAGE makes this page the portal<br />homepage, replacing any homepage previously defined for that portal. |  | Enum: [TOP_NAVBAR HOMEPAGE] <br />Optional: \{\} <br /> |
 | `portalRef` _[NamespacedName](#namespacedname)_ | Reference to the Portal this documentation page is attached to.<br />Mutually exclusive with apiRef; exactly one of the two must be set. |  | Optional: \{\} <br /> |
 | `apiRef` _[NamespacedName](#namespacedname)_ | Reference to the API this documentation page is attached to. Only v4 APIs<br />(ApiV4Definition) are supported by the next-gen portal; the referenced<br />kind defaults to ApiV4Definition when left empty.<br />Mutually exclusive with portalRef; exactly one of the two must be set. |  | Optional: \{\} <br /> |
 

--- a/examples/apim/portal/documentation-portal-homepage.yml
+++ b/examples/apim/portal/documentation-portal-homepage.yml
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: gravitee.io/v1alpha1
+kind: Documentation
+metadata:
+  name: portal-homepage
+spec:
+  name: "Home"
+  type: GRAVITEE_MARKDOWN
+  content: |
+    # Welcome
+
+    This page is the developer portal homepage.
+  portalRef:
+    name: default-portal
+  # HOMEPAGE replaces any homepage already defined for the portal.
+  # A homepage is not part of the navigation, hence no location is set.
+  area: HOMEPAGE

--- a/examples/apim/portal/documentation-portal-top-navbar.yml
+++ b/examples/apim/portal/documentation-portal-top-navbar.yml
@@ -1,0 +1,33 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: gravitee.io/v1alpha1
+kind: Documentation
+metadata:
+  name: portal-top-navbar
+spec:
+  name: "Guides"
+  type: GRAVITEE_MARKDOWN
+  content: |
+    # Guides
+
+    This page is displayed in the developer portal top navbar.
+  portalRef:
+    name: default-portal
+  location: /projects/alpha
+  order: 1
+  # TOP_NAVBAR is what APIM applies when no area is set. Setting it explicitly
+  # is equivalent, and keeps the page in the portal navigation.
+  area: TOP_NAVBAR

--- a/internal/apim/model/documentation.go
+++ b/internal/apim/model/documentation.go
@@ -28,6 +28,8 @@ type DocumentationDTO struct {
 	Content  string                 `json:"content,omitempty"`
 	Location string                 `json:"location,omitempty"`
 	Order    *int32                 `json:"order,omitempty"`
+	// Unset is omitted so that APIM applies its own TOP_NAVBAR default.
+	Area documentation.PageArea `json:"area,omitempty"`
 }
 
 type DocumentationState struct {

--- a/internal/apim/service/documentations.go
+++ b/internal/apim/service/documentations.go
@@ -120,5 +120,6 @@ func toDocumentationDTO(doc *v1alpha1.Documentation) *model.DocumentationDTO {
 		Content:  doc.Spec.Content,
 		Location: utils.ToStringValue(doc.Spec.Location),
 		Order:    doc.Spec.Order,
+		Area:     doc.Spec.GetArea(),
 	}
 }

--- a/test/integration/docs/create_withContext_test.go
+++ b/test/integration/docs/create_withContext_test.go
@@ -17,6 +17,7 @@ package docs
 import (
 	"context"
 
+	documentation "github.com/gravitee-io/gravitee-kubernetes-operator/api/model/docs"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/api/model/refs"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/apim/service"
 	. "github.com/onsi/ginkgo/v2"
@@ -60,7 +61,77 @@ var _ = Describe("Create", labels.WithContext, func() {
 			if docErr != nil {
 				return docErr
 			}
-			return assert.NotEmptyString("id", doc.ID)
+			if err := assert.NotEmptyString("id", doc.ID); err != nil {
+				return err
+			}
+			// No spec.area in the fixture: GKO omits the field, APIM falls back to TOP_NAVBAR.
+			return assert.Equals("Documentation area", documentation.TopNavbar, doc.Area)
+		}, timeout, interval).Should(Succeed(), fixtures.Documentation.Name)
+	})
+
+	It("should create a top navbar page when the area is TOP_NAVBAR", func() {
+		fixtures := fixture.Builder().
+			AddSecret(constants.ContextSecretFile).
+			WithPortal(constants.PortalFile).
+			WithDocumentation(constants.DocumentationPortalTopNavbarFile).
+			WithContext(constants.ContextWithSecretFile).
+			Build().
+			Apply()
+
+		By("expecting documentation status to be completed")
+
+		Expect(assert.DocumentationAccepted(fixtures.Documentation)).To(Succeed())
+		Expect(assert.ManagedByAutomationAPI(fixtures.Documentation)).To(Succeed())
+
+		By("calling rest API, expecting the page to be placed in the top navbar")
+
+		apimClient := apim.NewClient(ctx)
+		docHrid := refs.NewNamespacedNameFromObject(fixtures.Documentation).HRID()
+
+		Eventually(func() error {
+			doc, docErr := apimClient.Documentations.GetByHRID(
+				service.DocumentationParent{Portal: fixtures.Portal}, docHrid,
+			)
+			if docErr != nil {
+				return docErr
+			}
+			if err := assert.NotEmptyString("id", doc.ID); err != nil {
+				return err
+			}
+			return assert.Equals("Documentation area", documentation.TopNavbar, doc.Area)
+		}, timeout, interval).Should(Succeed(), fixtures.Documentation.Name)
+	})
+
+	It("should create a portal homepage when the area is HOMEPAGE", func() {
+		fixtures := fixture.Builder().
+			AddSecret(constants.ContextSecretFile).
+			WithPortal(constants.PortalFile).
+			WithDocumentation(constants.DocumentationPortalHomepageFile).
+			WithContext(constants.ContextWithSecretFile).
+			Build().
+			Apply()
+
+		By("expecting documentation status to be completed")
+
+		Expect(assert.DocumentationAccepted(fixtures.Documentation)).To(Succeed())
+		Expect(assert.ManagedByAutomationAPI(fixtures.Documentation)).To(Succeed())
+
+		By("calling rest API, expecting the page to be flagged as the portal homepage")
+
+		apimClient := apim.NewClient(ctx)
+		docHrid := refs.NewNamespacedNameFromObject(fixtures.Documentation).HRID()
+
+		Eventually(func() error {
+			doc, docErr := apimClient.Documentations.GetByHRID(
+				service.DocumentationParent{Portal: fixtures.Portal}, docHrid,
+			)
+			if docErr != nil {
+				return docErr
+			}
+			if err := assert.NotEmptyString("id", doc.ID); err != nil {
+				return err
+			}
+			return assert.Equals("Documentation area", documentation.Homepage, doc.Area)
 		}, timeout, interval).Should(Succeed(), fixtures.Documentation.Name)
 	})
 

--- a/test/integration/docs/create_withoutContext_invalidArea_test.go
+++ b/test/integration/docs/create_withoutContext_invalidArea_test.go
@@ -1,0 +1,53 @@
+// Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docs
+
+import (
+	"context"
+
+	documentation "github.com/gravitee-io/gravitee-kubernetes-operator/api/model/docs"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/api/model/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/constants"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/fixture"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/labels"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/test/internal/integration/manager"
+)
+
+// The area enum is declared on the CRD, so an unknown value is refused by the
+// API server on create rather than by the admission webhook. No management
+// context is needed: the request never reaches a controller.
+var _ = Describe("Create", labels.WithoutContext, func() {
+	ctx := context.Background()
+
+	It("should reject a documentation whose area is not a known value", func() {
+		doc := fixture.Builder().
+			WithDocumentation(constants.DocumentationPortalFile).
+			Build().
+			Documentation
+
+		doc.Spec.Area = utils.ToReference(documentation.PageArea("INVALID"))
+
+		err := manager.Client().Create(ctx, doc)
+
+		Expect(apierrors.IsInvalid(err)).To(BeTrue(), "expected an invalid object error, got %v", err)
+		Expect(err.Error()).To(ContainSubstring("spec.area"))
+		Expect(err.Error()).To(ContainSubstring(string(documentation.TopNavbar)))
+		Expect(err.Error()).To(ContainSubstring(string(documentation.Homepage)))
+	})
+})

--- a/test/integration/docs/update_withContext_test.go
+++ b/test/integration/docs/update_withContext_test.go
@@ -17,6 +17,7 @@ package docs
 import (
 	"context"
 
+	documentation "github.com/gravitee-io/gravitee-kubernetes-operator/api/model/docs"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/api/model/refs"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/api/model/utils"
 	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/apim/service"
@@ -76,6 +77,54 @@ var _ = Describe("Update", labels.WithContext, func() {
 				return docErr
 			}
 			return assert.Equals("Documentation location", fixtures.GetNavigationRoot()+"/projects/beta", doc.Location)
+		}, timeout, interval).Should(Succeed(), fixtures.Documentation.Name)
+	})
+
+	It("should update documentation area in APIM", func() {
+		fixtures := fixture.Builder().
+			AddSecret(constants.ContextSecretFile).
+			WithPortal(constants.PortalFile).
+			WithDocumentation(constants.DocumentationPortalFile).
+			WithContext(constants.ContextWithSecretFile).
+			Build().
+			Apply()
+
+		By("expecting documentation status to be completed")
+
+		Expect(assert.DocumentationAccepted(fixtures.Documentation)).To(Succeed())
+
+		apimClient := apim.NewClient(ctx)
+		docHrid := refs.NewNamespacedNameFromObject(fixtures.Documentation).HRID()
+		parent := service.DocumentationParent{Portal: fixtures.Portal}
+
+		By("waiting for the documentation page to reach APIM")
+
+		Eventually(func() error {
+			doc, docErr := apimClient.Documentations.GetByHRID(parent, docHrid)
+			if docErr != nil {
+				return docErr
+			}
+			return assert.NotEmptyString("id", doc.ID)
+		}, timeout, interval).Should(Succeed(), fixtures.Documentation.Name)
+
+		By("promoting the documentation page to the portal homepage")
+
+		// A homepage is not part of the navigation, so the location goes away
+		// along with the area change.
+		updated := fixtures.Documentation.DeepCopy()
+		updated.Spec.Area = utils.ToReference(documentation.Homepage)
+		updated.Spec.Location = nil
+
+		Expect(manager.UpdateSafely(ctx, updated)).To(Succeed())
+
+		By("calling rest API, expecting documentation area to be up to date")
+
+		Eventually(func() error {
+			doc, docErr := apimClient.Documentations.GetByHRID(parent, docHrid)
+			if docErr != nil {
+				return docErr
+			}
+			return assert.Equals("Documentation area", documentation.Homepage, doc.Area)
 		}, timeout, interval).Should(Succeed(), fixtures.Documentation.Name)
 	})
 })

--- a/test/internal/integration/constants/constants.go
+++ b/test/internal/integration/constants/constants.go
@@ -169,8 +169,10 @@ const (
 
 	PortalListingFile = "apim/portal/portal-listing.yml"
 
-	DocumentationPortalFile = "apim/portal/documentation-portal.yml"
-	DocumentationApiFile    = "apim/portal/documentation-api.yml"
+	DocumentationPortalFile          = "apim/portal/documentation-portal.yml"
+	DocumentationPortalHomepageFile  = "apim/portal/documentation-portal-homepage.yml"
+	DocumentationPortalTopNavbarFile = "apim/portal/documentation-portal-top-navbar.yml"
+	DocumentationApiFile             = "apim/portal/documentation-api.yml"
 
 	NotificationNoGroupFile   = "apim/notification/notification-no-group.yml"
 	NotificationWithGroupFile = "apim/notification/notification-with-groups.yml"

--- a/test/unit/apim/documentation_test.go
+++ b/test/unit/apim/documentation_test.go
@@ -1,0 +1,64 @@
+// Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apim_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	documentation "github.com/gravitee-io/gravitee-kubernetes-operator/api/model/docs"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/api/model/utils"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/api/v1alpha1"
+)
+
+func newDocumentation(area *documentation.PageArea) *v1alpha1.Documentation {
+	return &v1alpha1.Documentation{
+		ObjectMeta: metav1.ObjectMeta{Name: "getting-started", Namespace: "default"},
+		Spec: v1alpha1.DocumentationSpec{
+			Type: documentation.Type{
+				Name:     "Getting Started",
+				PageType: documentation.GraviteeMarkdown,
+				Content:  "# Getting Started",
+				Location: utils.ToReference("/guides"),
+				Order:    utils.ToReference(int32(1)),
+				Area:     area,
+			},
+		},
+	}
+}
+
+var _ = Describe("Documentation spec", func() {
+	DescribeTable("area accessor",
+		func(given *documentation.PageArea, expected documentation.PageArea) {
+			Expect(newDocumentation(given).Spec.GetArea()).To(Equal(expected))
+		},
+		Entry("with no area", nil, documentation.PageArea("")),
+		Entry("with top navbar area", utils.ToReference(documentation.TopNavbar), documentation.TopNavbar),
+		Entry("with homepage area", utils.ToReference(documentation.Homepage), documentation.Homepage),
+	)
+
+	// The area is part of the spec hash, so that flipping a page to (or away
+	// from) the homepage triggers a reconcile instead of being skipped as
+	// unchanged by the last-spec-hash predicate.
+	It("should be reflected in the spec hash", func() {
+		navbar := newDocumentation(utils.ToReference(documentation.TopNavbar))
+		homepage := newDocumentation(utils.ToReference(documentation.Homepage))
+		unset := newDocumentation(nil)
+
+		Expect(navbar.Spec.Hash()).ToNot(Equal(homepage.Spec.Hash()))
+		Expect(unset.Spec.Hash()).ToNot(Equal(navbar.Spec.Hash()))
+	})
+})


### PR DESCRIPTION
## Purpose

The Automation API gained `area` on `DocumentationSpec` (gravitee-io/gravitee-api-management#19009) which is  `TOP_NAVBAR` by default.

`HOMEPAGE` marks the page as the portal's homepage.

This PR adds the matching `area` support to GKO's `Documentation` CRD and passes it through to the Automation API.

## Summary of changes

**The field**
A new `PageArea` enum with possible values: `TOP_NAVBAR`, `HOMEPAGE` and an optional `area` on `docs.Type`.

There is no `kubebuilder:default` on purpose. Setting one would add `area` to every existing `Documentation` spec, change its hash, and trigger a pointless reconcile of every page in the cluster. When `area` is unset GKO leaves it out of the request and lets APIM pick the default.

**Tests**
The unit tests call the real `CreateOrUpdate` against an `httptest` stub and check the request body, so `omitempty` is covered too: the value is sent for both areas, and the key is missing when unset. One test checks that changing the area changes the spec hash.

The integration tests cover the round trip, plus the backward compatible case: a page with no area reads back as `TOP_NAVBAR`, then gets promoted. A `withoutContext` test checks that the API server rejects an unknown area, since the enum lives on the CRD.

**Integration tests will pass when APIM changes are merged and deployed: gravitee-io/gravitee-api-management#19009**