### PR TITLE
fix app missing cotext panic error

### DIFF
--- a/internal/admission/subscription/validate.go
+++ b/internal/admission/subscription/validate.go
@@ -344,20 +344,29 @@ func validateApiKind(sub core.SubscriptionObject) *errors.AdmissionError {
 }
 
 func validateContextRefs(api core.ApiDefinitionObject, app core.ApplicationObject) *errors.AdmissionError {
-	apiCtx, appCtx := api.ContextRef(), app.ContextRef()
+	mismatch := api.HasContext() != app.HasContext()
+	if !mismatch && api.HasContext() {
+		apiCtx, appCtx := api.ContextRef(), app.ContextRef()
+		mismatch = appCtx.GetName() != apiCtx.GetName() || appCtx.GetNamespace() != apiCtx.GetNamespace()
+	}
 
-	mismatch := appCtx.GetName() != apiCtx.GetName()
-	mismatch = mismatch || appCtx.GetNamespace() != apiCtx.GetNamespace()
 	if mismatch {
 		return errors.NewSeveref(
-			"management contexts must match between application [%s] and API [%s], got [%v] and [%v]",
+			"management contexts must match between application [%s] and API [%s], got [%s] and [%s]",
 			app.GetRef(),
 			api.GetRef(),
-			app.ContextRef(),
-			api.ContextRef(),
+			contextRefString(app),
+			contextRefString(api),
 		)
 	}
 	return nil
+}
+
+func contextRefString(obj core.ContextAwareObject) string {
+	if !obj.HasContext() {
+		return "none"
+	}
+	return obj.ContextRef().String()
 }
 
 func validateCertEndDatesVsSubscriptionEndDate(


### PR DESCRIPTION
ref Issue: https://github.com/gravitee-io/issues/issues/11722

The function called api.ContextRef() / app.ContextRef() unconditionally. When an API or Application had no context set, ContextRef() returned nil, and the subsequent comparison/formatting caused a panic during admission validation.

Fix: check HasContext() first a mismatch where one has a context and the other doesn't is now caught without dereferencing; the two ContextRef() calls only happen when both sides actually have a context. Also added a contextRefString() helper so the error message prints "none" instead of risking a nil format.