### PR TITLE
ci: include unit test coverage in sonarcloud analysis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -890,6 +890,7 @@ workflows:
           name: Sonarcloud analysis
           context: cicd-orchestrator
           requires:
+            - Run unit tests
             - Run IT with context
             - Run IT without context
             - Run Conformance Test


### PR DESCRIPTION
On `4.10.x`, the PR workflow's Sonarcloud job does not depend on `Run unit tests`:

    requires:
      - Run IT with context
      - Run IT without context
      - Run Conformance Test

CircleCI builds a job's workspace from its ancestors in the dependency graph, so `cover-unit.out` — which the unit job already produces with `--coverpkg` over the whole module and persists to the workspace — never reaches the Sonar container. Sonar then analyzes integration coverage only, even though `sonar-project.properties` already lists
`cover-unit.out` in `sonar.go.coverage.reportPaths`.

The visible effect is that any new code covered solely by unit tests is reported uncovered, failing the `new_coverage` condition. A guard clause shows its condition as covered (integration traffic evaluates it) and the branch body as uncovered (integration traffic never trips it).

This blocked several backports to this branch with an identical 55.6% new coverage —identical across independent PRs, which rules out a race and points at the missing dependency.

Adding `Run unit tests` to `requires` puts the unit job in Sonar's ancestry so the coverage report is attached. Wall-clock is effectively unchanged: unit tests are the fastest job in the pipeline and Sonar already waits on the much slower integration and conformance jobs.

Not needed on 4.11.x or 4.12.x, where the Sonar job is filtered to `branches: only: master` and so never runs on pull requests.
