### PR TITLE
ci: replace aqua with aikido

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ orbs:
   slack: circleci/slack@5.2.3
   gh: circleci/github-cli@2.7.2
   azure-cli: circleci/azure-cli@1.3.2
-  aquasec: gravitee-io/aquasec@1.0.5
+  aikido: gravitee-io/aikido@1.0.3
 
 parameters:
   go-version:
@@ -69,28 +69,6 @@ executors:
     docker:
       - image: mcr.microsoft.com/azure-cli:2.85.0
     resource_class: small
-
-commands:
-  cmd-setup-aqua-scan:
-    steps:
-      - keeper/env-export:
-          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/API Key
-          var-name: AQUA_KEY
-      - keeper/env-export:
-          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/Secret
-          var-name: AQUA_SECRET
-      - keeper/env-export:
-          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/login
-          var-name: AQUA_USERNAME
-      - keeper/env-export:
-          secret-url: keeper://LYg-wdlM5UDzSqFFH6Kyig/field/password
-          var-name: AQUA_PASSWORD
-      - keeper/env-export:
-          secret-url: keeper://QeHHkvALPob4pgs1hMd9Gw/custom_field/ScannerToken
-          var-name: SCANNER_TOKEN
-      - keeper/env-export:
-          secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-          var-name: GITHUB_TOKEN
 
 jobs:
 
@@ -1107,6 +1085,51 @@ jobs:
           name: Rebase stale OperatorHub fork branches
           command: npx zx hack/scripts/rebase-operatorhub-prs.mjs
 
+  # The Aikido scanner mounts /var/run/docker.sock, which setup_remote_docker
+  # does not provide, hence the machine executor and the local docker pulls.
+  job-aikido-scan-images:
+    description: A job that scans built docker images with Aikido
+    machine:
+      image: ubuntu-2204:current
+    resource_class: medium
+    parameters:
+      images:
+        type: string
+        default: ""
+        description: |
+          Newline separated list of images to scan. When empty, the staged
+          image is scanned, using the chart version as its tag.
+    steps:
+      - checkout
+      - keeper/env-export:
+          secret-url: keeper://_XrkO71xa9HZBwxYoUHX0w/field/password
+          var-name: AIKIDO_API_KEY
+      - run:
+          name: Pull docker images to scan
+          command: |
+            IMAGES="<< parameters.images >>"
+            if [ -z "$IMAGES" ]; then
+              VERSION="$(npx zx hack/scripts/get-chart-version.mjs)"
+              IMAGES="graviteeio.azurecr.io/kubernetes-operator:${VERSION}"
+            fi
+            : > /tmp/aikido-images.txt
+            for image in $IMAGES; do
+              if docker pull "$image"; then
+                echo "$image" >> /tmp/aikido-images.txt
+              else
+                echo "WARN: could not pull $image, it will not be scanned"
+              fi
+            done
+            if [ ! -s /tmp/aikido-images.txt ]; then
+              echo "ERROR: none of the images could be pulled"
+              exit 1
+            fi
+      - aikido/scan_docker_image:
+          built_docker_image_file: /tmp/aikido-images.txt
+          fail_on: ""
+      - run:
+          name: Docker logout
+          command: docker logout graviteeio.azurecr.io || true
 workflows:
   pre-merge:
     when:
@@ -1140,29 +1163,12 @@ workflows:
           name: Test Helm chart
           requires:
             - Lint Helm chart
-      - aquasec/fs_scan:
-          context: cicd-orchestrator
-          pre-steps:
-            - cmd-setup-aqua-scan
   post-merge:
     when:
       equal:
         - none
         - << pipeline.parameters.trigger >>
     jobs:
-      - aquasec/fs_scan:
-          name: Scan code repository
-          context: cicd-orchestrator
-          pre-steps:
-            - cmd-setup-aqua-scan
-          filters:
-            branches:
-              only:
-                - /^[0-9]+\.[0-9]+\.x$/
-                - master
-                - ci-stage-helm-chart
-            tags:
-              ignore: /.*/
       - job-stage-image:
           name: Stage Docker image
           context: cicd-orchestrator
@@ -1254,29 +1260,7 @@ workflows:
               only:
                 - master
 
