### PR TITLE
fix(dynamic): return an error instead of panicking when resolving a nil reference

### DIFF
--- a/internal/k8s/dynamic/apis.go
+++ b/internal/k8s/dynamic/apis.go
@@ -32,6 +32,10 @@ type ListOptions struct {
 }
 
 func ResolveAPI(ctx context.Context, ref core.ObjectRef, parentNs string) (core.ApiDefinitionObject, error) {
+	if isNilRef(ref) {
+		return nil, errors.NewSevere("API definition reference is mandatory")
+	}
+
 	refKind := ref.GetKind()
 	if ref.GetKind() == "" {
 		refKind = ApiV4GVR.Resource

--- a/internal/k8s/dynamic/group.go
+++ b/internal/k8s/dynamic/group.go
@@ -23,6 +23,10 @@ import (
 )
 
 func ResolveGroup(ctx context.Context, ref core.ObjectRef, namespace string) (*v1alpha1.Group, error) {
+	if isNilRef(ref) {
+		return nil, errors.NewSevere("Group reference is mandatory")
+	}
+
 	refKind := ref.GetKind()
 	if ref.GetKind() == "" {
 		refKind = GroupGVR.Resource

--- a/internal/k8s/dynamic/notification.go
+++ b/internal/k8s/dynamic/notification.go
@@ -23,6 +23,10 @@ import (
 )
 
 func ResolveNotification(ctx context.Context, ref core.ObjectRef, namespace string) (*v1alpha1.Notification, error) {
+	if isNilRef(ref) {
+		return nil, fmt.Errorf("notification reference is mandatory")
+	}
+
 	refKind := ref.GetKind()
 	if ref.GetKind() == "" {
 		refKind = NotificationGVR.Resource

--- a/internal/k8s/dynamic/resolve.go
+++ b/internal/k8s/dynamic/resolve.go
@@ -16,6 +16,8 @@ package dynamic
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 
 	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/core"
 	gerrors "github.com/gravitee-io/gravitee-kubernetes-operator/internal/errors"
@@ -56,12 +58,23 @@ func resolveRef[T any](
 	return convert(dynamic.Object, target)
 }
 
+// isNilRef reports whether a reference is absent. References are not always required,
+// e.g. contextRef is optional on API definitions, and an unset one reaches the resolvers
+// as an interface wrapping a nil pointer, which is not equal to nil on its own.
+func isNilRef(ref core.ObjectRef) bool {
+	return ref == nil || reflect.ValueOf(ref).IsNil()
+}
+
 func resolve(
 	ctx context.Context,
 	ref core.ObjectRef,
 	parentNs string,
 	gvr schema.GroupVersionResource,
 ) (*unstructured.Unstructured, error) {
+	if isNilRef(ref) {
+		return nil, fmt.Errorf("no %s reference to resolve in namespace %s", gvr.Resource, parentNs)
+	}
+
 	if ref.GetNamespace() == "" {
 		ref.SetNamespace(parentNs)
 	}

--- a/test/unit/dynamic/suite_test.go
+++ b/test/unit/dynamic/suite_test.go
@@ -1,0 +1,83 @@
+// Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dynamic
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitee-io/gravitee-kubernetes-operator/api/model/refs"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/core"
+	"github.com/gravitee-io/gravitee-kubernetes-operator/internal/k8s/dynamic"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDynamic(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "package dynamic")
+}
+
+// References are not always required, e.g. contextRef is optional on API definitions.
+// An unset reference reaches the resolvers as an interface wrapping a nil pointer, which
+// must be reported as an error rather than dereferenced. These resolve before any client
+// call, so they need no cluster.
+var _ = Describe("Resolving a nil reference", func() {
+	ctx := context.Background()
+
+	DescribeTable("returns an error instead of panicking",
+		func(resolve func(core.ObjectRef) error) {
+			// An unset reference reaches a resolver as an interface wrapping a nil
+			// pointer, which is not equal to nil on its own.
+			var unset *refs.NamespacedName
+			Expect(resolve(unset)).To(HaveOccurred())
+
+			// A caller may also pass no reference at all.
+			Expect(resolve(nil)).To(HaveOccurred())
+		},
+		Entry("management context", func(ref core.ObjectRef) error {
+			_, err := dynamic.ResolveContext(ctx, ref, "default")
+			return err
+		}),
+		Entry("API definition", func(ref core.ObjectRef) error {
+			_, err := dynamic.ResolveAPI(ctx, ref, "default")
+			return err
+		}),
+		Entry("application", func(ref core.ObjectRef) error {
+			_, err := dynamic.ResolveApplication(ctx, ref, "default")
+			return err
+		}),
+		Entry("group", func(ref core.ObjectRef) error {
+			_, err := dynamic.ResolveGroup(ctx, ref, "default")
+			return err
+		}),
+		Entry("API resource", func(ref core.ObjectRef) error {
+			_, err := dynamic.ResolveResource(ctx, ref, "default")
+			return err
+		}),
+		Entry("portal", func(ref core.ObjectRef) error {
+			_, err := dynamic.ResolvePortal(ctx, ref, "default")
+			return err
+		}),
+		Entry("notification", func(ref core.ObjectRef) error {
+			_, err := dynamic.ResolveNotification(ctx, ref, "default")
+			return err
+		}),
+		Entry("secret", func(ref core.ObjectRef) error {
+			_, err := dynamic.ResolveSecret(ctx, ref, "default")
+			return err
+		}),
+	)
+})


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-14925

### Problem
`internal/k8s/dynamic/resolve.go` dereferenced a reference before validating it:

    if ref.GetNamespace() == "" {     // nil *NamespacedName -> panic
        ref.SetNamespace(parentNs)
    }

`contextRef` is optional on `ApiDefinition` / `ApiV4Definition`, so `api.ContextRef()` returns a nil `*refs.NamespacedName` inside a non-nil `core.ObjectRef` interface — not equal to nil on its own, and fatal to dereference. The operator panics before the client is ever reached.

Sibling of APIM-14905, which fixed the same defect on the admission path.

### Scope is wider than the ticket describes
The ticket points at `resolve`, but guarding it alone is not sufficient. Three exported resolvers dereference the ref *before* delegating to `resolve`:

- `ResolveAPI` (`apis.go`)
- `ResolveGroup` (`group.go`)
- `ResolveNotification` (`notification.go`)

all via `refKind := ref.GetKind()`. This was caught by the test, not by inspection: with only `resolve` guarded, `ResolveContext` and `ResolveApplication` passed while `ResolveAPI` still panicked.

That matters for the reported bug — the subscription reconciler reaches the management context through `ResolveContext`, so guarding `resolve` alone would have fixed the reported crash while leaving `ResolveAPI`, called from the same reconciler on every pass, a live panic.

### Fix
An `IsNilRef` helper in `resolve.go`, using the pattern already established in this codebase (`admission/subscription/validate.go:198`, `admission/api/base/validate.go:110`):

    ref == nil || reflect.ValueOf(ref).IsNil()

Applied in `resolve` plus the three early-dereferencing resolvers. No signature changes — `resolve` already returned an error, and all callers already propagate it.

`resolve` returns a plain `fmt.Errorf`, since `resolveRef` already wraps what it returns with `NewResolveRefError` — matching how client `Get` errors flow today. The three resolvers use each function's existing style for its "kind is mandatory" case.

These are recoverable errors, so the controller requeues with backoff rather than giving up; a spec fix triggers a fresh reconcile. Happy to switch to `NewUnrecoverableError` if you'd rather stop the loop immediately.

### Tests
`test/unit/dynamic/suite_test.go` — a table covering **all eight** exported resolvers (context, API, application, group, resource, portal, notification, secret). The guards fire before any client call, so no cluster is needed and it runs under `make unit` in CI.

Verified both directions: with the fix stashed the suite panics, with it restored 8/8 pass. Full `make unit` green, plus vet, staticcheck, revive, prettier and licence checks.

### Not included
The ticket's third suggestion — writing failure status via `defer` so a panic cannot leave a resource with no status — is deliberately out of scope. It changes the reconcile flow for every subscription and deserves its own discussion.