-      - aquasec/register_artifact:
-          name: Register staged image for scanning
-          context: cicd-orchestrator
-          filters:
-            branches:
-              only:
-                - /^[0-9]+\.[0-9]+\.x$/
-                - master
-                - ci-stage-helm-chart
-            tags:
-              ignore: /.*/
-          requires:
-            - Stage Docker image
-          built_docker_image_file: /tmp/docker-image.txt
-          pre-steps:
-            - checkout
-            - cmd-setup-aqua-scan
-            - run:
-                name: Store docker image version
-                command: |
-                  export VERSION="$(npx zx hack/scripts/get-chart-version.mjs)"
-                  echo "graviteeio.azurecr.io/kubernetes-operator:${VERSION}" > /tmp/docker-image.txt
-      - aquasec/docker_image_scan:
+      - job-aikido-scan-images:
           name: Scan staged image
           context: cicd-orchestrator
           filters:
@@ -1288,27 +1272,12 @@ workflows:
             tags:
               ignore: /.*/
           requires:
-            - Register staged image for scanning
-          scanner_url: https://82fb8f75da.cloud.aquasec.com
-          built_docker_image_file: /tmp/docker-image.txt
+            - Stage Docker image
           pre-steps:
-            - checkout
-            - cmd-setup-aqua-scan
-            - run:
-                name: Store docker image version
-                command: |
-                  export VERSION="$(npx zx hack/scripts/get-chart-version.mjs)"
-                  echo "graviteeio.azurecr.io/kubernetes-operator:${VERSION}" > /tmp/docker-image.txt
             - gravitee/docker-login:
                 registry: graviteeio.azurecr.io
                 username: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
                 password: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
-            - run:
-                name: Pull Docker image
-                command: |
-                  export VERSION="$(npx zx hack/scripts/get-chart-version.mjs)"
-                  docker pull "graviteeio.azurecr.io/kubernetes-operator:${VERSION}"
-             
   release:
     when:
       equal:
@@ -1323,12 +1292,14 @@ workflows:
           context: cicd-orchestrator
           requires:
             - Release
-      - aquasec/register_artifact:
-          name: Register release artifact
+      - job-aikido-scan-images:
+          name: Scan release images
           context: cicd-orchestrator
           requires:
             - Release
-          built_docker_image_file: /tmp/docker-image.txt
+          images: |
+            graviteeio/kubernetes-operator:<< pipeline.parameters.release-version >>
+            graviteeio/gko-bundle:<< pipeline.parameters.release-version >>
           pre-steps:
             - run:
                 name: Skip on dry run
@@ -1336,31 +1307,6 @@ workflows:
                   if [ "<< pipeline.parameters.dry-run >>" = "true" ]; then
                     circleci-agent step halt
                   fi
-            - cmd-setup-aqua-scan
-            - run:
-                name: Store docker image version
-                command: echo "graviteeio/kubernetes-operator:<< pipeline.parameters.release-version >>" > /tmp/docker-image.txt
-      - aquasec/docker_image_scan:
-          name: Scan release image
-          context: cicd-orchestrator
-          requires:
-            - Register release artifact
-          scanner_url: https://82fb8f75da.cloud.aquasec.com
-          built_docker_image_file: /tmp/docker-image.txt
-          pre-steps:
-            - run:
-                name: Skip on dry run
-                command: |
-                  if [ "<< pipeline.parameters.dry-run >>" = "true" ]; then
-                    circleci-agent step halt
-                  fi
-            - cmd-setup-aqua-scan
-            - run:
-                name: Store docker image version
-                command: echo "graviteeio/kubernetes-operator:<< pipeline.parameters.release-version >>" > /tmp/docker-image.txt
-            - run:
-                name: Pull docker image
-                command: docker pull "graviteeio/kubernetes-operator:<< pipeline.parameters.release-version >>"
 
   freeze:
     when:


### PR DESCRIPTION
Aqua fs_scan jobs are removed with no pipeline counterpart: source code scanning is covered by the Aikido repository integration. Built docker images are pulled and scanned by the Aikido local scanner, which needs a machine executor to mount the docker socket. The release scan now also covers the gko-bundle image.